### PR TITLE
feat(DiffFlameGraph): Add flame graph range in timeseries legend

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
@@ -251,7 +251,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-bottom: ${theme.spacing(2)};
 
     & > h6 {
-      margin-top: -2px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 ${theme.spacing(1)} 0 0;
     }
   `,
   timePicker: css`

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
@@ -170,8 +170,8 @@ export class SceneComparePanel extends SceneObjectBase<SceneComparePanelState> {
     const annotation = timeseriesPanel.state.body.state.$data?.state.data?.annotations?.[0] as RangeAnnotation;
 
     annotation?.fields.some(({ name, values }) => {
-      diffFrom ||= name === 'time' ? values[0] : undefined;
-      diffTo ||= name === 'timeEnd' ? values[0] : undefined;
+      diffFrom = name === 'time' ? values[0] : diffFrom;
+      diffTo = name === 'timeEnd' ? values[0] : diffTo;
       return diffFrom && diffTo;
     });
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/components/SceneTimeRangeWithAnnotations.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/components/SceneTimeRangeWithAnnotations.ts
@@ -1,4 +1,4 @@
-import { dateTime, TimeRange } from '@grafana/data';
+import { dateTime, LoadingState, TimeRange } from '@grafana/data';
 import {
   sceneGraph,
   SceneObjectBase,
@@ -81,7 +81,7 @@ export class SceneTimeRangeWithAnnotations
 
     this._subs.add(
       this.getTimeseries().state.$data?.subscribeToState((newState, prevState) => {
-        if (!newState.data) {
+        if (!newState.data || newState.data.state !== LoadingState.Done) {
           return;
         }
 

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -75,9 +75,14 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
   onActivate() {
     const { body } = this.state;
 
-    const sub = (body.state.$data as SceneDataProvider).subscribeToState((newState) => {
+    const sub = (body.state.$data as SceneDataProvider).subscribeToState((newState, prevState) => {
       if (newState.data?.state !== LoadingState.Done) {
         return;
+      }
+
+      // ensure we retain the previous annotations, if they exist
+      if (!newState.data.annotations?.length && prevState.data?.annotations?.length) {
+        newState.data.annotations = prevState.data.annotations;
       }
 
       const { series } = newState.data;


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR adds the selected flame graph ranges in the "Diff flame graph" view (in the legend of each time series):

| Before | After |
|  ---   |  ---  |
| <img width="1693" alt="Screenshot 2024-08-27 at 21 54 30" src="https://github.com/user-attachments/assets/c79342fe-b0ab-45a8-9205-0e8b73001419"> | <img width="1693" alt="Screenshot 2024-08-27 at 21 53 57" src="https://github.com/user-attachments/assets/dc2ac498-3d5d-46ac-85d6-15eb7b8a9d70"> |

Indeed, while navigating in time, users might "lose" this information.

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

- Manually, after checking this branch locally
