### PR TITLE
feat(DataSource): Persist the last selected data source

### DIFF
--- a/src/pages/ProfilesExplorerView/variables/ProfilesDataSourceVariable.ts
+++ b/src/pages/ProfilesExplorerView/variables/ProfilesDataSourceVariable.ts
@@ -1,5 +1,6 @@
 import { DataSourceVariable } from '@grafana/scenes';
 import { ApiClient } from '@shared/infrastructure/http/ApiClient';
+import { userStorage } from '@shared/infrastructure/userStorage';
 
 export class ProfilesDataSourceVariable extends DataSourceVariable {
   constructor() {
@@ -17,5 +18,13 @@ export class ProfilesDataSourceVariable extends DataSourceVariable {
 
   onActivate() {
     this.setState({ skipUrlSync: false });
+
+    this.subscribeToState((newState, prevState) => {
+      if (newState.value && newState.value !== prevState.value) {
+        const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
+        storage.dataSource = newState.value;
+        userStorage.set(userStorage.KEYS.PROFILES_EXPLORER, storage);
+      }
+    });
   }
 }

--- a/src/shared/infrastructure/http/ApiClient.ts
+++ b/src/shared/infrastructure/http/ApiClient.ts
@@ -1,6 +1,7 @@
 import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
+import { userStorage } from '../userStorage';
 import { HttpClient } from './HttpClient';
 
 const PYROSCOPE_DATA_SOURCES_TYPE = 'grafana-pyroscope-datasource';
@@ -18,10 +19,12 @@ export class ApiClient extends HttpClient {
       (ds) => ds.type === PYROSCOPE_DATA_SOURCES_TYPE
     ) as CustomDataSourceInstanceSettings[];
 
-    const initDataSourceUid = new URL(window.location.href).searchParams.get(PYROSCOPE_URL_SEARCH_PARAM_NAME);
+    const uidFromUrl = new URL(window.location.href).searchParams.get(PYROSCOPE_URL_SEARCH_PARAM_NAME);
+    const uidFromLocalStorage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER)?.dataSource;
 
     return (
-      pyroscopeDataSources.find((ds) => ds.uid === initDataSourceUid) ||
+      pyroscopeDataSources.find((ds) => ds.uid === uidFromUrl) ||
+      pyroscopeDataSources.find((ds) => ds.uid === uidFromLocalStorage) ||
       pyroscopeDataSources.find((ds) => ds.jsonData.overridesDefault) ||
       pyroscopeDataSources.find((ds) => ds.isDefault) ||
       pyroscopeDataSources[0]


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/explore-profiles/issues/42

### 📖 Summary of the changes

Now, when a user selects a different data source in the UI, it is stored in local storage.
This value is then used as default when the user revisits the Explore Profiles app.

### 🧪 How to test?

Manually, in an instance with multiple data sources:

- Land on the page for the first time, select a different data source 
- Navigate to (e.g.) a dashboard
- Go back to Explore Profiles
- The data source that was selected in the 1st step is selected
