### PR TITLE
chore: clean up GitSession cookie usages

### DIFF
--- a/samples/provisioning-local/datasources/datasources.yaml
+++ b/samples/provisioning-local/datasources/datasources.yaml
@@ -7,7 +7,7 @@ datasources:
     url: http://pyroscope:4100
     isDefault: true
     jsonData:
-      keepCookies: [GitSession, pyroscope_git_session]
+      keepCookies: [pyroscope_git_session]
     basicAuth: true
     # 1. our plugin backend expects a string
     # 2. this value must match the one in samples/provisioning/plugins/app.yaml

--- a/samples/provisioning-remote/datasources/datasources.yaml
+++ b/samples/provisioning-remote/datasources/datasources.yaml
@@ -7,7 +7,7 @@ datasources:
     url: $REMOTE_BACKEND_URL
     isDefault: true
     jsonData:
-      keepCookies: [GitSession, pyroscope_git_session]
+      keepCookies: [pyroscope_git_session]
     basicAuth: true
     # 1. our plugin backend expects a string
     # 2. this value must match the one in samples/provisioning/plugins/app.yaml

--- a/samples/provisioning/datasources/datasources.yaml
+++ b/samples/provisioning/datasources/datasources.yaml
@@ -7,7 +7,7 @@ datasources:
     url: http://pyroscope:4100
     isDefault: true
     jsonData:
-      keepCookies: [GitSession, pyroscope_git_session]
+      keepCookies: [pyroscope_git_session]
     basicAuth: true
     # 1. our plugin backend expects a string
     # 2. this value must match the one in samples/provisioning/plugins/app.yaml
@@ -25,7 +25,7 @@ datasources:
       # i.e. if a Prometheus DS is set to default, we can't set a Profiles DS to default
       # for these situations, we can override the default value here
       overridesDefault: true
-      keepCookies: [GitSession, pyroscope_git_session]
+      keepCookies: [pyroscope_git_session]
     basicAuth: true
     # 1. our plugin backend expects a string
     # 2. this value must match the one in samples/provisioning/plugins/app.yaml

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookie.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookie.ts
@@ -2,8 +2,8 @@
 const MAX_UNIX_TS_MS = 8640000000000000;
 
 /**
- * This is a value class representing a GitSession cookie value in the browser.
- * It provides APIs to decode a GitSession cookie value and to check if the the
+ * This is a value class representing a pyroscope_git_session cookie value in the browser.
+ * It provides APIs to decode a pyroscope_git_session cookie value and to check if the the
  * underlying user token is expired.
  */
 export class GitSessionCookie {
@@ -43,7 +43,7 @@ export class GitSessionCookie {
     try {
       decoded = atob(value);
     } catch (e) {
-      console.error('failed to base64 decode GitSession value', e);
+      console.error('failed to base64 decode pyroscope_git_session value', e);
       return undefined;
     }
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
@@ -1,8 +1,6 @@
 import { GitSessionCookie } from './GitSessionCookie';
 
-const GITHUB_SESSION_COOKIE_NAME = 'GitSession';
-const NEW_GITHUB_SESSION_COOKIE_NAME = 'pyroscope_git_session';
-const ACCEPTED_GITHUB_SESSION_COOKIE_NAMES = [GITHUB_SESSION_COOKIE_NAME, NEW_GITHUB_SESSION_COOKIE_NAME];
+const GITHUB_SESSION_COOKIE_NAME = 'pyroscope_git_session';
 
 export interface GitSessionCookieManager {
   getCookie(): GitSessionCookie | undefined;
@@ -27,15 +25,11 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
   }
 
   setCookie(cookie: string): void {
-    if (
-      !cookie.startsWith(`${GITHUB_SESSION_COOKIE_NAME}=`) &&
-      !cookie.startsWith(`${NEW_GITHUB_SESSION_COOKIE_NAME}=`)
-    ) {
-      // If incoming cookie is not named, we use the old cookie name
+    if (!cookie.startsWith(`${GITHUB_SESSION_COOKIE_NAME}=`)) {
       cookie = `${GITHUB_SESSION_COOKIE_NAME}=${cookie}`;
     }
 
-    const rawCookie = InternalGitSessionCookieManager.getCookieFromJar(cookie, ACCEPTED_GITHUB_SESSION_COOKIE_NAMES);
+    const rawCookie = InternalGitSessionCookieManager.getCookieFromJar(cookie, GITHUB_SESSION_COOKIE_NAME);
     if (rawCookie === undefined) {
       // If we can't parse the key-value pair out of [cookie], let's return now
       // to avoid corrupting the state of the manager or browser cookie.
@@ -54,10 +48,7 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
   }
 
   private syncCookieWithBrowser(): void {
-    const cookie = InternalGitSessionCookieManager.getCookieFromJar(
-      document.cookie,
-      ACCEPTED_GITHUB_SESSION_COOKIE_NAMES
-    );
+    const cookie = InternalGitSessionCookieManager.getCookieFromJar(document.cookie, GITHUB_SESSION_COOKIE_NAME);
     if (cookie?.key === this.rawCookie?.key && cookie?.value === this.rawCookie?.value) {
       return;
     }
@@ -65,7 +56,7 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
     cookie !== undefined ? this.setCookie(`${cookie.key}=${cookie.value}`) : this.deleteCookie();
   }
 
-  private static getCookieFromJar(jar: string, candidates: string[]): Cookie | undefined {
+  private static getCookieFromJar(jar: string, name: string): Cookie | undefined {
     return jar
       .split(';')
       .map((ck) => {
@@ -77,7 +68,7 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
         const value = rest.join('=');
         return { key: key.trim(), value: value?.trim() };
       })
-      .find(({ key }) => candidates.includes(key));
+      .find(({ key }) => key === name);
   }
 }
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/PrivateVcsClient.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/PrivateVcsClient.ts
@@ -40,9 +40,9 @@ export const PLACEHOLDER_COMMIT_DATA = Object.freeze({
  * is refreshed, the queued requests will be dispatched using the new token.
  *
  * WARNING: Only one instance of this class should be instantiated because it
- * needs to keep a singleton reference to the `GitSession` cookie. This class
- * will refresh the `GitSession` cookie whenever it expires and multiple
- * instances will cause unexpected errors and race conditions.
+ * needs to keep a singleton reference to the `pyroscope_git_session` cookie.
+ * This class will refresh the `pyroscope_git_session` cookie whenever it expires
+ * and multiple instances will cause unexpected errors and race conditions.
  */
 export class PrivateVcsClient extends DataSourceProxyClient {
   private sessionManager: GitSessionCookieManager;

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/__tests__/GitSessionCookieManager.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/__tests__/GitSessionCookieManager.spec.ts
@@ -23,18 +23,6 @@ describe('GitSessionCookieManager', () => {
     expect(cookie2).toStrictEqual(cookie1);
   });
 
-  it('can read and cache a namespaced cookie from the browser', () => {
-    const metadata = btoa('some encrypted secret');
-    const expiry = 1712762580000;
-    document.cookie = createNamespacedCookie(metadata, expiry);
-
-    const cookie1 = manager.getCookie();
-    expect(cookie1).toEqual(new GitSessionCookie(metadata, expiry));
-
-    const cookie2 = manager.getCookie();
-    expect(cookie2).toStrictEqual(cookie1);
-  });
-
   it('can read a legacy cookie', () => {
     const metadata = btoa('some encrypted secret');
     const newCookie = createLegacyCookie(metadata);
@@ -61,25 +49,11 @@ describe('GitSessionCookieManager', () => {
     expect(document.cookie).toEqual(newCookie);
   });
 
-  it('can set a namespaced cookie', () => {
-    const metadata = btoa('some encrypted secret');
-    const expiry = 1712762580000;
-    const newCookie = createNamespacedCookie(metadata, expiry);
-
-    const cookie1 = manager.getCookie();
-    expect(cookie1).toBeUndefined();
-
-    manager.setCookie(newCookie);
-    const cookie2 = manager.getCookie();
-    expect(cookie2).toEqual(new GitSessionCookie(metadata, expiry));
-    expect(document.cookie).toEqual(newCookie);
-  });
-
-  it('can set a cookie without the "GitSession" key', () => {
+  it('can set a cookie without the "pyroscope_git_session" key', () => {
     const metadata = btoa('some encrypted secret');
     const expiry = 1712762580000;
     const newCookie = createCookie(metadata, expiry);
-    const newCookieValue = newCookie.replace(/^GitSession=/, '');
+    const newCookieValue = newCookie.replace(/^pyroscope_git_session=/, '');
 
     const cookie1 = manager.getCookie();
     expect(cookie1).toBeUndefined();
@@ -103,7 +77,7 @@ describe('GitSessionCookieManager', () => {
     expect(document.cookie).toEqual(newCookie);
   });
 
-  it('can delete a "GitSession" cookie', () => {
+  it('can delete a "pyroscope_git_session" cookie', () => {
     const metadata = btoa('some encrypted secret');
     const expiry = 1712762580000;
     document.cookie = createCookie(metadata, expiry);
@@ -114,7 +88,7 @@ describe('GitSessionCookieManager', () => {
     expect(document.cookie).toEqual('');
   });
 
-  it('can delete a "GitSession" cookie that does not exist', () => {
+  it('can delete a "pyroscope_git_session" cookie that does not exist', () => {
     expect(document.cookie).toEqual('');
 
     manager.deleteCookie();
@@ -142,18 +116,9 @@ function createCookie(metadata: string, expiry: number): string {
     expiry: expiry,
   });
   const encoded = btoa(sessionCookie);
-  return `GitSession=${encoded}`;
+  return `pyroscope_git_session=${encoded}`;
 }
 
 function createLegacyCookie(metadata: string): string {
-  return `GitSession=${metadata}`;
-}
-
-function createNamespacedCookie(metadata: string, expiry: number): string {
-  const sessionCookie = JSON.stringify({
-    metadata: metadata,
-    expiry: expiry,
-  });
-  const encoded = btoa(sessionCookie);
-  return `pyroscope_git_session=${encoded}`;
+  return `pyroscope_git_session=${metadata}`;
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/pyroscope-squad/issues/171

Merge after backend starts using new cookie name:

This is the fourth step on the GitSession cookie rename. 
In this PR, we clean up all the usages of `GitSession` name in favour of the new `pyroscope_git_session`. Note that this PR is a branch of the previous PR: 
https://github.com/grafana/explore-profiles/pull/151
If you change base branch to main, you can check that the changes before and after the migration is a rename `GitSession` to `pyroscope_git_session`

### 📖 Summary of the changes

We remove the logic that handles both cookie names in favour of a single cookie name. We remove all references of `GitSession` as well.

### 🧪 How to test?

1. Run this in local.
2. Use a local pyroscope with the new version that uses `pyroscope_git_session` and check that GitHub Integration works.
