### PR TITLE
docs: Fix broken link in docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -32,7 +32,7 @@ cards:
       description: How do you use profiling data to investigate an issue? Start here.
       height: 24
     - title: Determine your use case
-      href: ./troubleshooting/
+      href: ./determine-use-case/
       description: Choose one of the two most common use cases to guide your exploration.
       height: 24
     - title: Choose a view


### PR DESCRIPTION
### ✨ Description

Home page link to the Determine use case had a bad link to the troubleshooting section.


**Related issue(s):**

No issues. 

### 📖 Summary of the changes

Fixes a broken link in the home page. 

### 🧪 How to test?

Build the docs locally and click the link for Determine use case docs. 