### PR TITLE
fix(VersionInfoTooltip): Fix repo URL

### DIFF
--- a/src/shared/ui/VersionInfoTooltip.tsx
+++ b/src/shared/ui/VersionInfoTooltip.tsx
@@ -12,7 +12,7 @@ import pkg from '../../../package.json';
 import { GIT_COMMIT } from '../../version';
 
 const pluginCommitSha: string = GIT_COMMIT;
-const pluginCommitURL = `https://github.com/grafana/pyroscope-app-plugin/commit/${pluginCommitSha}`;
+const pluginCommitURL = `https://github.com/grafana/explore-profiles/commit/${pluginCommitSha}`;
 const pyroscopeGitInfo = pkg.dependencies['grafana-pyroscope'];
 const pyroscopeCommitSha = pyroscopeGitInfo.split('#')[1];
 const pyroscopeCommitURL = `https://github.com/grafana/pyroscope/commit/${pyroscopeCommitSha}`;


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

Once deployed, the "PLUGIN COMMIT SHA" link should lead to this repository

<img width="395" alt="image" src="https://github.com/grafana/explore-profiles/assets/146180665/a58490a6-94b4-482d-a238-1167c51e3233">

