### PR TITLE
fix(Favorites): Render "No results" when there are no favorites

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -398,7 +398,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
   shouldRenderItems(newItems: SceneByVariableRepeaterGridState['items']) {
     const { items } = this.state;
 
-    if (items.length !== newItems.length) {
+    if (!newItems.length || items.length !== newItems.length) {
       return true;
     }
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR fixes a small UI issue when the user lands on a grid with no items (e.g. "Favorites"):

| Before | After |
|  ---   |  ---  |
| <img width="1705" alt="image" src="https://github.com/user-attachments/assets/867f404e-4155-4c5a-99fc-15b6ea55cacf"> | <img width="1701" alt="image" src="https://github.com/user-attachments/assets/342ad18a-f79f-49a8-bd7d-9b195e77db79"> |

### 📖 Summary of the changes

`-`

### 🧪 How to test?

- When there are no favorites in the browser's local storage, the "No results" + image should be displayed
