### PR TITLE
fix(ExploreProfiles): Fix color contrast in light mode for the label values table

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneAllLabelValuesTable.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneAllLabelValuesTable.tsx
@@ -92,7 +92,6 @@ export class SceneAllLabelValuesTable extends SceneObjectBase<SceneAllLabelValue
       this.state.body!.setState({
         fieldConfig: {
           defaults: {
-            color: { mode: 'fixed', fixedColor: '#CCCCDC' },
             custom: {
               filterable: true,
               cellOptions: {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

### 📖 Summary of the changes

| Before | After |
|  ---   |  ---  |
| ![image](https://github.com/grafana/explore-profiles/assets/146180665/4225f763-344f-436f-9c99-5749ecb1db03) |  ![image](https://github.com/grafana/explore-profiles/assets/146180665/862266d2-4279-47ae-b66e-4ec0d54adf76)|

### 🧪 How to test?

`-`