### PR TITLE
feat: support submodules for GitHub Integration

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
@@ -20,9 +20,10 @@ export function useCodeContainer(dataSourceUid: string, functionDetails: Functio
   } = useFetchVCSFile({
     enabled: isLoggedIn,
     dataSourceUid,
-    path: functionDetails.fileName,
+    localPath: functionDetails.fileName,
     repository: version?.repository ?? '',
     gitRef: version?.git_ref ?? '',
+    rootPath: version?.root_path ?? '',
   });
 
   // might be a bit costly so we memoize it

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/infrastructure/useFetchVCSFile.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/infrastructure/useFetchVCSFile.ts
@@ -8,7 +8,8 @@ type FetchParams = {
   dataSourceUid: string;
   repository: string;
   gitRef: string;
-  path: string;
+  localPath: string;
+  rootPath: string;
 };
 
 type FetchResponse = {
@@ -20,15 +21,14 @@ type FetchResponse = {
   };
 };
 
-export function useFetchVCSFile({ enabled, dataSourceUid, repository, gitRef, path }: FetchParams): FetchResponse {
+export function useFetchVCSFile({ enabled, dataSourceUid, repository, gitRef, localPath, rootPath }: FetchParams): FetchResponse {
   const privateVcsClient = DataSourceProxyClientBuilder.build(dataSourceUid, PrivateVcsClient);
-
   const { isFetching, error, data } = useQuery({
-    enabled: Boolean(enabled && path),
-    queryKey: ['vcs-file', repository, gitRef, path],
+    enabled: Boolean(enabled && localPath),
+    queryKey: ['vcs-file', repository, gitRef, localPath, rootPath],
     queryFn: () =>
       privateVcsClient
-        .getFile(repository, gitRef, path)
+        .getFile(repository, gitRef, localPath, rootPath)
         .then((code) => ({
           content: code.content,
           URL: code.URL,

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/PrivateVcsClient.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/PrivateVcsClient.ts
@@ -69,13 +69,14 @@ export class PrivateVcsClient extends DataSourceProxyClient {
    * @param localPath A file path relative to the repository root
    * @returns Base64 encoded file contents.
    */
-  async getFile(repositoryUrl: string, gitRef: string, localPath: string): Promise<GetFileResponse> {
+  async getFile(repositoryUrl: string, gitRef: string, localPath: string, rootPath: string): Promise<GetFileResponse> {
     const response = await this.postWithRefresh(
       '/vcs.v1.VCSService/GetFile',
       JSON.stringify({
         repositoryURL: repositoryUrl,
         ref: gitRef,
         localPath,
+        rootPath,
       })
     );
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/types/FunctionDetails.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/types/FunctionDetails.ts
@@ -1,6 +1,7 @@
 export type FunctionVersion = {
   repository: string;
   git_ref: string;
+  root_path: string;
 };
 
 export type Commit = {

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/infrastructure/fetchCommitsInfo.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/infrastructure/fetchCommitsInfo.ts
@@ -11,6 +11,7 @@ export async function fetchCommitsInfo(
   const commits = functionsDetails.map((details) => ({
     repositoryUrl: details?.version?.repository || '',
     gitRef: details?.version?.git_ref || 'HEAD',
+    rootPath: details?.version?.root_path || '',
   }));
 
   // TODO: extract to its own hook and simplify useSceneFunctionDetailsPanel()?


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/pyroscope-squad/issues/173

In this PR we introduce the usage of the root path. For the GitHub integration, it's a hint on where the sources are located inside the repository. More information at https://github.com/grafana/pyroscope/pull/3531

### 📖 Summary of the changes
Just extracting the root_path from the version data that comes from the backend. Then send it back when searching for the file.

### 🧪 How to test?
Run the rideshare example from this branch: https://github.com/grafana/pyroscope/pull/3531
Select in the flame graph some function related to the rideshare example to look at. The GetFile call should include the root_path "examples/language-sdk-instrumentation/golang-push/rideshare"
