### PR TITLE
docs: Configure custom PR label 

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           add_label: 'true'
+          custom_labels: '{"docs": "type/docs"}'


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR configures the `ytanikin/PRConventionalCommits` GitHub Action to add a custom "docs" label.

See https://github.com/ytanikin/PRConventionalCommits?tab=readme-ov-file#example-usage-with-ticket-number-validation-and-custom-labeling

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The label that is automatically generated on this PR should be "type/docs" and not "docs"