### PR TITLE
fix(SceneFlameGraph): Respect maxNodes when set in the URL

### DIFF
--- a/src/pages/ProfilesExplorerView/exploration-types/SceneServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/exploration-types/SceneServiceFlameGraph/SceneFlameGraph.tsx
@@ -55,22 +55,24 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     const { isLight } = useTheme2();
     const getTheme = useMemo(() => () => createTheme({ colors: { mode: isLight ? 'light' : 'dark' } }), [isLight]);
 
-    const maxNodes = useMaxNodesFromUrl()[0] as number;
+    const [maxNodes] = useMaxNodesFromUrl();
     const { settings, error: isFetchingSettingsError } = useFetchPluginSettings();
     const { $data, title } = this.useState();
 
+    if (isFetchingSettingsError) {
+      displayWarning([
+        'Error while retrieving the plugin settings!',
+        'Some features might not work as expected (e.g. collapsed flame graphs). Please try to reload the page, sorry for the inconvenience.',
+      ]);
+    }
+
     useEffect(() => {
-      if (isFetchingSettingsError) {
-        displayWarning([
-          'Error while retrieving the plugin settings!',
-          'Some features might not work as expected (e.g. collapsed flame graphs). Please try to reload the page, sorry for the inconvenience.',
-        ]);
-      } else if (settings) {
+      if (maxNodes) {
         this.setState({
           $data: buildFlameGraphQueryRunner({ maxNodes }),
         });
       }
-    }, [isFetchingSettingsError, settings, maxNodes]);
+    }, [maxNodes]);
 
     const $dataState = $data!.useState();
     const isFetchingProfileData = $dataState?.data?.state === LoadingState.Loading;


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR fixes an issue where, when set in the URL, the `maxNodes` parameter is not taken into account.

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

- Setting (e.g.) `?maxNodes=42` as an URL search parameter should work.
- Not setting the `maxNodes` in the URL should take the value from the user settings.
