### PR TITLE
fix(SceneFlameGraph): Fix runtime error

### DIFF
--- a/src/pages/ProfilesExplorerView/exploration-types/SceneServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/exploration-types/SceneServiceFlameGraph/SceneFlameGraph.tsx
@@ -76,7 +76,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
 
     const $dataState = $data!.useState();
     const isFetchingProfileData = $dataState?.data?.state === LoadingState.Loading;
-    const profileData = $dataState?.data?.series[0];
+    const profileData = $dataState?.data?.series?.[0];
     const hasProfileData = Number(profileData?.length) > 1;
 
     return {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR fixes a runtime error on the "Flame graph" exploration type:

<img width="1110" alt="image" src="https://github.com/user-attachments/assets/44439c32-48a8-4f5f-88f2-64bc1425ad94">

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

- Land on the "Flame graph" exploration type, no error should occur
