### PR TITLE
feat(Timeseries): Add total resource consumption in legend

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/infrastructure/data-transformations.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/infrastructure/data-transformations.ts
@@ -4,15 +4,18 @@ import { map, Observable } from 'rxjs';
 
 import { LabelsDataSource } from '../../../infrastructure/labels/LabelsDataSource';
 
+// General note: because (e.g.) SceneLabelValuesTimeseries sets the data provider in its constructor, data can come as undefined, hence all the optional chaining operators
+// in the transformers below
+
 export const addRefId = () => (source: Observable<DataFrame[]>) =>
-  source.pipe(map((data: DataFrame[]) => data.map((d, i) => merge(d, { refId: `${d.refId}-${i}` }))));
+  source.pipe(map((data: DataFrame[]) => data?.map((d, i) => merge(d, { refId: `${d.refId}-${i}` }))));
 
 export const addStats = () => (source: Observable<DataFrame[]>) =>
   source.pipe(
     map((data: DataFrame[]) => {
-      const totalSeriesCount = data.length;
+      const totalSeriesCount = data?.length;
 
-      return data.map((d) => {
+      return data?.map((d) => {
         const allValuesSum = d.fields
           ?.find((field) => field.type === 'number')
           ?.values.reduce((acc: number, value: number) => acc + value, 0);
@@ -39,7 +42,7 @@ export const addStats = () => (source: Observable<DataFrame[]>) =>
 export const sortSeries = () => (source: Observable<DataFrame[]>) =>
   source.pipe(
     map((data: DataFrame[]) =>
-      data.sort((d1, d2) => {
+      data?.sort((d1, d2) => {
         const d1Sum = d1.meta?.stats?.find(({ displayName }) => displayName === 'allValuesSum')?.value || 0;
         const d2Sum = d2.meta?.stats?.find(({ displayName }) => displayName === 'allValuesSum')?.value || 0;
         return d2Sum - d1Sum;
@@ -48,4 +51,4 @@ export const sortSeries = () => (source: Observable<DataFrame[]>) =>
   );
 
 export const limitNumberOfSeries = () => (source: Observable<DataFrame[]>) =>
-  source.pipe(map((data: DataFrame[]) => data.slice(0, LabelsDataSource.MAX_TIMESERIES_LABEL_VALUES)));
+  source.pipe(map((data: DataFrame[]) => data?.slice(0, LabelsDataSource.MAX_TIMESERIES_LABEL_VALUES)));

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
@@ -18,14 +18,20 @@ interface SceneLabelValueStatState extends SceneObjectState {
 }
 
 export class SceneLabelValueStat extends SceneObjectBase<SceneLabelValueStatState> {
-  constructor({ item, headerActions }: { item: GridItemData; headerActions: () => VizPanelState['headerActions'] }) {
+  constructor({
+    item,
+    headerActions,
+  }: {
+    item: GridItemData;
+    headerActions: (item: GridItemData) => VizPanelState['headerActions'];
+  }) {
     super({
       key: 'stat-label-value',
       body: PanelBuilders.stat()
         .setTitle(item.label)
         .setDescription('This panel displays aggregate values over the current time period')
         .setData(buildTimeSeriesQueryRunner(item.queryRunnerParams))
-        .setHeaderActions(headerActions())
+        .setHeaderActions(headerActions(item))
         .setOption('reduceOptions', { values: false, calcs: ['sum'] })
         .setColor({ mode: 'fixed', fixedColor: getColorByIndex(item.index) })
         .setOption('graphMode', BigValueGraphMode.None)

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValueStat.tsx
@@ -6,6 +6,7 @@ import {
   VizPanel,
   VizPanelState,
 } from '@grafana/scenes';
+import { BigValueGraphMode, BigValueTextMode } from '@grafana/ui';
 import React from 'react';
 
 import { getColorByIndex } from '../helpers/getColorByIndex';
@@ -25,8 +26,10 @@ export class SceneLabelValueStat extends SceneObjectBase<SceneLabelValueStatStat
         .setDescription('This panel displays aggregate values over the current time period')
         .setData(buildTimeSeriesQueryRunner(item.queryRunnerParams))
         .setHeaderActions(headerActions())
-        .setColor({ mode: 'fixed', fixedColor: getColorByIndex(item.index) })
         .setOption('reduceOptions', { values: false, calcs: ['sum'] })
+        .setColor({ mode: 'fixed', fixedColor: getColorByIndex(item.index) })
+        .setOption('graphMode', BigValueGraphMode.None)
+        .setOption('textMode', BigValueTextMode.Value)
         .build(),
     });
   }

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesBarGauge.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesBarGauge.tsx
@@ -21,7 +21,13 @@ interface SceneLabelValuesBarGaugeState extends SceneObjectState {
 }
 
 export class SceneLabelValuesBarGauge extends SceneObjectBase<SceneLabelValuesBarGaugeState> {
-  constructor({ item, headerActions }: { item: GridItemData; headerActions: () => VizPanelState['headerActions'] }) {
+  constructor({
+    item,
+    headerActions,
+  }: {
+    item: GridItemData;
+    headerActions: (item: GridItemData) => VizPanelState['headerActions'];
+  }) {
     super({
       key: 'bar-gauge-label-values',
       body: PanelBuilders.bargauge()
@@ -32,7 +38,7 @@ export class SceneLabelValuesBarGauge extends SceneObjectBase<SceneLabelValuesBa
             transformations: [addRefId, addStats, sortSeries],
           })
         )
-        .setHeaderActions(headerActions())
+        .setHeaderActions(headerActions(item))
         .build(),
     });
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Whenever the UI displays a single timeseries, the total resource consumption is displayed in the legend:
<img width="1691" alt="image" src="https://github.com/user-attachments/assets/b5d900b8-c978-4953-ae73-15fb1fdb827a">

This PR also does some refactorings to prepare the integration of the Comparison view.

### 📖 Summary of the changes

See diff tab for specific comments

### 🧪 How to test?

`-`
