### PR TITLE
refactor(Labels): Move some "groupBy" logic out of SceneByVariableRepeaterGrid

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneGroupByLabels.tsx
@@ -97,31 +97,26 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
   subscribeToPanelTypeChange() {
     const panelTypeSwitcher = findSceneObjectByClass(this, ScenePanelTypeSwitcher) as ScenePanelTypeSwitcher;
 
-    const onChangeState = (newState: typeof panelTypeSwitcher.state, prevState?: typeof panelTypeSwitcher.state) => {
-      if (newState.panelType !== prevState?.panelType) {
-        this.state.body.renderGridItems();
+    return panelTypeSwitcher.subscribeToState(
+      (newState: typeof panelTypeSwitcher.state, prevState?: typeof panelTypeSwitcher.state) => {
+        if (newState.panelType !== prevState?.panelType) {
+          this.state.body.renderGridItems();
+        }
       }
-    };
-
-    return panelTypeSwitcher.subscribeToState(onChangeState);
+    );
   }
 
   subscribeToFiltersChange() {
+    const filtersVariable = findSceneObjectByClass(this, FiltersVariable) as FiltersVariable;
     const noDataSwitcher = findSceneObjectByClass(this, SceneNoDataSwitcher) as SceneNoDataSwitcher;
 
     // the handler will be called each time a filter is added/removed/modified
-    const filtersSub = (findSceneObjectByClass(this, FiltersVariable) as FiltersVariable).subscribeToState(() => {
+    return filtersVariable.subscribeToState(() => {
       if (noDataSwitcher.state.hideNoData === 'on') {
         // we force render because the filters only influence the query made in each panel, not the list of items to render (which come from the groupBy options)
         this.state.body.renderGridItems(true);
       }
     });
-
-    return {
-      unsubscribe() {
-        filtersSub.unsubscribe();
-      },
-    };
   }
 
   subscribeToPanelEvents() {

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -37,7 +37,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     displayAllValues?: boolean;
   }) {
     super({
-      key: 'bar-timeseries-label-values',
+      key: 'timeseries-label-values',
       body: PanelBuilders.timeseries()
         .setTitle(item.label)
         .setData(

--- a/src/pages/ProfilesExplorerView/domain/variables/ProfileMetricVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ProfileMetricVariable.tsx
@@ -114,7 +114,7 @@ export class ProfileMetricVariable extends QueryVariable {
     }, [options]);
 
     if (error) {
-      console.error('Error while loading "serviceName" variable values!');
+      console.error('Error while loading "profileMetricId" variable values!');
       console.error(error);
 
       return (


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just a quick PR to pull out some specific "groupBy" labels logic from `SceneByVariableRepeaterGrid`

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass 
- The `Labels` exploration view should work as before