### PR TITLE
fix(SceneByVariableRepeaterGrid): Prevent extra renders

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -229,7 +229,11 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     const onChangeState = (newState: typeof noDataSwitcher.state, prevState?: typeof noDataSwitcher.state) => {
       if (newState.hideNoData !== prevState?.hideNoData) {
         this.setState({ hideNoData: newState.hideNoData === 'on' });
-        this.renderGridItems();
+
+        // we force render because this.state.items certainly have not changed but we want to update the UI panels anyway
+        this.renderGridItems(true);
+
+        // TODO: also listen to filters change and force re-renders if hideNoData === 'on'
       }
     };
 
@@ -356,7 +360,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     return this.filterItems(items).sort(this.state.sortItemsFn);
   }
 
-  shouldUpdateItems(newItems: SceneByVariableRepeaterGridState['items']) {
+  shouldRenderItems(newItems: SceneByVariableRepeaterGridState['items']) {
     const { items } = this.state;
 
     if (items.length !== newItems.length) {
@@ -372,7 +376,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     return false;
   }
 
-  renderGridItems() {
+  renderGridItems(forceRender = false) {
     const variable = sceneGraph.lookupVariable(this.state.variableName, this) as QueryVariable;
 
     if (variable.state.loading) {
@@ -386,7 +390,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
 
     const newItems = this.buildItemsData(variable);
 
-    if (!this.shouldUpdateItems(newItems)) {
+    if (!forceRender && !this.shouldRenderItems(newItems)) {
       return;
     }
 

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -391,13 +391,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
       return true;
     }
 
-    for (let i = 0; i < items.length; i += 1) {
-      if (!isEqual(items[i], newItems[i])) {
-        return true;
-      }
-    }
-
-    return false;
+    return !isEqual(items, newItems);
   }
 
   renderGridItems(forceRender = false) {
@@ -417,6 +411,8 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     if (!forceRender && !this.shouldRenderItems(newItems)) {
       return;
     }
+
+    console.log('*** render');
 
     this.setState({ items: newItems });
 

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -249,10 +249,10 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
   }
 
   subscribeToFiltersChange() {
+    const noDataSwitcher = findSceneObjectByClass(this, SceneNoDataSwitcher) as SceneNoDataSwitcher;
+
     // the handler will be called each time a filter is added/removed/modified
     const filtersSub = (findSceneObjectByClass(this, FiltersVariable) as FiltersVariable).subscribeToState(() => {
-      const noDataSwitcher = findSceneObjectByClass(this, SceneNoDataSwitcher) as SceneNoDataSwitcher;
-
       if (noDataSwitcher.state.hideNoData === 'on') {
         // we force render because the filters only influence the query made in each panel, not the list of items to render (which come from the groupBy options)
         this.renderGridItems(true);
@@ -411,8 +411,6 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     if (!forceRender && !this.shouldRenderItems(newItems)) {
       return;
     }
-
-    console.log('*** render');
 
     this.setState({ items: newItems });
 

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -116,14 +116,12 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     const variableSub = variable.subscribeToState((newState, prevState) => {
       if (!newState.loading) {
         if (prevState.loading) {
-          console.log('*** done loading');
           this.renderGridItems();
           return;
         }
 
         // TODO: create a dedicated variable instead of looking at the groupBy value?
         if (variable.state.name === 'groupBy' && newState.value !== prevState.value) {
-          console.log('*** groupBy %s to %s', prevState.value, newState.value);
           this.renderGridItems();
           return;
         }

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -356,16 +356,41 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     return this.filterItems(items).sort(this.state.sortItemsFn);
   }
 
-  // TODO: prevent too many re-renders
+  shouldUpdateItems(newItems: SceneByVariableRepeaterGridState['items']) {
+    const { items } = this.state;
+
+    if (items.length !== newItems.length) {
+      return true;
+    }
+
+    for (let i = 0; i < items.length; i += 1) {
+      if (JSON.stringify(items[i]) !== JSON.stringify(newItems[i])) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   renderGridItems() {
     const variable = sceneGraph.lookupVariable(this.state.variableName, this) as QueryVariable;
+
+    if (variable.state.loading) {
+      return;
+    }
 
     if (variable.state.error) {
       this.renderErrorState(variable.state.error);
       return;
     }
 
-    this.setState({ items: this.buildItemsData(variable) });
+    const newItems = this.buildItemsData(variable);
+
+    if (!this.shouldUpdateItems(newItems)) {
+      return;
+    }
+
+    this.setState({ items: newItems });
 
     if (!this.state.items.length) {
       this.renderEmptyState();

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
@@ -101,9 +101,11 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
     const labelValue = queryRunnerParams!.groupBy!.label;
     const groupByVariable = findSceneObjectByClass(this, GroupByVariable) as GroupByVariable;
 
-    groupByVariable.changeValueTo(labelValue);
+    // we clear the filter before changing the groupBy value because changing it will _directly_ cause the grid items to be updated
+    // by doing so, we prevent a flash of "No results"
+    (findSceneObjectByClass(this, SceneQuickFilter) as SceneQuickFilter).clear();
 
-    (findSceneObjectByClass(this, SceneQuickFilter) as SceneQuickFilter)?.clear();
+    groupByVariable.changeValueTo(labelValue);
 
     // the event may be published from an expanded panel in the drawer
     this.state.drawer.close();

--- a/src/pages/ProfilesExplorerView/infrastructure/labels/LabelsDataSource.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/labels/LabelsDataSource.ts
@@ -64,6 +64,7 @@ export class LabelsDataSource extends RuntimeDataSource {
     const { scopedVars, range } = options;
     const sceneObject = scopedVars?.__sceneObject?.value as GroupByVariable;
 
+    // save bandwidth
     if (!sceneObject.isActive) {
       return [];
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR is an enhancement to prevent extra grid renders when none of the grid items have changed. 

### 📖 Summary of the changes

See diff tab for specific comments.

### 🧪 How to test?

`-`
