### PR TITLE
fix(SceneLabelValuesTimeseries): Colors and legends are preserved on expanded timeseries

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/infrastructure/data-transformations.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/infrastructure/data-transformations.ts
@@ -35,6 +35,7 @@ export const addStats = () => (source: Observable<DataFrame[]>) =>
     })
   );
 
+// depends on the "addStats" transformation to work properly
 export const sortSeries = () => (source: Observable<DataFrame[]>) =>
   source.pipe(
     map((data: DataFrame[]) =>

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -36,30 +36,26 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     headerActions: (item: GridItemData) => VizPanelState['headerActions'];
     displayAllValues?: boolean;
   }) {
-    const data = displayAllValues
-      ? buildTimeSeriesQueryRunner(item.queryRunnerParams)
-      : new SceneDataTransformer({
-          $data: buildTimeSeriesQueryRunner(item.queryRunnerParams),
-          transformations: [addRefId, addStats, sortSeries, limitNumberOfSeries],
-        });
-
     super({
       key: 'bar-timeseries-label-values',
       body: PanelBuilders.timeseries()
         .setTitle(item.label)
-        .setData(data)
+        .setData(
+          new SceneDataTransformer({
+            $data: buildTimeSeriesQueryRunner(item.queryRunnerParams),
+            transformations: displayAllValues
+              ? [addRefId, addStats, sortSeries]
+              : [addRefId, addStats, sortSeries, limitNumberOfSeries],
+          })
+        )
         .setHeaderActions(headerActions(item))
-        .setMin(0)
-        .setCustomFieldConfig('fillOpacity', 0)
         .build(),
     });
 
-    if (!displayAllValues) {
-      this.addActivationHandler(this.onActivate.bind(this, item));
-    }
+    this.addActivationHandler(this.onActivate.bind(this, item, Boolean(displayAllValues)));
   }
 
-  onActivate(item: GridItemData) {
+  onActivate(item: GridItemData, displayAllValues: boolean) {
     const { body } = this.state;
 
     const sub = (body.state.$data as SceneDataTransformer)!.subscribeToState((state) => {
@@ -67,7 +63,11 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
         return;
       }
 
-      body.setState(this.getConfig(item, state.data.series));
+      const config = displayAllValues
+        ? this.getAllValuesConfig(item, state.data.series)
+        : this.getConfig(item, state.data.series);
+
+      body.setState(config);
     });
 
     return () => {
@@ -92,7 +92,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
         defaults: {
           min: 0,
           custom: {
-            fillOpacity: series.length === LabelsDataSource.MAX_TIMESERIES_LABEL_VALUES ? 0 : 9,
+            fillOpacity: series.length >= LabelsDataSource.MAX_TIMESERIES_LABEL_VALUES ? 0 : 9,
             gradientMode: series.length === 1 ? GraphGradientMode.None : GraphGradientMode.Opacity,
           },
         },
@@ -100,6 +100,21 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
       },
     };
   }
+
+  getAllValuesConfig(item: GridItemData, series: DataFrame[]) {
+    return {
+      fieldConfig: {
+        defaults: {
+          min: 0,
+          custom: {
+            fillOpacity: 0,
+          },
+        },
+        overrides: this.getOverrides(item, series),
+      },
+    };
+  }
+
   getOverrides(item: GridItemData, series: DataFrame[]) {
     const groupByLabel = item.queryRunnerParams.groupBy?.label;
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Before this PR, when expanding a panel, the series colors and legends were not preserved. This PR fixes this inconsistency.

**As a grid item:**
<img width="425" alt="image" src="https://github.com/user-attachments/assets/8da7efea-688e-4d5b-9151-0305984ce2e5">

**After expanding the panel:**
| Before | After |
|  ---   |  ---  |
| <img width="1266" alt="image" src="https://github.com/user-attachments/assets/53d1af9a-93d0-4732-bb67-722e30c7c4a2"> | <img width="1260" alt="image" src="https://github.com/user-attachments/assets/604e03d0-b3bd-468f-aeb4-0674e6f8810a"> |

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

`-`
