### PR TITLE
feat(*): Add histogram visualizations

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -19,13 +19,15 @@ import React from 'react';
 import { EventTimeseriesDataReceived } from '../../domain/events/EventTimeseriesDataReceived';
 import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { getSceneVariableValue } from '../../helpers/getSceneVariableValue';
+import { panelBuilder } from '../../helpers/panelBuilder';
 import { SceneLabelValuesBarGauge } from '../SceneLabelValuesBarGauge';
+import { SceneLabelValuesHistogram } from '../SceneLabelValuesHistogram';
 import { SceneLabelValuesTimeseries } from '../SceneLabelValuesTimeseries';
 import { SceneEmptyState } from './components/SceneEmptyState/SceneEmptyState';
 import { SceneErrorState } from './components/SceneErrorState/SceneErrorState';
 import { LayoutType, SceneLayoutSwitcher, SceneLayoutSwitcherState } from './components/SceneLayoutSwitcher';
 import { SceneNoDataSwitcher, SceneNoDataSwitcherState } from './components/SceneNoDataSwitcher';
-import { PanelType, ScenePanelTypeSwitcher } from './components/ScenePanelTypeSwitcher';
+import { ScenePanelTypeSwitcher } from './components/ScenePanelTypeSwitcher';
 import { SceneQuickFilter, SceneQuickFilterState } from './components/SceneQuickFilter';
 import { sortFavGridItems } from './domain/sortFavGridItems';
 import { GridItemData } from './types/GridItemData';
@@ -279,7 +281,10 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     }
 
     const gridItems = this.state.items.map((item) => {
-      const vizPanel = this.buildVizPanel(item);
+      const vizPanel = panelBuilder(item.panelType, {
+        item,
+        headerActions: this.state.headerActions.bind(null, item, this.state.items),
+      });
 
       if (this.state.hideNoData) {
         this.setupHideNoData(vizPanel);
@@ -297,24 +302,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     });
   }
 
-  buildVizPanel(item: GridItemData) {
-    switch (item.panelType) {
-      case PanelType.BARGAUGE:
-        return new SceneLabelValuesBarGauge({
-          item,
-          headerActions: this.state.headerActions.bind(null, item, this.state.items),
-        });
-
-      case PanelType.TIMESERIES:
-      default:
-        return new SceneLabelValuesTimeseries({
-          item,
-          headerActions: this.state.headerActions.bind(null, item, this.state.items),
-        });
-    }
-  }
-
-  setupHideNoData(vizPanel: SceneLabelValuesTimeseries | SceneLabelValuesBarGauge) {
+  setupHideNoData(vizPanel: SceneLabelValuesTimeseries | SceneLabelValuesBarGauge | SceneLabelValuesHistogram) {
     const sub = vizPanel.subscribeToEvent(EventTimeseriesDataReceived, (event) => {
       if (event.payload.series?.length) {
         return;

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 export enum PanelType {
   TIMESERIES = 'time-series',
   BARGAUGE = 'bar-gauge',
+  HISTOGRAM = 'histogram',
 }
 
 export interface ScenePanelTypeSwitcherState extends SceneObjectState {
@@ -24,7 +25,8 @@ export class ScenePanelTypeSwitcher extends SceneObjectBase<ScenePanelTypeSwitch
 
   static OPTIONS = [
     { label: 'Time series', value: PanelType.TIMESERIES, icon: 'heart-rate' },
-    { label: 'Totals', value: PanelType.BARGAUGE, icon: 'graph-bar' },
+    { label: 'Totals', value: PanelType.BARGAUGE, icon: 'align-left' },
+    { label: 'Histograms', value: PanelType.HISTOGRAM, icon: 'graph-bar' },
   ];
 
   static DEFAULT_PANEL_TYPE = PanelType.TIMESERIES;

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/types/GridItemData.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/types/GridItemData.ts
@@ -15,5 +15,5 @@ export type GridItemData = {
     };
     filters?: AdHocVariableFilter[];
   };
-  panelType?: PanelType;
+  panelType: PanelType;
 };

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
@@ -23,6 +23,7 @@ import { FiltersVariable } from '../../../../domain/variables/FiltersVariable/Fi
 import { getSceneVariableValue } from '../../../../helpers/getSceneVariableValue';
 import { getSeriesStatsValue } from '../../../../infrastructure/helpers/getSeriesStatsValue';
 import { getProfileMetricLabel } from '../../../../infrastructure/series/helpers/getProfileMetricLabel';
+import { PanelType } from '../../../SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher';
 import { addRefId, addStats } from '../../../SceneByVariableRepeaterGrid/infrastructure/data-transformations';
 import { CompareTarget } from '../../../SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/domain/types';
 import { SceneLabelValuesTimeseries } from '../../../SceneLabelValuesTimeseries';
@@ -106,6 +107,7 @@ export class SceneComparePanel extends SceneObjectBase<SceneComparePanelState> {
         value: target,
         label: '',
         queryRunnerParams: {},
+        panelType: PanelType.TIMESERIES,
       },
       data: new SceneDataTransformer({
         $data: buildCompareTimeSeriesQueryRunner({ filterKey }),

--- a/src/pages/ProfilesExplorerView/components/SceneExploreFavorites/SceneExploreFavorites.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreFavorites/SceneExploreFavorites.tsx
@@ -7,7 +7,6 @@ import {
 } from '@grafana/scenes';
 import React from 'react';
 
-import { PanelType } from '../../components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher';
 import { SceneByVariableRepeaterGrid } from '../../components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
 import { GridItemData } from '../../components/SceneByVariableRepeaterGrid/types/GridItemData';
 import { SceneDrawer } from '../../components/SceneDrawer';
@@ -17,11 +16,10 @@ import { EventExpandPanel } from '../../domain/events/EventExpandPanel';
 import { EventViewServiceFlameGraph } from '../../domain/events/EventViewServiceFlameGraph';
 import { EventViewServiceLabels } from '../../domain/events/EventViewServiceLabels';
 import { FavoriteVariable } from '../../domain/variables/FavoriteVariable';
+import { panelBuilder } from '../../helpers/panelBuilder';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
 import { SceneNoDataSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneNoDataSwitcher';
 import { SceneQuickFilter } from '../SceneByVariableRepeaterGrid/components/SceneQuickFilter';
-import { SceneLabelValuesBarGauge } from '../SceneLabelValuesBarGauge';
-import { SceneLabelValuesTimeseries } from '../SceneLabelValuesTimeseries';
 
 interface SceneExploreFavoritesState extends EmbeddedSceneState {
   drawer: SceneDrawer;
@@ -102,25 +100,19 @@ export class SceneExploreFavorites extends SceneObjectBase<SceneExploreFavorites
   }
 
   openExpandedPanelDrawer(item: GridItemData) {
+    const headerActions = () => [
+      new SelectAction({ EventClass: EventViewServiceLabels, item }),
+      new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
+    ];
+
     this.state.drawer.open({
       title: item.label,
-      body:
-        item.panelType === PanelType.BARGAUGE
-          ? new SceneLabelValuesBarGauge({
-              item,
-              headerActions: () => [
-                new SelectAction({ EventClass: EventViewServiceLabels, item }),
-                new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
-              ],
-            })
-          : new SceneLabelValuesTimeseries({
-              displayAllValues: true,
-              item,
-              headerActions: () => [
-                new SelectAction({ EventClass: EventViewServiceLabels, item }),
-                new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
-              ],
-            }),
+      body: panelBuilder(item.panelType, {
+        displayAllValues: true,
+        legendPlacement: 'right',
+        item,
+        headerActions,
+      }),
     });
   }
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/SceneGroupByLabels.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/SceneGroupByLabels.tsx
@@ -24,6 +24,7 @@ import { addFilter } from '../../../../domain/variables/FiltersVariable/filters-
 import { FiltersVariable } from '../../../../domain/variables/FiltersVariable/FiltersVariable';
 import { GroupByVariable } from '../../../../domain/variables/GroupByVariable/GroupByVariable';
 import { getSceneVariableValue } from '../../../../helpers/getSceneVariableValue';
+import { panelBuilder } from '../../../../helpers/panelBuilder';
 import { interpolateQueryRunnerVariables } from '../../../../infrastructure/helpers/interpolateQueryRunnerVariables';
 import { getProfileMetricLabel } from '../../../../infrastructure/series/helpers/getProfileMetricLabel';
 import { SceneLayoutSwitcher } from '../../../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
@@ -37,8 +38,6 @@ import { SceneQuickFilter } from '../../../SceneByVariableRepeaterGrid/component
 import { SceneByVariableRepeaterGrid } from '../../../SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
 import { GridItemData } from '../../../SceneByVariableRepeaterGrid/types/GridItemData';
 import { SceneDrawer } from '../../../SceneDrawer';
-import { SceneLabelValuesBarGauge } from '../../../SceneLabelValuesBarGauge';
-import { SceneLabelValuesTimeseries } from '../../../SceneLabelValuesTimeseries';
 import { SceneProfilesExplorer } from '../../../SceneProfilesExplorer/SceneProfilesExplorer';
 import { SceneStatsPanel } from './components/SceneLabelValuesGrid/components/SceneStatsPanel/SceneStatsPanel';
 import { CompareTarget } from './components/SceneLabelValuesGrid/domain/types';
@@ -274,20 +273,18 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
   openExpandedPanelDrawer(item: GridItemData) {
     const serviceName = getSceneVariableValue(this, 'serviceName');
     const profileMetricId = getSceneVariableValue(this, 'profileMetricId');
+    const title = `${serviceName} · ${getProfileMetricLabel(profileMetricId)} · ${item.label}`;
+
+    const headerActions = () => [new SelectAction({ EventClass: EventSelectLabel, item }), new FavAction({ item })];
 
     this.state.drawer.open({
-      title: `${serviceName} · ${getProfileMetricLabel(profileMetricId)} · ${item.label}`,
-      body:
-        item.panelType === PanelType.BARGAUGE
-          ? new SceneLabelValuesBarGauge({
-              item,
-              headerActions: () => [new SelectAction({ EventClass: EventSelectLabel, item }), new FavAction({ item })],
-            })
-          : new SceneLabelValuesTimeseries({
-              displayAllValues: true,
-              item,
-              headerActions: () => [new SelectAction({ EventClass: EventSelectLabel, item }), new FavAction({ item })],
-            }),
+      title,
+      body: panelBuilder(item.panelType, {
+        displayAllValues: true,
+        legendPlacement: 'right',
+        item,
+        headerActions,
+      }),
     });
   }
 

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesHistogram.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesHistogram.tsx
@@ -1,0 +1,146 @@
+import { DataFrame, FieldMatcherID, getValueFormat, LoadingState } from '@grafana/data';
+import {
+  PanelBuilders,
+  SceneComponentProps,
+  SceneDataTransformer,
+  SceneObjectBase,
+  SceneObjectState,
+  VizPanel,
+  VizPanelState,
+} from '@grafana/scenes';
+import { SortOrder } from '@grafana/schema';
+import { LegendDisplayMode, TooltipDisplayMode, VizLegendOptions } from '@grafana/ui';
+import React from 'react';
+
+import { EventTimeseriesDataReceived } from '../domain/events/EventTimeseriesDataReceived';
+import { getColorByIndex } from '../helpers/getColorByIndex';
+import { getSeriesLabelFieldName } from '../infrastructure/helpers/getSeriesLabelFieldName';
+import { getSeriesStatsValue } from '../infrastructure/helpers/getSeriesStatsValue';
+import { buildTimeSeriesQueryRunner } from '../infrastructure/timeseries/buildTimeSeriesQueryRunner';
+import { addRefId, addStats, sortSeries } from './SceneByVariableRepeaterGrid/infrastructure/data-transformations';
+import { GridItemData } from './SceneByVariableRepeaterGrid/types/GridItemData';
+
+interface SceneLabelValuesHistogramState extends SceneObjectState {
+  body: VizPanel;
+  legendPlacement: VizLegendOptions['placement'];
+}
+
+export class SceneLabelValuesHistogram extends SceneObjectBase<SceneLabelValuesHistogramState> {
+  constructor({
+    item,
+    headerActions,
+    legendPlacement,
+  }: {
+    item: GridItemData;
+    headerActions: (item: GridItemData) => VizPanelState['headerActions'];
+    legendPlacement?: SceneLabelValuesHistogramState['legendPlacement'];
+  }) {
+    super({
+      key: 'histogram-label-values',
+      legendPlacement: legendPlacement || 'bottom',
+      body: PanelBuilders.histogram()
+        .setTitle(item.label)
+        .setData(
+          new SceneDataTransformer({
+            $data: buildTimeSeriesQueryRunner(item.queryRunnerParams),
+            transformations: [addRefId, addStats, sortSeries],
+          })
+        )
+        .setHeaderActions(headerActions(item))
+        .build(),
+    });
+
+    this.addActivationHandler(this.onActivate.bind(this, item));
+  }
+
+  onActivate(item: GridItemData) {
+    const { body } = this.state;
+
+    const sub = (body.state.$data as SceneDataTransformer)!.subscribeToState((newState) => {
+      if (newState.data?.state !== LoadingState.Done) {
+        return;
+      }
+
+      const { series } = newState.data;
+
+      if (series?.length) {
+        body.setState(this.getConfig(item, series));
+      }
+
+      // we publish the event only after setting the new config so that the subscribers can modify it
+      this.publishEvent(new EventTimeseriesDataReceived({ series }), true);
+    });
+
+    return () => {
+      sub.unsubscribe();
+    };
+  }
+
+  getConfig(item: GridItemData, series: DataFrame[]) {
+    const { legendPlacement } = this.state;
+    const groupByLabel = item.queryRunnerParams.groupBy?.label;
+
+    return {
+      title: series.length > 1 ? `${item.label} (${series.length})` : item.label,
+      options: {
+        tooltip: {
+          mode: TooltipDisplayMode.Single,
+          sort: SortOrder.None,
+        },
+        legend: {
+          showLegend: true,
+          displayMode: LegendDisplayMode.List,
+          placement: legendPlacement,
+          calcs: [],
+        },
+      },
+      fieldConfig: {
+        defaults: {
+          // we force the label value because the overrides don't seem to work when we receive a single serie
+          displayName: series.length === 1 ? groupByLabel : undefined,
+          custom: {
+            lineWidth: 0,
+          },
+        },
+        overrides: this.getOverrides(item, series),
+      },
+    };
+  }
+
+  getOverrides(item: GridItemData, series: DataFrame[]) {
+    const { index: startColorIndex, queryRunnerParams } = item;
+    const groupByLabel = queryRunnerParams.groupBy?.label;
+
+    return series.map((s, i) => {
+      const metricField = s.fields[1];
+      let displayName = groupByLabel ? getSeriesLabelFieldName(metricField, groupByLabel) : metricField.name;
+
+      if (series.length === 1) {
+        const allValuesSum = getSeriesStatsValue(s, 'allValuesSum') || 0;
+        const formattedValue = getValueFormat(metricField.config.unit)(allValuesSum);
+
+        displayName = `${displayName} / total = ${formattedValue.text}${formattedValue.suffix}`;
+      }
+
+      return {
+        matcher: { id: FieldMatcherID.byFrameRefID, options: s.refId },
+        properties: [
+          {
+            id: 'displayName',
+            value: displayName,
+          },
+          {
+            id: 'color',
+            value: { mode: 'fixed', fixedColor: getColorByIndex(startColorIndex + i) },
+          },
+        ],
+      };
+    });
+  }
+
+  static Component({ model }: SceneComponentProps<SceneLabelValuesHistogram>) {
+    const { body } = model.useState();
+
+    return <body.Component model={body} />;
+  }
+}

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesHistogram.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesHistogram.tsx
@@ -99,7 +99,7 @@ export class SceneLabelValuesHistogram extends SceneObjectBase<SceneLabelValuesH
           // we force the label value because the overrides don't seem to work when we receive a single serie
           displayName: series.length === 1 ? groupByLabel : undefined,
           custom: {
-            lineWidth: 0,
+            lineWidth: 1,
           },
         },
         overrides: this.getOverrides(item, series),

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -9,7 +9,8 @@ import {
   VizPanel,
   VizPanelState,
 } from '@grafana/scenes';
-import { GraphGradientMode } from '@grafana/schema';
+import { GraphGradientMode, SortOrder } from '@grafana/schema';
+import { LegendDisplayMode, TooltipDisplayMode, VizLegendOptions } from '@grafana/ui';
 import React from 'react';
 
 import { EventTimeseriesDataReceived } from '../domain/events/EventTimeseriesDataReceived';
@@ -29,8 +30,9 @@ import { GridItemData } from './SceneByVariableRepeaterGrid/types/GridItemData';
 interface SceneLabelValuesTimeseriesState extends SceneObjectState {
   item: GridItemData;
   headerActions: (item: GridItemData) => VizPanelState['headerActions'];
-  displayAllValues: boolean;
   body: VizPanel;
+  displayAllValues: boolean;
+  legendPlacement: VizLegendOptions['placement'];
   overrides?: (series: DataFrame[]) => VizPanelState['fieldConfig']['overrides'];
 }
 
@@ -39,12 +41,14 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     item,
     headerActions,
     displayAllValues,
+    legendPlacement,
     data,
     overrides,
   }: {
     item: SceneLabelValuesTimeseriesState['item'];
     headerActions: SceneLabelValuesTimeseriesState['headerActions'];
     displayAllValues?: SceneLabelValuesTimeseriesState['displayAllValues'];
+    legendPlacement?: SceneLabelValuesTimeseriesState['legendPlacement'];
     data?: SceneDataProvider;
     overrides?: SceneLabelValuesTimeseriesState['overrides'];
   }) {
@@ -53,6 +57,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
       item,
       headerActions,
       displayAllValues: Boolean(displayAllValues),
+      legendPlacement: legendPlacement || 'bottom',
       overrides,
       body: PanelBuilders.timeseries()
         .setTitle(item.label)
@@ -98,8 +103,8 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
   }
 
   getConfig(series: DataFrame[]) {
-    const { item } = this.state;
-    let { title } = this.state.body.state;
+    const { body, item, legendPlacement } = this.state;
+    let { title } = body.state;
     let description;
 
     if (item.queryRunnerParams.groupBy?.label) {
@@ -116,6 +121,17 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     return {
       title,
       description,
+      options: {
+        tooltip: {
+          mode: 'single',
+          sort: 'none',
+        },
+        legend: {
+          showLegend: true,
+          displayMode: 'list',
+          placement: legendPlacement,
+        },
+      },
       fieldConfig: {
         defaults: {
           min: 0,
@@ -130,7 +146,21 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
   }
 
   getAllValuesConfig(series: DataFrame[]) {
+    const { legendPlacement } = this.state;
+
     return {
+      options: {
+        tooltip: {
+          mode: TooltipDisplayMode.Single,
+          sort: SortOrder.None,
+        },
+        legend: {
+          showLegend: true,
+          displayMode: LegendDisplayMode.List,
+          placement: legendPlacement,
+          calcs: [],
+        },
+      },
       fieldConfig: {
         defaults: {
           min: 0,

--- a/src/pages/ProfilesExplorerView/helpers/panelBuilder.ts
+++ b/src/pages/ProfilesExplorerView/helpers/panelBuilder.ts
@@ -1,0 +1,18 @@
+import { PanelType } from '../components/SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher';
+import { SceneLabelValuesBarGauge } from '../components/SceneLabelValuesBarGauge';
+import { SceneLabelValuesHistogram } from '../components/SceneLabelValuesHistogram';
+import { SceneLabelValuesTimeseries } from '../components/SceneLabelValuesTimeseries';
+
+export function panelBuilder(panelType: PanelType, options: any) {
+  switch (panelType) {
+    case PanelType.BARGAUGE:
+      return new SceneLabelValuesBarGauge(options);
+
+    case PanelType.HISTOGRAM:
+      return new SceneLabelValuesHistogram(options);
+
+    case PanelType.TIMESERIES:
+    default:
+      return new SceneLabelValuesTimeseries(options);
+  }
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** solves https://github.com/grafana/explore-profiles/issues/75

<img width="1704" alt="image" src="https://github.com/user-attachments/assets/393ea05f-f0b1-4423-bd9a-03f00650eea7">

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

Manually, after checking this PR's branch locally:
- In the "Labels" view, by clicking on the new "Histograms" button
- After favoriting a panel, it should be displayed properly in the "Favorites" view

In both "Labels" and "Favorites", the expanded panel should be displayed properly (after clicking on the "expand" panel icon):
<img width="1706" alt="image" src="https://github.com/user-attachments/assets/9644db11-30bb-44e1-a980-757a03b51a8c">
