### PR TITLE
fix(SceneLabelValuePanel): Fix border color when baseline/comparison is selected

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/components/SceneLabelValuePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/components/SceneLabelValuePanel.tsx
@@ -108,7 +108,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   timeseriesPanel: css`
     flex-grow: 1;
 
-    & [data-viz-panel-key] > div {
+    & [data-viz-panel-key] > * {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/components/SceneLabelValuePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/components/SceneLabelValuePanel.tsx
@@ -69,11 +69,11 @@ export class SceneLabelValuePanel extends SceneObjectBase<SceneLabelValuesStatAn
     const { compareTargetValue } = statsPanel.useState();
 
     return (
-      <div className={styles.container}>
-        <div className={cx(styles.statsPanel, compareTargetValue && 'selected')}>
+      <div className={cx(styles.container, compareTargetValue && 'selected')}>
+        <div className={styles.statsPanel}>
           <statsPanel.Component model={statsPanel} />
         </div>
-        <div className={cx(styles.timeseriesPanel, compareTargetValue && 'selected')}>
+        <div className={styles.timeseriesPanel}>
           <timeseriesPanel.Component model={timeseriesPanel} />
         </div>
       </div>
@@ -88,6 +88,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     min-height: ${GRID_AUTO_ROWS};
     flex-flow: row;
 
+    box-sizing: border-box;
+    border: 1px solid transparent;
+    &.selected {
+      border: 1px solid ${theme.colors.primary.main};
+    }
+
     & > div {
       display: flex;
       position: relative;
@@ -98,12 +104,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   statsPanel: css`
     width: ${SceneStatsPanel.WIDTH_IN_PIXELS}px;
-
-    &.selected > div {
-      border-top: 1px solid ${theme.colors.primary.main};
-      border-bottom: 1px solid ${theme.colors.primary.main};
-      border-left: 1px solid ${theme.colors.primary.main};
-    }
   `,
   timeseriesPanel: css`
     flex-grow: 1;
@@ -111,12 +111,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     & [data-viz-panel-key] > div {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-    }
-
-    &.selected [data-viz-panel-key] > div {
-      border-top: 1px solid ${theme.colors.primary.main};
-      border-bottom: 1px solid ${theme.colors.primary.main};
-      border-right: 1px solid ${theme.colors.primary.main};
     }
   `,
 });


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Seems to happen with Grafana 11.3:

| Before | After |
|  ---   |  ---  |
| <img width="844" alt="image" src="https://github.com/user-attachments/assets/5936716d-c40d-4741-ac50-459b8bc6e381"> | <img width="845" alt="image" src="https://github.com/user-attachments/assets/9cbae1b2-3296-43d4-b7a8-16a967ae352d"> |

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

`-`
