### PR TITLE
feat(Labels): Various UI/UX improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[bug] "
+title: '[bug] '
 labels: bug
 assignees: ''
-
 ---
 
 ### Bug description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[feature] "
+title: '[feature] '
 labels: ''
 assignees: ''
-
 ---
 
 ### Feature description

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -13,6 +13,7 @@ import {
   VizPanelState,
 } from '@grafana/scenes';
 import { Spinner } from '@grafana/ui';
+import { noOp } from '@shared/domain/noOp';
 import { debounce, isEqual } from 'lodash';
 import React from 'react';
 
@@ -234,6 +235,14 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
 
   subscribeToHideNoDataChange() {
     const noDataSwitcher = findSceneObjectByClass(this, SceneNoDataSwitcher) as SceneNoDataSwitcher;
+
+    if (!noDataSwitcher.isActive) {
+      this.setState({ hideNoData: false });
+
+      return {
+        unsubscribe: noOp,
+      };
+    }
 
     const onChangeState = (newState: typeof noDataSwitcher.state, prevState?: typeof noDataSwitcher.state) => {
       if (newState.hideNoData !== prevState?.hideNoData) {

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -35,7 +35,7 @@ import { GridItemData } from './types/GridItemData';
 interface SceneByVariableRepeaterGridState extends EmbeddedSceneState {
   variableName: string;
   items: GridItemData[];
-  headerActions: (item: GridItemData) => VizPanelState['headerActions'];
+  headerActions: (item: GridItemData, items: GridItemData[]) => VizPanelState['headerActions'];
   sortItemsFn: (a: GridItemData, b: GridItemData) => number;
   hideNoData: boolean;
 }
@@ -443,14 +443,23 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
   buildVizPanel(item: GridItemData) {
     switch (item.panelType) {
       case PanelType.BARGAUGE:
-        return new SceneLabelValuesBarGauge({ item, headerActions: this.state.headerActions });
+        return new SceneLabelValuesBarGauge({
+          item,
+          headerActions: this.state.headerActions.bind(null, item, this.state.items),
+        });
 
       case PanelType.STATS:
-        return new SceneLabelValueStat({ item, headerActions: this.state.headerActions });
+        return new SceneLabelValueStat({
+          item,
+          headerActions: this.state.headerActions.bind(null, item, this.state.items),
+        });
 
       case PanelType.TIMESERIES:
       default:
-        return new SceneLabelValuesTimeseries({ item, headerActions: this.state.headerActions });
+        return new SceneLabelValuesTimeseries({
+          item,
+          headerActions: this.state.headerActions.bind(null, item, this.state.items),
+        });
     }
   }
 

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
@@ -25,7 +25,7 @@ export class ScenePanelTypeSwitcher extends SceneObjectBase<ScenePanelTypeSwitch
 
   static OPTIONS = [
     { label: 'Time series', value: PanelType.TIMESERIES, icon: 'heart-rate' },
-    { label: 'Bar gauge', value: PanelType.BARGAUGE, icon: 'graph-bar' },
+    { label: 'Aggregate', value: PanelType.BARGAUGE, icon: 'graph-bar' },
   ];
 
   static DEFAULT_PANEL_TYPE = PanelType.TIMESERIES;

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 export enum PanelType {
   TIMESERIES = 'time-series',
   BARGAUGE = 'bar-gauge',
+  STATS = 'stats',
 }
 
 interface ScenePanelTypeSwitcherState extends SceneObjectState {

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
@@ -25,7 +25,7 @@ export class ScenePanelTypeSwitcher extends SceneObjectBase<ScenePanelTypeSwitch
 
   static OPTIONS = [
     { label: 'Time series', value: PanelType.TIMESERIES, icon: 'heart-rate' },
-    { label: 'Aggregate', value: PanelType.BARGAUGE, icon: 'graph-bar' },
+    { label: 'Totals', value: PanelType.BARGAUGE, icon: 'graph-bar' },
   ];
 
   static DEFAULT_PANEL_TYPE = PanelType.TIMESERIES;

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
@@ -38,14 +38,22 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
       body: new SceneByVariableRepeaterGrid({
         key: 'service-labels-grid',
         variableName: 'groupBy',
-        headerActions: (item) => {
+        headerActions: (item, items) => {
           const { queryRunnerParams } = item;
 
           if (!queryRunnerParams.groupBy) {
+            if (items.length > 1) {
+              return [
+                new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
+                new SelectAction({ EventClass: EventAddLabelToFilters, item }),
+                new CompareAction({ item }),
+                new FavAction({ item }),
+              ];
+            }
+
             return [
               new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
               new SelectAction({ EventClass: EventAddLabelToFilters, item }),
-              new CompareAction({ item }),
               new FavAction({ item }),
             ];
           }

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
@@ -50,11 +50,15 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
             ];
           }
 
-          return [
-            new SelectAction({ EventClass: EventSelectLabel, item }),
-            new SelectAction({ EventClass: EventExpandPanel, item }),
-            new FavAction({ item }),
-          ];
+          if (queryRunnerParams.groupBy.values.length > 1) {
+            return [
+              new SelectAction({ EventClass: EventSelectLabel, item }),
+              new SelectAction({ EventClass: EventExpandPanel, item }),
+              new FavAction({ item }),
+            ];
+          }
+
+          return [new FavAction({ item })];
         },
       }),
       drawer: new SceneDrawer(),

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
@@ -1,0 +1,45 @@
+import {
+  PanelBuilders,
+  SceneComponentProps,
+  SceneObjectBase,
+  SceneObjectState,
+  VizPanel,
+  VizPanelState,
+} from '@grafana/scenes';
+import React from 'react';
+
+import { getColorByIndex } from '../helpers/getColorByIndex';
+import { buildTimeSeriesQueryRunner } from '../infrastructure/timeseries/buildTimeSeriesQueryRunner';
+import { GridItemData } from './SceneByVariableRepeaterGrid/types/GridItemData';
+
+interface SceneLabelValueStatState extends SceneObjectState {
+  body: VizPanel;
+}
+
+export class SceneLabelValueStat extends SceneObjectBase<SceneLabelValueStatState> {
+  constructor({
+    item,
+    headerActions,
+  }: {
+    item: GridItemData;
+    headerActions: (item: GridItemData) => VizPanelState['headerActions'];
+  }) {
+    super({
+      key: 'stat-label-value',
+      body: PanelBuilders.stat()
+        .setTitle(item.label)
+        .setDescription('This panel displays aggregate values over the current time period')
+        .setData(buildTimeSeriesQueryRunner(item.queryRunnerParams))
+        .setHeaderActions(headerActions(item))
+        .setColor({ mode: 'fixed', fixedColor: getColorByIndex(item.index) })
+        .setOption('reduceOptions', { values: false, calcs: ['sum'] })
+        .build(),
+    });
+  }
+
+  static Component({ model }: SceneComponentProps<SceneLabelValueStat>) {
+    const { body } = model.useState();
+
+    return <body.Component model={body} />;
+  }
+}

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
@@ -17,20 +17,14 @@ interface SceneLabelValueStatState extends SceneObjectState {
 }
 
 export class SceneLabelValueStat extends SceneObjectBase<SceneLabelValueStatState> {
-  constructor({
-    item,
-    headerActions,
-  }: {
-    item: GridItemData;
-    headerActions: (item: GridItemData) => VizPanelState['headerActions'];
-  }) {
+  constructor({ item, headerActions }: { item: GridItemData; headerActions: () => VizPanelState['headerActions'] }) {
     super({
       key: 'stat-label-value',
       body: PanelBuilders.stat()
         .setTitle(item.label)
         .setDescription('This panel displays aggregate values over the current time period')
         .setData(buildTimeSeriesQueryRunner(item.queryRunnerParams))
-        .setHeaderActions(headerActions(item))
+        .setHeaderActions(headerActions())
         .setColor({ mode: 'fixed', fixedColor: getColorByIndex(item.index) })
         .setOption('reduceOptions', { values: false, calcs: ['sum'] })
         .build(),

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesBarGauge.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesBarGauge.tsx
@@ -21,13 +21,7 @@ interface SceneLabelValuesBarGaugeState extends SceneObjectState {
 }
 
 export class SceneLabelValuesBarGauge extends SceneObjectBase<SceneLabelValuesBarGaugeState> {
-  constructor({
-    item,
-    headerActions,
-  }: {
-    item: GridItemData;
-    headerActions: (item: GridItemData) => VizPanelState['headerActions'];
-  }) {
+  constructor({ item, headerActions }: { item: GridItemData; headerActions: () => VizPanelState['headerActions'] }) {
     super({
       key: 'bar-gauge-label-values',
       body: PanelBuilders.bargauge()
@@ -38,7 +32,7 @@ export class SceneLabelValuesBarGauge extends SceneObjectBase<SceneLabelValuesBa
             transformations: [addRefId, addStats, sortSeries],
           })
         )
-        .setHeaderActions(headerActions(item))
+        .setHeaderActions(headerActions())
         .build(),
     });
 

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -33,7 +33,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     displayAllValues,
   }: {
     item: GridItemData;
-    headerActions: (item: GridItemData) => VizPanelState['headerActions'];
+    headerActions: () => VizPanelState['headerActions'];
     displayAllValues?: boolean;
   }) {
     super({
@@ -48,7 +48,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
               : [addRefId, addStats, sortSeries, limitNumberOfSeries],
           })
         )
-        .setHeaderActions(headerActions(item))
+        .setHeaderActions(headerActions())
         .build(),
     });
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/explore-profiles/issues/88 and more

A couple of UI/UX improvements for the "Labels" exploration type:

- The "Select" action has been removed on panels with a single label value (further breakdown does not make sense)
- The "Compare" action has been removed when there's only a single panel in the grid (nothing to compare to)
- Bar gauges for single label values are not helpful (see https://github.com/grafana/explore-profiles/issues/88), they have been replaced by Stats visualizations, e.g.: 
  <img width="1701" alt="image" src="https://github.com/user-attachments/assets/d90c9b6b-f335-45db-a248-2e0492ead2f5">
- The "Bar gauge" button on the panel type switcher has been renamed to "Aggregate" (works for when the UI displays bar gauge or stat panels):
  <img width="1695" alt="image" src="https://github.com/user-attachments/assets/529d3f48-6923-44ff-9f1d-9ae74f4a6ba3">

### 📖 Summary of the changes

See diff tab for specific comments

### 🧪 How to test?

- See related issue + manual testing in local after checking out this PR's branch
