### PR TITLE
chore(Labels): Add border to separate compare actions

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/components/SceneStatsPanel/ui/StatsPanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/components/SceneStatsPanel/ui/StatsPanel.tsx
@@ -92,5 +92,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     justify-content: space-between;
     font-size: 11px;
+    border-top: 1px solid ${theme.colors.border.weak};
+    padding: ${theme.spacing(1)} 0 0 0;
   `,
 });


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just a small cosmetic change, to better separate the compare actions in the "Labels" view:

| Before | After |
|  ---   |  ---  |
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/b5f3212b-a656-4f93-b66b-aa160b3d6e10"> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/cac9e8fc-5843-42f0-a889-402126730d70"> |

### 📖 Summary of the changes

`-`

### 🧪 How to test?

`-`