### PR TITLE
fix(CompareAction): Add missing data source query parameter to compare URL

### DIFF
--- a/src/pages/ProfilesExplorerView/actions/CompareAction.tsx
+++ b/src/pages/ProfilesExplorerView/actions/CompareAction.tsx
@@ -17,6 +17,7 @@ import { GridItemData } from '../components/SceneByVariableRepeaterGrid/GridItem
 import { interpolateQueryRunnerVariables } from '../data/helpers/interpolateQueryRunnerVariables';
 import { computeRoundedTimeRange } from '../helpers/computeRoundedTimeRange';
 import { findSceneObjectByClass } from '../helpers/findSceneObjectByClass';
+import { getSceneVariableValue } from '../helpers/getSceneVariableValue';
 import { FiltersVariable } from '../variables/FiltersVariable/FiltersVariable';
 
 interface CompareActionState extends SceneObjectState {
@@ -109,6 +110,9 @@ export class CompareAction extends SceneObjectBase<CompareActionState> {
     }
 
     const diffUrl = new URL('a/grafana-pyroscope-app/comparison-diff', appUrl);
+
+    // data source
+    diffUrl.searchParams.set('var-dataSource', getSceneVariableValue(this, 'dataSource'));
 
     // time range
     const { from, to } = computeRoundedTimeRange(sceneGraph.getTimeRange(this).state.value);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Before this PR, when going from the "Labels" exploration type to the compare page, the data source query parameter was not passed. If there were multiple Pyroscope data sources, it could lead to a broken UI (e.g.):

<img width="1704" alt="image" src="https://github.com/user-attachments/assets/1e6500d5-cced-44fa-b530-c5b13cc57639">

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- In an instance with multiple Pyroscope data sources configured
- Go to the "Labels" exploration type
- Select 2 label values for comparison
- Click "Compare" to open the "Comparison Diff View"
- The UI should always display correctly all the data, regardless of the data source that was selected
