### PR TITLE
fix: failover for when there's no default pyroscope data source

### DIFF
--- a/src/shared/infrastructure/http/ApiClient.ts
+++ b/src/shared/infrastructure/http/ApiClient.ts
@@ -22,7 +22,8 @@ export class ApiClient extends HttpClient {
 
     const pyroscopeDataSource =
       pyroscopeDataSources.find(({ uid }) => uid === initDataSourceUid) ||
-      pyroscopeDataSources.find(({ isDefault }) => isDefault);
+      pyroscopeDataSources.find(({ isDefault }) => isDefault) ||
+      pyroscopeDataSources[0];
 
     if (!pyroscopeDataSource) {
       throw new Error(


### PR DESCRIPTION
Hopefully fixes the issue we have when there's no default pyroscope data source https://raintank-corp.slack.com/archives/C048VSWPZ4P/p1719416849483569?thread_ts=1719406016.679409&cid=C048VSWPZ4P