### PR TITLE
fix(DiffFlameGraph): Fix the "Explain Flame Graph" (AI) feature

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/SceneAiPanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/SceneAiPanel.tsx
@@ -1,0 +1,143 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { Alert, Button, IconButton, Spinner, useStyles2 } from '@grafana/ui';
+import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
+import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
+import { InlineBanner } from '@shared/ui/InlineBanner';
+import { Panel } from '@shared/ui/Panel/Panel';
+import React from 'react';
+
+import { ProfilesDataSourceVariable } from '../../domain/variables/ProfilesDataSourceVariable';
+import { getSceneVariableValue } from '../../helpers/getSceneVariableValue';
+import { AiReply } from './components/AiReply';
+import { FollowUpForm } from './components/FollowUpForm';
+import { useOpenAiChatCompletions } from './domain/useOpenAiChatCompletions';
+import { FetchParams, useFetchDotProfiles } from './infrastructure/useFetchDotProfiles';
+
+interface SceneAiPanelState extends SceneObjectState {
+  isDiff: boolean;
+}
+
+export class SceneAiPanel extends SceneObjectBase<SceneAiPanelState> {
+  constructor({ isDiff }: { isDiff: SceneAiPanelState['isDiff'] }) {
+    super({
+      key: 'ai-panel',
+      isDiff,
+    });
+  }
+
+  useSceneAiPanel = (params: FetchParams): DomainHookReturnValue => {
+    const dataSourceUid = sceneGraph.findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable).useState()
+      .value as string;
+
+    const { error: fetchError, isFetching, profiles } = useFetchDotProfiles(dataSourceUid, params);
+
+    const profileMetricId = getSceneVariableValue(this, 'profileMetricId');
+    const profileType = getProfileMetric(profileMetricId as ProfileMetricId).type;
+
+    const { reply, error: llmError, retry } = useOpenAiChatCompletions(profileType, profiles);
+
+    return {
+      data: {
+        isLoading: isFetching || (!isFetching && !fetchError && !llmError && !reply.text.trim()),
+        fetchError,
+        llmError,
+        reply,
+        shouldDisplayReply: Boolean(reply?.hasStarted || reply?.hasFinished),
+        shouldDisplayFollowUpForm: !fetchError && !llmError && Boolean(reply?.hasFinished),
+      },
+      actions: {
+        retry,
+        submitFollowupQuestion(question: string) {
+          reply.askFollowupQuestion(question);
+        },
+      },
+    };
+  };
+
+  static Component = ({
+    model,
+    params,
+    onClose,
+  }: SceneComponentProps<SceneAiPanel> & {
+    params: FetchParams;
+    onClose: () => void;
+  }) => {
+    const styles = useStyles2(getStyles);
+    const { data, actions } = model.useSceneAiPanel(params);
+
+    return (
+      <Panel
+        className={styles.sidePanel}
+        title="Flame graph analysis"
+        isLoading={data.isLoading}
+        headerActions={
+          <IconButton
+            title="Close panel"
+            name="times-circle"
+            variant="secondary"
+            aria-label="close"
+            onClick={onClose}
+          />
+        }
+        dataTestId="ai-panel"
+      >
+        <div className={styles.content}>
+          {data.fetchError && (
+            <InlineBanner
+              severity="error"
+              title="Error while loading profile data!"
+              message="Sorry for any inconvenience, please try again later."
+            />
+          )}
+
+          {data.shouldDisplayReply && <AiReply reply={data.reply} />}
+
+          {data.isLoading && (
+            <>
+              <Spinner inline />
+              &nbsp;Analyzing...
+            </>
+          )}
+
+          {data.llmError && (
+            <Alert title="An error occured while generating content using OpenAI!" severity="warning">
+              <div>
+                <div>
+                  <p>{data.llmError.message}</p>
+                  <p>
+                    Sorry for any inconvenience, please retry or if the problem persists, contact your organization
+                    admin.
+                  </p>
+                </div>
+              </div>
+              <Button className={styles.retryButton} variant="secondary" fill="outline" onClick={() => actions.retry()}>
+                Retry
+              </Button>
+            </Alert>
+          )}
+
+          {data.shouldDisplayFollowUpForm && <FollowUpForm onSubmit={actions.submitFollowupQuestion} />}
+        </div>
+      </Panel>
+    );
+  };
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  sidePanel: css`
+    flex: 1 0 50%;
+    margin-left: 8px;
+    max-width: calc(50% - 4px);
+  `,
+  title: css`
+    margin: -4px 0 4px 0;
+  `,
+  content: css`
+    padding: ${theme.spacing(1)};
+  `,
+  retryButton: css`
+    float: right;
+  `,
+});

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/AIButton.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/AIButton.tsx
@@ -1,0 +1,53 @@
+import { css } from '@emotion/css';
+import { IconName } from '@grafana/data';
+import { Button, useStyles2 } from '@grafana/ui';
+import { reportInteraction } from '@shared/domain/reportInteraction';
+import React, { ReactNode } from 'react';
+
+import { useFetchLlmPluginStatus } from './infrastructure/useFetchLlmPluginStatus';
+
+type AIButtonProps = {
+  children: ReactNode;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+  interactionName: string;
+};
+
+export function AIButton({ children, onClick, disabled, interactionName }: AIButtonProps) {
+  const styles = useStyles2(getStyles);
+  const { isEnabled, error, isFetching } = useFetchLlmPluginStatus();
+
+  let icon: IconName = 'ai';
+  let title = '';
+
+  if (error) {
+    icon = 'shield-exclamation';
+    title = 'Grafana LLM plugin missing or not configured!';
+  } else if (isFetching) {
+    icon = 'fa fa-spinner';
+    title = 'Checking the status of the Grafana LLM plugin...';
+  }
+
+  return (
+    <Button
+      className={styles.aiButton}
+      size="md"
+      fill="text"
+      icon={icon}
+      title={isEnabled ? 'Ask FlameGrot AI' : title}
+      disabled={!isEnabled || disabled}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        reportInteraction(interactionName);
+        onClick(event);
+      }}
+    >
+      {children}
+    </Button>
+  );
+}
+
+const getStyles = () => ({
+  aiButton: css`
+    padding: 0 4px;
+  `,
+});

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/infrastructure/useFetchLlmPluginStatus.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/infrastructure/useFetchLlmPluginStatus.ts
@@ -1,0 +1,16 @@
+import { llms } from '@grafana/experimental';
+import { useQuery } from '@tanstack/react-query';
+
+export function useFetchLlmPluginStatus() {
+  const { data, isFetching, error } = useQuery({
+    queryKey: ['llm'],
+    queryFn: () => llms.openai.enabled(),
+  });
+
+  if (error) {
+    console.error('Error while checking the status of the Grafana LLM plugin!');
+    console.error(error);
+  }
+
+  return { isEnabled: Boolean(data), isFetching, error };
+}

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiReply.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiReply.tsx
@@ -1,0 +1,113 @@
+import { css } from '@emotion/css';
+import { useStyles2 } from '@grafana/ui';
+import Markdown from 'markdown-to-jsx';
+import React, { ReactNode } from 'react';
+
+import { OpenAiReply } from '../domain/useOpenAiChatCompletions';
+
+// yeah, I know...
+const setNativeValue = (element: Element, value: string) => {
+  const valueSetter = Object!.getOwnPropertyDescriptor(element, 'value')!.set;
+  const prototypeValueSetter = Object!.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value')!.set;
+
+  if (valueSetter && valueSetter !== prototypeValueSetter) {
+    prototypeValueSetter!.call(element, value);
+  } else {
+    valueSetter!.call(element, value);
+  }
+};
+
+const onClickSearchTerm = (event: any) => {
+  const searchInputElement = document.querySelector('[placeholder^="Search"]');
+
+  if (searchInputElement === null) {
+    console.error('Cannot find search input element!');
+    return;
+  }
+
+  const value = event.target.textContent.trim();
+
+  setNativeValue(searchInputElement, value);
+
+  searchInputElement.dispatchEvent(new Event('input', { bubbles: true }));
+};
+
+const SearchTerm = ({ children }: { children: ReactNode }) => {
+  const styles = useStyles2(getStyles);
+
+  // If the code block contains newlines, don't make it a search link
+  if (typeof children === 'string' && children.includes('\n')) {
+    return <code>{children}</code>;
+  }
+
+  return (
+    <code className={styles.searchLink} title="Search for this node" onClick={onClickSearchTerm}>
+      {children}
+    </code>
+  );
+};
+
+const MARKDOWN_OPTIONS = {
+  overrides: {
+    code: {
+      component: SearchTerm,
+    },
+  },
+};
+
+type AiReplyProps = {
+  reply: OpenAiReply['reply'];
+};
+
+export function AiReply({ reply }: AiReplyProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.container}>
+      {reply?.messages
+        ?.filter((message) => message.role !== 'system')
+        .map((message) => (
+          <>
+            <div className={styles.reply}>
+              <Markdown options={MARKDOWN_OPTIONS}>{message.content}</Markdown>
+            </div>
+            <hr />
+          </>
+        ))}
+
+      <div className={styles.reply}>
+        <Markdown options={MARKDOWN_OPTIONS}>{reply.text}</Markdown>
+      </div>
+    </div>
+  );
+}
+
+const getStyles = () => ({
+  container: css`
+    width: 100%;
+    height: 100%;
+  `,
+  reply: css`
+    font-size: 13px;
+
+    & ol,
+    & ul {
+      margin: 0 0 16px 24px;
+    }
+  `,
+  searchLink: css`
+    color: rgb(255, 136, 51);
+    border: 1px solid transparent;
+    padding: 2px 4px;
+    cursor: pointer;
+    font-size: 13px;
+
+    &:hover,
+    &:focus,
+    &:active {
+      box-sizing: border-box;
+      border: 1px solid rgb(255, 136, 51, 0.8);
+      border-radius: 4px;
+    }
+  `,
+});

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/FollowUpForm.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/FollowUpForm.tsx
@@ -1,0 +1,70 @@
+import { css } from '@emotion/css';
+import { Button, TextArea, useStyles2 } from '@grafana/ui';
+import React, { KeyboardEvent, useCallback, useState } from 'react';
+
+const getStyles = () => ({
+  textarea: css`
+    margin-bottom: 8px;
+  `,
+  sendButton: css`
+    float: right;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  `,
+});
+
+type FollowUpFormProps = {
+  onSubmit: (question: string) => void;
+};
+
+function useFollowUpForm(onSubmit: FollowUpFormProps['onSubmit']) {
+  const [question, setQuestion] = useState('');
+
+  const onChangeInput = useCallback((event: any) => {
+    setQuestion(event.target.value);
+  }, []);
+
+  const onClickSend = useCallback(() => {
+    const questionToSend = question.trim();
+    if (!questionToSend) {
+      return;
+    }
+
+    onSubmit(questionToSend);
+
+    setQuestion('');
+  }, [question, onSubmit]);
+
+  return {
+    question,
+    onChangeInput,
+    onClickSend,
+  };
+}
+
+export function FollowUpForm({ onSubmit }: FollowUpFormProps) {
+  const styles = useStyles2(getStyles);
+  const { question, onChangeInput, onClickSend } = useFollowUpForm(onSubmit);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.code === 'Enter' && !event.shiftKey) {
+      onClickSend();
+    }
+  };
+
+  return (
+    <div>
+      <TextArea
+        className={styles.textarea}
+        placeholder="Ask a follow-up question..."
+        value={question}
+        onChange={onChangeInput}
+        onKeyDown={onKeyDown}
+      />
+
+      <Button className={styles.sendButton} onClick={onClickSend}>
+        Send
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/domain/buildLlmPrompts.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/domain/buildLlmPrompts.ts
@@ -1,0 +1,119 @@
+/* https://platform.openai.com/docs/models/overview */
+
+export const model = 'gpt-4-1106-preview';
+
+/* https://platform.openai.com/docs/guides/prompt-engineering/tactics */
+
+enum PromptCategories {
+  system = 'system',
+  user = 'user',
+}
+
+type Prompts = Record<string, (profileType: string, profiles: string[]) => string>;
+
+const prompts: Record<PromptCategories, Prompts> = {
+  system: {
+    // add new system prompts above
+    empty: () => `
+    You are a performance profiling expert and excel at analyzing profiles in the DOT format.
+    In the DOT format, a row like N47 -> N61 means the function from N47 called the function from N61.
+`,
+  },
+  user: {
+    // add new user prompts above
+    single: (profileType: string, profiles: string[]) => `
+    Analyze this flamegraph in DOT format and address these key aspects:
+    - **Performance Bottleneck**: Identify the primary factors slowing down the process, consuming excessive memory, or causing a bottleneck in the system.
+    - **Root Cause**: Explain clearly why these bottlenecks are occurring.
+    - **Recommended Fix**: Suggest practical solutions for these issues.
+
+    Guidelines:
+    - Always use full function names without splitting them from package names.
+    - Exclude numeric values, percentages, and node names (e.g., N1, N3, Node 1, Node 2).
+    - Focus on user code over low-level runtime optimizations.
+    - For standard library or runtime functions, explain their presence/function and link them to user code functions calling them. Avoid repetitive mentions from the same call chain.
+    - Do not mention that the flamegraph profile is in DOT format.
+    - Only use h5 and h6 markdown headers (e.g., ##### Performance Bottleneck, ###### Recommended Fix)
+    - Do not use h1,h2,h3,h4 headers (e.g., ## Bottleneck, ### Root Cause, #### Recommended Fix)
+
+    Format the response using markdown headers for each section corresponding to the key aspects.
+
+    The profile type is: ${profileType}
+    Profile in DOT format:
+    ${profiles[0]}
+`,
+    anton: (profileType: string, profiles: string[]) => `
+Give me actionable feedback and suggestions on how I improve the application performance.
+
+Do not break function names.
+Do not show any numeric values, absolute or percents.
+Do not show node names like N1, N3, or Node 1, Node 2.
+Do not suggest low-level runtime optimisations, focus on the user code.
+
+Always use full function names.
+Never split function and package name.
+
+Remove any numeric values, absolute or percents, from the output.
+Remove node names like N1, N3, or Node 1, Node 2 from the output.
+
+If the function is widely known (e.g., a runtime or stdlib function), provide me concise explanation why the function is present in the profile and what could be the cause.
+If a function is defined in the runtime or in the standard library, tell me which function in the user code calls it.
+Avoid mentioning functions from the same call-chain.
+
+5 suggestions is enough.
+The profile type is ${profileType}
+Below is the performance profile in DOT format:
+${profiles[0]}
+`,
+    diff: (profileType: string, profiles: string[]) => `
+Analyze the differences between these two performance profiles presented in DOT format. Provide a detailed comparison focusing on the following aspects:
+
+- Performance Change: Determine how the performance has changed from the first profile to the second. Identify if there are new bottlenecks, improved or worsened performance areas, or significant changes in resource consumption.
+- Function Impact: Highlight no more than 3 specific functions that have undergone notable changes in their performance impact. Discuss any new functions that have appeared in the second profile or any existing functions that have significantly increased or decreased in resource usage.
+- Potential Causes: Discuss the possible reasons for these changes in performance, linking them to the differences in function execution or resource usage between the two profiles.
+
+Guidelines for Analysis:
+- Use full function names without separating them from their package names
+- Focus on user code rather than low-level runtime optimizations or standard library functions unless they are directly relevant to the user code's performance changes
+- Exclude numeric values, percentages, and node names (e.g., N1, N3, Node 1, Node 2) from the analysis
+- Format the response using markdown headers for each section to structure the analysis clearly
+
+The profile type is: ${profileType}
+
+First performance profile in DOT format:
+${profiles[0]}
+
+Second performance profile in DOT format:
+${profiles[1]}
+`,
+  },
+};
+
+export const buildPrompts = ({
+  system,
+  user,
+  profileType,
+  profiles,
+}: {
+  system: string;
+  user: string;
+  profileType: string;
+  profiles: string[];
+}) => {
+  const systemPrompt = prompts.system[system];
+
+  if (typeof systemPrompt !== 'function') {
+    throw new Error(`Cannot find system prompt "${system}"!`);
+  }
+
+  const userPrompt = prompts.user[user];
+
+  if (typeof userPrompt !== 'function') {
+    throw new Error(`Cannot find user prompt "${user}"!`);
+  }
+
+  return {
+    system: systemPrompt(profileType, profiles),
+    user: userPrompt(profileType, profiles),
+  };
+};

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/domain/useOpenAiChatCompletions.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/domain/useOpenAiChatCompletions.ts
@@ -1,0 +1,153 @@
+import { llms } from '@grafana/experimental';
+import { useCallback, useEffect, useState } from 'react';
+import { Subscription } from 'rxjs';
+
+import { buildPrompts, model } from './buildLlmPrompts';
+
+// taken from "@grafana/experimental"
+type Role = 'system' | 'user' | 'assistant' | 'function';
+
+type Message = {
+  role: Role;
+  content: string;
+  name?: string;
+  function_call?: Object;
+};
+
+export type OpenAiReply = {
+  reply: {
+    text: string;
+    hasStarted: boolean;
+    hasFinished: boolean;
+    messages: Message[];
+    askFollowupQuestion: (question: string) => void;
+  };
+  retry: () => void;
+  error: Error | null;
+};
+
+export function useOpenAiChatCompletions(profileType: string, profiles: string[]): OpenAiReply {
+  const [reply, setReply] = useState('');
+  const [replyHasStarted, setReplyHasStarted] = useState(false);
+  const [replyHasFinished, setReplyHasFinished] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [subscription, setSubscription] = useState<Subscription>();
+
+  const sendMessages = useCallback((messagesToSend: Message[]) => {
+    setMessages(messagesToSend);
+
+    setError(null);
+
+    setReply('');
+    setReplyHasStarted(true);
+    setReplyHasFinished(false);
+
+    const stream = llms.openai
+      .streamChatCompletions({
+        model,
+        messages: messagesToSend,
+      })
+      .pipe(
+        // Accumulate the stream content into a stream of strings, where each
+        // element contains the accumulated message so far.
+        llms.openai.accumulateContent()
+      );
+
+    const subscription = stream.subscribe({
+      next: setReply,
+      error(e) {
+        setError(e);
+        setReplyHasStarted(false);
+        setReplyHasFinished(true);
+        setSubscription(undefined);
+      },
+      complete() {
+        setReplyHasStarted(false);
+        setReplyHasFinished(true);
+        setSubscription(undefined);
+      },
+    });
+
+    setSubscription(subscription);
+  }, []);
+
+  const askFollowupQuestion = useCallback(
+    (question: string): void => {
+      const messagesToAdd: Message[] = [
+        {
+          role: 'assistant',
+          content: reply,
+        },
+        {
+          role: 'user',
+          content: question,
+        },
+      ];
+
+      try {
+        sendMessages([...messages, ...messagesToAdd]);
+      } catch (error) {
+        setError(error as Error);
+      }
+    },
+    [messages, reply, sendMessages]
+  );
+
+  useEffect(() => {
+    if (!profiles.length || messages.length > 0) {
+      return;
+    }
+
+    const prompts = buildPrompts({
+      system: 'empty',
+      user: profiles.length === 2 ? 'diff' : 'single',
+      profileType,
+      profiles,
+    });
+
+    try {
+      sendMessages([
+        {
+          role: 'system',
+          content: prompts.system,
+        },
+        {
+          role: 'system',
+          content: prompts.user,
+        },
+      ]);
+    } catch (error) {
+      setError(error as Error);
+    }
+  }, [messages.length, profileType, profiles, profiles.length, sendMessages]);
+
+  useEffect(() => {
+    return () => {
+      if (subscription) {
+        subscription.unsubscribe();
+        setSubscription(undefined);
+      }
+    };
+  }, [subscription]);
+
+  return {
+    reply: {
+      text: reply,
+      hasStarted: replyHasStarted,
+      hasFinished: replyHasFinished,
+      messages: messages,
+      askFollowupQuestion,
+    },
+    retry() {
+      if (messages.length > 0) {
+        try {
+          sendMessages(messages);
+        } catch (error) {
+          setError(error as Error);
+        }
+      }
+    },
+    error,
+  };
+}

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/ProfileApiClient.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/ProfileApiClient.ts
@@ -1,0 +1,38 @@
+import { TimeRange } from '@grafana/data';
+
+import { DataSourceProxyClient } from '../../../infrastructure/series/http/DataSourceProxyClient';
+
+// dot format returns string (TODO: json format later)
+type DiffProfileResponse = string;
+
+type GetParams = {
+  query: string;
+  timeRange: TimeRange;
+  format: string; // dot (TODO: json)
+  maxNodes: number;
+};
+
+export class ProfileApiClient extends DataSourceProxyClient {
+  constructor(options: { dataSourceUid: string }) {
+    super(options);
+  }
+
+  async get(params: GetParams): Promise<DiffProfileResponse> {
+    const searchParams = new URLSearchParams({
+      query: params.query,
+      from: String(params.timeRange.from.unix() * 1000),
+      until: String(params.timeRange.to.unix() * 1000),
+      format: params.format,
+    });
+
+    if (params.maxNodes) {
+      searchParams.set('max-nodes', String(params.maxNodes));
+    }
+
+    const response = await this.fetch(`/pyroscope/render?${searchParams.toString()}`);
+
+    const text = await response.text();
+
+    return text;
+  }
+}

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/cleanupDotResponse.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/cleanupDotResponse.ts
@@ -1,0 +1,12 @@
+export function cleanupDotResponse(profile: string): string {
+  return profile
+    .replace(/fontsize=\d+ /g, '')
+    .replace(/id="node\d+" /g, '')
+    .replace(/labeltooltip=".*\)" /g, '')
+    .replace(/tooltip=".*\)" /g, '')
+    .replace(/(N\d+ -> N\d+).*/g, '$1')
+    .replace(/N\d+ \[label="other.*\n/, '')
+    .replace(/shape=box /g, '')
+    .replace(/fillcolor="#\w{6}"/g, '')
+    .replace(/color="#\w{6}" /g, '');
+}

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/useFetchDotProfiles.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/useFetchDotProfiles.ts
@@ -1,0 +1,40 @@
+import { TimeRange } from '@grafana/data';
+import { useQuery } from '@tanstack/react-query';
+
+import { DataSourceProxyClientBuilder } from '../../../infrastructure/series/http/DataSourceProxyClientBuilder';
+import { cleanupDotResponse } from './cleanupDotResponse';
+import { ProfileApiClient } from './ProfileApiClient';
+
+export type FetchParams = Array<{
+  query: string;
+  timeRange: TimeRange;
+}>;
+
+const MAX_NODES = 100;
+
+export function useFetchDotProfiles(dataSourceUid: string, fetchParams: FetchParams) {
+  const profileApiClient = DataSourceProxyClientBuilder.build(dataSourceUid, ProfileApiClient) as ProfileApiClient;
+
+  const { isFetching, error, data } = useQuery({
+    queryKey: [
+      'dot-profiles',
+      dataSourceUid,
+      ...fetchParams.flatMap(({ query, timeRange }) => [query, timeRange.from.unix(), timeRange.to.unix()]),
+      MAX_NODES,
+    ],
+    queryFn: () => {
+      // TODO: pass a signal options to properly abort all in-flight requests
+      return Promise.all(
+        fetchParams.map(({ query, timeRange }) =>
+          profileApiClient.get({ query, timeRange, format: 'dot', maxNodes: MAX_NODES }).then(cleanupDotResponse)
+        )
+      );
+    },
+  });
+
+  return {
+    isFetching,
+    error,
+    profiles: data || [],
+  };
+}

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/SceneExploreDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/SceneExploreDiffFlameGraph.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { DashboardCursorSync, GrafanaTheme2 } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
 import { behaviors, SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
@@ -43,6 +44,11 @@ export class SceneExploreDiffFlameGraph extends SceneObjectBase<SceneExploreDiff
   }
 
   onActivate() {
+    // hack to force UrlSyncManager to handle a new location
+    // this will sync the state from the URL by calling updateFromUrl() on all the time ranges (`SceneTimeRange` and our custom `SceneTimeRangeWithAnnotations`) that are defined on `SceneComparePanel`
+    // if not, landing on this view will result in empty URL search parameters (to/from and diffTo/diffFrom) which will make shareable links useless
+    locationService.partial({}, true); // replace to avoid creating history items
+
     const profileMetricVariable = sceneGraph.findByKeyAndType(this, 'profileMetricId', ProfileMetricVariable);
 
     profileMetricVariable.setState({ query: ProfileMetricVariable.QUERY_SERVICE_NAME_DEPENDENT });

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/components/SceneTimeRangeWithAnnotations.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/components/SceneTimeRangeWithAnnotations.ts
@@ -124,6 +124,10 @@ export class SceneTimeRangeWithAnnotations
   updateTimeseriesAnnotation() {
     const { annotationTimeRange, annotationColor, annotationTitle } = this.state;
 
+    if (!annotationTimeRange.from.unix() || !annotationTimeRange.to.unix()) {
+      return;
+    }
+
     const { $data } = this.getTimeseries().state;
 
     const data = $data?.state.data;

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/components/SceneTimeRangeWithAnnotations.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/components/SceneTimeRangeWithAnnotations.ts
@@ -124,10 +124,6 @@ export class SceneTimeRangeWithAnnotations
   updateTimeseriesAnnotation() {
     const { annotationTimeRange, annotationColor, annotationTitle } = this.state;
 
-    if (!annotationTimeRange.from.unix() || !annotationTimeRange.to.unix()) {
-      return;
-    }
-
     const { $data } = this.getTimeseries().state;
 
     const data = $data?.state.data;

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
@@ -175,7 +175,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
             <InlineBanner
               severity="warning"
               title="No profile data available"
-              message="Please verify that you've selected adequate time ranges and filters."
+              message="Please verify that you've selected adequate filters and time ranges."
             />
           )}
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
@@ -29,7 +29,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
   constructor() {
     super({
       key: 'diff-flame-graph',
-      aiPanel: new SceneAiPanel({ isDiff: true }),
+      aiPanel: new SceneAiPanel(),
     });
   }
 
@@ -98,7 +98,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
         fetchSettingsError,
         ai: {
           panel: aiPanel,
-          params: [
+          fetchParams: [
             { query: baselineQuery, timeRange: baselineTimeRange },
             { query: comparisonQuery, timeRange: comparisonTimeRange },
           ],
@@ -190,7 +190,12 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
         </Panel>
 
         {sidePanel.isOpen('ai') && (
-          <data.ai.panel.Component model={data.ai.panel} params={data.ai.params} onClose={sidePanel.close} />
+          <data.ai.panel.Component
+            model={data.ai.panel}
+            isDiff
+            fetchParams={data.ai.fetchParams}
+            onClose={sidePanel.close}
+          />
         )}
       </div>
     );

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/infrastructure/useFetchDiffProfile.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/infrastructure/useFetchDiffProfile.ts
@@ -33,10 +33,10 @@ export function useFetchDiffProfile({
     // for UX: keep previous data while fetching -> profile does not re-render with empty panels when refreshing
     placeholderData: (previousData) => previousData,
     enabled,
-    // we use "raw" to cache relative time ranges between renders, so that only refetch() will trigger a new query
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: [
       'diff-profile',
+      dataSourceUid,
       baselineQuery,
       baselineTimeRange.from.unix(),
       baselineTimeRange.to.unix(),

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -40,7 +40,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
         queries: [],
       }),
       lastTimeRange: undefined,
-      aiPanel: new SceneAiPanel({ isDiff: false }),
+      aiPanel: new SceneAiPanel(),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -124,7 +124,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
         settings,
         ai: {
           panel: aiPanel,
-          params: [{ query, timeRange: lastTimeRange }],
+          fetchParams: [{ query, timeRange: lastTimeRange }],
         },
       },
       actions: {
@@ -183,7 +183,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
         </Panel>
 
         {sidePanel.isOpen('ai') && (
-          <data.ai.panel.Component model={data.ai.panel} params={data.ai.params} onClose={sidePanel.close} />
+          <data.ai.panel.Component model={data.ai.panel} fetchParams={data.ai.fetchParams} onClose={sidePanel.close} />
         )}
 
         {sidePanel.isOpen('function-details') && (

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -1,10 +1,8 @@
 import { css } from '@emotion/css';
-import { createTheme, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { createTheme, GrafanaTheme2, LoadingState, TimeRange } from '@grafana/data';
 import { FlameGraph } from '@grafana/flamegraph';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState, SceneQueryRunner } from '@grafana/scenes';
 import { Spinner, useStyles2, useTheme2 } from '@grafana/ui';
-import { AiPanel } from '@shared/components/AiPanel/AiPanel';
-import { AIButton } from '@shared/components/AiPanel/components/AIButton';
 import { FunctionDetailsPanel } from '@shared/components/FunctionDetailsPanel/FunctionDetailsPanel';
 import { displayWarning } from '@shared/domain/displayStatus';
 import { useGitHubIntegration } from '@shared/domain/github-integration/useGitHubIntegration';
@@ -18,12 +16,17 @@ import { Panel } from '@shared/ui/Panel/Panel';
 import React, { useEffect, useMemo } from 'react';
 import { Unsubscribable } from 'rxjs';
 
+import { useBuildPyroscopeQuery } from '../../domain/useBuildPyroscopeQuery';
 import { getSceneVariableValue } from '../../helpers/getSceneVariableValue';
 import { buildFlameGraphQueryRunner } from '../../infrastructure/flame-graph/buildFlameGraphQueryRunner';
 import { PYROSCOPE_DATA_SOURCE } from '../../infrastructure/pyroscope-data-sources';
+import { AIButton } from '../SceneAiPanel/components/AiButton/AIButton';
+import { SceneAiPanel } from '../SceneAiPanel/SceneAiPanel';
 
 interface SceneFlameGraphState extends SceneObjectState {
   $data: SceneQueryRunner;
+  lastTimeRange?: TimeRange;
+  aiPanel: SceneAiPanel;
 }
 
 // I've tried to use a SplitLayout for the body without any success (left: flame graph, right: explain flame graph content)
@@ -36,6 +39,8 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
         datasource: PYROSCOPE_DATA_SOURCE,
         queries: [],
       }),
+      lastTimeRange: undefined,
+      aiPanel: new SceneAiPanel({ isDiff: false }),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -55,7 +60,12 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
 
       dataSubscription = newState.$data?.subscribeToState((newDataState) => {
         if (newDataState.data?.state === LoadingState.Done) {
-          timelineAndProfileApiClient.setLastTimeRange(newDataState.data.timeRange);
+          const lastTimeRange = newDataState.data.timeRange;
+
+          // For the "Function Details" feature only
+          timelineAndProfileApiClient.setLastTimeRange(lastTimeRange);
+
+          this.setState({ lastTimeRange });
         }
       });
     });
@@ -66,13 +76,21 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     };
   }
 
+  buildTitle() {
+    const serviceName = getSceneVariableValue(this, 'serviceName');
+    const profileMetricId = getSceneVariableValue(this, 'profileMetricId');
+    const profileMetricType = getProfileMetric(profileMetricId as ProfileMetricId).type;
+
+    return `🔥 Flame graph for ${serviceName} (${profileMetricType})`;
+  }
+
   useSceneFlameGraph = (): DomainHookReturnValue => {
     const { isLight } = useTheme2();
     const getTheme = useMemo(() => () => createTheme({ colors: { mode: isLight ? 'light' : 'dark' } }), [isLight]);
 
     const [maxNodes] = useMaxNodesFromUrl();
     const { settings, error: isFetchingSettingsError } = useFetchPluginSettings();
-    const { $data } = this.useState();
+    const { $data, aiPanel, lastTimeRange } = this.useState();
 
     if (isFetchingSettingsError) {
       displayWarning([
@@ -94,18 +112,20 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     const profileData = $dataState?.data?.series?.[0];
     const hasProfileData = Number(profileData?.length) > 1;
 
-    const serviceName = getSceneVariableValue(this, 'serviceName');
-    const profileMetricId = getSceneVariableValue(this, 'profileMetricId');
-    const profileMetricType = getProfileMetric(profileMetricId as ProfileMetricId).type;
+    const query = useBuildPyroscopeQuery(this, 'filters');
 
     return {
       data: {
-        title: `${serviceName} flame graph (${profileMetricType})`,
+        title: this.buildTitle(),
         isLoading: isFetchingProfileData,
         isFetchingProfileData,
         hasProfileData,
         profileData,
         settings,
+        ai: {
+          panel: aiPanel,
+          params: [{ query, timeRange: lastTimeRange }],
+        },
       },
       actions: {
         getTheme,
@@ -117,15 +137,16 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     const styles = useStyles2(getStyles);
 
     const { data, actions } = model.useSceneFlameGraph();
-
     const sidePanel = useToggleSidePanel();
     const gitHubIntegration = useGitHubIntegration(sidePanel);
 
+    const isAiButtonDisabled = data.isLoading || !data.hasProfileData;
+
     useEffect(() => {
-      if (data.isLoading) {
+      if (isAiButtonDisabled) {
         sidePanel.close();
       }
-    }, [data.isLoading, sidePanel]);
+    }, [isAiButtonDisabled, sidePanel]);
 
     const panelTitle = useMemo(
       () => (
@@ -145,11 +166,8 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
           isLoading={data.isLoading}
           headerActions={
             <AIButton
-              className={styles.aiButton}
-              onClick={() => {
-                sidePanel.open('ai');
-              }}
-              disabled={data.isLoading || !data.hasProfileData || sidePanel.isOpen('ai')}
+              disabled={isAiButtonDisabled || sidePanel.isOpen('ai')}
+              onClick={() => sidePanel.open('ai')}
               interactionName="g_pyroscope_app_explain_flamegraph_clicked"
             >
               Explain Flame Graph
@@ -164,7 +182,9 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
           />
         </Panel>
 
-        {sidePanel.isOpen('ai') && <AiPanel className={styles.sidePanel} onClose={sidePanel.close} />}
+        {sidePanel.isOpen('ai') && (
+          <data.ai.panel.Component model={data.ai.panel} params={data.ai.params} onClose={sidePanel.close} />
+        )}
 
         {sidePanel.isOpen('function-details') && (
           <FunctionDetailsPanel
@@ -193,8 +213,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   spinner: css`
     margin-left: ${theme.spacing(1)};
-  `,
-  aiButton: css`
-    margin-top: ${theme.spacing(1)};
   `,
 });

--- a/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
@@ -3,8 +3,7 @@ import { AdHocFiltersVariable, SceneComponentProps, sceneGraph } from '@grafana/
 import { useStyles2 } from '@grafana/ui';
 import { CompleteFilters } from '@shared/components/QueryBuilder/domain/types';
 import { QueryBuilder } from '@shared/components/QueryBuilder/QueryBuilder';
-import { useQueryFromUrl } from '@shared/domain/url-params/useQueryFromUrl';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { useBuildPyroscopeQuery } from '../../useBuildPyroscopeQuery';
 import { ProfilesDataSourceVariable } from '../ProfilesDataSourceVariable';
@@ -47,17 +46,10 @@ export class FiltersVariable extends AdHocFiltersVariable {
 
   static Component = ({ model }: SceneComponentProps<AdHocFiltersVariable & { onChangeQuery?: any }>) => {
     const styles = useStyles2(getStyles);
+
     const { key } = model.useState();
-    const [, setQuery] = useQueryFromUrl();
 
     const query = useBuildPyroscopeQuery(model, key as string);
-
-    useEffect(() => {
-      if (typeof query === 'string') {
-        // Explain Flame Graph (AI button) depends on the query value so we have to sync it here
-        setQuery(query);
-      }
-    }, [query, setQuery]);
 
     const { value: dataSourceUid } = sceneGraph
       .findByKeyAndType(model, 'dataSource', ProfilesDataSourceVariable)

--- a/src/shared/domain/useToggleSidePanel.ts
+++ b/src/shared/domain/useToggleSidePanel.ts
@@ -1,6 +1,4 @@
-import { useQueryFromUrl } from '@shared/domain/url-params/useQueryFromUrl';
-import { useTimeRangeFromUrl } from '@shared/domain/url-params/useTimeRangeFromUrl';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 type PanelId = 'ai' | 'function-details' | null;
 
@@ -14,16 +12,8 @@ export type SidePanel = {
 };
 
 export function useToggleSidePanel(): SidePanel {
-  const [query] = useQueryFromUrl();
-  const [timeRange] = useTimeRangeFromUrl();
   const [openPanelId, setOpenPanelId] = useState<PanelId>(null);
   const [onOpenHandler, setOnOpenHandler] = useState<OnOpenHandler>();
-
-  // TOOD: better alternative - add callback props on <Toolbar />
-  useEffect(() => {
-    setOpenPanelId(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, timeRange.raw.from.toString(), timeRange.raw.to.toString()]);
 
   return {
     onOpen(handler: OnOpenHandler) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** is caused by https://github.com/grafana/explore-profiles/pull/119

This PR aims at fixing the "Explain Flame Graph" feature on the comparison view. Namely, before this PR:
- the `isDiff` prop [was not passed](https://github.com/grafana/explore-profiles/pull/119/files#diff-b648e06443c5667d8938e238e6b0a8b7579e793379e4fdd1cfc0c0191a7984e6R182) to the `AiPanel` component, leading to an incorrect AI analysis based solely on a single profile
- obtaining the queries required to fetch the profiles in DOT format relied on `parseLeftRightUrlSearchParams` which worked only for the legacy pages

### 📖 Summary of the changes

To fix the issues, this PR introduces the new `SceneAiPanel` (based on the non-Scenes `AiPanel`), used both in `SceneFlameGraph` and `SceneDiffFlameGraph`.

See the diff tab for specific comments.

### 🧪 How to test?

Manually after checking this PR branch in local:
- The analysis for a single flamegraph should work as before
- The analysis for a diff flamegraph should work

In both case, the API requests made by the browser should have the correct query(-ies) and the correct time range(s). In the case of a single flame graph, the time range must be the last one used to fetch the main timeseries. And in the case of a diff flame graph, they must be equal to the ranges selected by the user on the baseline & comparison timeseries.
