### PR TITLE
feat: Update plugin metadata to auto enable 

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,13 +3,21 @@
   "type": "app",
   "name": "Explore Profiles",
   "id": "grafana-pyroscope-app",
+  "autoEnabled": true,
   "backend": false,
   "dependencies": {
     "grafanaDependency": ">=10.4.3",
     "plugins": []
   },
   "info": {
-    "keywords": ["app"],
+    "keywords": [
+      "app",
+      "pyroscope",
+      "profiling",
+      "explore",
+      "profiles",
+      "performance"
+    ],
     "description": "Continuous profiling service powered by Grafana Pyroscope",
     "author": {
       "name": "Grafana"
@@ -25,7 +33,17 @@
       }
     ],
     "version": "%VERSION%",
-    "updated": "%TODAY%"
+    "updated": "%TODAY%",
+    "links": [
+      {
+        "name": "GitHub",
+        "url": "https://github.com/grafana/explore-profiles"
+      },
+      {
+        "name": "Report bug",
+        "url": "https://github.com/grafana/explore-profiles/issues/new"
+      }
+    ]
   },
   "includes": [
     {


### PR DESCRIPTION
This will enable the plugin automatically after install.

I also expose the repo and the issue tracker and updated the keywords.

Based on: https://github.com/grafana/explore-logs/blob/main/src/plugin.json
