### PR TITLE
chore: Add tracking to the version number for better insights on user stats

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,25 +1,14 @@
-import { PageLayoutType, usePluginContext } from '@grafana/data';
+import { PageLayoutType } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { setTrackingVersion } from '@shared/domain/reportInteraction';
 import { queryClient } from '@shared/infrastructure/react-query/queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { Onboarding } from './components/Onboarding/Onboarding';
 import { Routes } from './components/Routes/Routes';
 import './infrastructure/faro';
 
 export function App() {
-  const {
-    meta: {
-      info: { version },
-    },
-  } = usePluginContext();
-
-  useEffect(() => {
-    setTrackingVersion(version);
-  }, [version]);
-
   return (
     <QueryClientProvider client={queryClient}>
       <Onboarding>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,14 +1,25 @@
-import { PageLayoutType } from '@grafana/data';
+import { PageLayoutType, usePluginContext } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
+import { setTrackingVersion } from '@shared/domain/reportInteraction';
 import { queryClient } from '@shared/infrastructure/react-query/queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Onboarding } from './components/Onboarding/Onboarding';
 import { Routes } from './components/Routes/Routes';
 import './infrastructure/faro';
 
 export function App() {
+  const {
+    meta: {
+      info: { version },
+    },
+  } = usePluginContext();
+
+  useEffect(() => {
+    setTrackingVersion(version);
+  }, [version]);
+
   return (
     <QueryClientProvider client={queryClient}>
       <Onboarding>

--- a/src/shared/domain/__tests__/reportInteraction.spec.ts
+++ b/src/shared/domain/__tests__/reportInteraction.spec.ts
@@ -1,14 +1,19 @@
 import { reportInteraction as grafanaReportInteraction } from '@grafana/runtime';
 
-import { reportInteraction } from '../reportInteraction';
+import { reportInteraction, setTrackingVersion } from '../reportInteraction';
 
 jest.mock('@grafana/runtime', () => ({ reportInteraction: jest.fn() }));
 
 describe('reportInteraction(interactionName, properties)', () => {
   const originalLocation = window.location;
 
+  beforeEach(() => {
+    setTrackingVersion('1.0.0');
+  });
+
   afterEach(() => {
     window.location = originalLocation;
+    setTrackingVersion('unset');
   });
 
   it('calls Grafana\'s reportInteraction with a new "page" property', () => {
@@ -19,7 +24,10 @@ describe('reportInteraction(interactionName, properties)', () => {
 
     reportInteraction('unit_test_executed');
 
-    expect(grafanaReportInteraction).toHaveBeenCalledWith('unit_test_executed', { page: 'test-page-1' });
+    expect(grafanaReportInteraction).toHaveBeenCalledWith('unit_test_executed', {
+      page: 'test-page-1',
+      version: '1.0.0',
+    });
   });
 
   describe('if some extra properties are passed', () => {
@@ -34,6 +42,7 @@ describe('reportInteraction(interactionName, properties)', () => {
       expect(grafanaReportInteraction).toHaveBeenCalledWith('unit_test_executed', {
         page: 'test-page-2',
         testFramework: 'Jest',
+        version: '1.0.0',
       });
     });
   });

--- a/src/shared/domain/__tests__/reportInteraction.spec.ts
+++ b/src/shared/domain/__tests__/reportInteraction.spec.ts
@@ -1,19 +1,23 @@
 import { reportInteraction as grafanaReportInteraction } from '@grafana/runtime';
 
-import { reportInteraction, setTrackingVersion } from '../reportInteraction';
+import { reportInteraction } from '../reportInteraction';
 
-jest.mock('@grafana/runtime', () => ({ reportInteraction: jest.fn() }));
+jest.mock('@grafana/runtime', () => ({
+  reportInteraction: jest.fn(),
+  config: {
+    apps: {
+      'grafana-pyroscope-app': {
+        version: '1.0.0',
+      },
+    },
+  },
+}));
 
 describe('reportInteraction(interactionName, properties)', () => {
   const originalLocation = window.location;
 
-  beforeEach(() => {
-    setTrackingVersion('1.0.0');
-  });
-
   afterEach(() => {
     window.location = originalLocation;
-    setTrackingVersion('unset');
   });
 
   it('calls Grafana\'s reportInteraction with a new "page" property', () => {

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -1,6 +1,6 @@
-import { reportInteraction as grafanaReportInteraction } from '@grafana/runtime';
+import { config, reportInteraction as grafanaReportInteraction } from '@grafana/runtime';
 
-import { ROUTES } from '../../constants';
+import { PYROSCOPE_APP_ID, ROUTES } from '../../constants';
 
 const PROFILES_EXPLORER_PAGE_NAME = ROUTES.PROFILES_EXPLORER_VIEW.slice(1);
 
@@ -11,6 +11,7 @@ function getCurrentPage(): string {
 
 function getExtraProperties() {
   const page = getCurrentPage();
+  const version = config.apps[PYROSCOPE_APP_ID].version;
   const extraProperties: Record<string, any> = { page, version };
 
   if (page === PROFILES_EXPLORER_PAGE_NAME) {
@@ -25,13 +26,4 @@ export function reportInteraction(interactionName: string, properties?: Record<s
     ...properties,
     ...getExtraProperties(),
   });
-}
-
-/**
- * "unset" may be tracked in case reportInteraction is called before the plugin version is retrieved
- */
-let version = 'unset';
-
-export function setTrackingVersion(value: string): void {
-  version = value;
 }

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -11,7 +11,7 @@ function getCurrentPage(): string {
 
 function getExtraProperties() {
   const page = getCurrentPage();
-  const extraProperties: Record<string, any> = { page };
+  const extraProperties: Record<string, any> = { page, version };
 
   if (page === PROFILES_EXPLORER_PAGE_NAME) {
     extraProperties.explorationType = new URLSearchParams(window.location.search).get('explorationType');
@@ -25,4 +25,13 @@ export function reportInteraction(interactionName: string, properties?: Record<s
     ...properties,
     ...getExtraProperties(),
   });
+}
+
+/**
+ * "unset" may be tracked in case reportInteraction is called before the plugin version is retrieved
+ */
+let version = 'unset';
+
+export function setTrackingVersion(value: string): void {
+  version = value;
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

N/A

### 📖 Summary of the changes

Adding version to all tracked events to better distinguish usage stats

### 🧪 How to test?

Run following command in dev tools:

```
window._debug.echo.enable();
```

You should see the version being tracked as an extra property:

![Screenshot 2024-09-04 at 15 23 06](https://github.com/user-attachments/assets/bf6f6177-aa39-4544-99c6-680bfb928091)
