### PR TITLE
fix(ScenesProfileExplorer): Make labels more responsive on smaller screens

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -415,6 +415,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   dataSourceVariable: css`
     display: flex;
+    ${theme.breakpoints.down('xl')} {
+      label {
+        display: none;
+      }
+    }
   `,
   variable: css`
     display: flex;

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/ui/ExplorationTypeSelector.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/ui/ExplorationTypeSelector.tsx
@@ -48,6 +48,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   explorationTypeContainer: css`
     display: flex;
     align-items: center;
+    ${theme.breakpoints.down('xl')} {
+      label {
+        display: none;
+      }
+    }
   `,
   breadcrumb: css`
     height: 32px;


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

Fixes #116

### 📖 Summary of the changes

Just an idea how we could approach #116 by hiding the labels for the data source picker and exploration type on smaller screens. It uses `xl` theme breakpoint (~1200px) which is a bit wider than needed (~1080px) so we can adjust it.

### 🧪 How to test?

Load Explore profiles app and resize the window to below 1200px

Here's how it looks like:


https://github.com/user-attachments/assets/a51357f6-b329-4977-976e-26dd1d047eca

