### PR TITLE
fix: Fail on first package and sign error

### DIFF
--- a/scripts/package-and-sign
+++ b/scripts/package-and-sign
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 mkdir -p ./gpx_files
 mv ./dist/gpx_* ./gpx_files


### PR DESCRIPTION
This has hidden some signature problems. So this tightens up the script, by failing on the first error, when a pipe command fails and when undeclared variables are used.

