### PR TITLE
chore: Add missing key to children component

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/ui/ExplorationTypeSelector.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/ui/ExplorationTypeSelector.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Button, Icon, InlineLabel, useStyles2 } from '@grafana/ui';
 import { noOp } from '@shared/domain/noOp';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 export type ExplorationTypeSelectorProps = {
   options: Array<SelectableValue<string>>;
@@ -21,7 +21,7 @@ export function ExplorationTypeSelector({ options, value, onChange }: Exploratio
         {options.map((option, i) => {
           const isActive = value === option.value;
           return (
-            <>
+            <Fragment key={option.value}>
               <Button
                 className={isActive ? cx(styles.button, styles.active) : styles.button}
                 size="sm"
@@ -37,7 +37,7 @@ export function ExplorationTypeSelector({ options, value, onChange }: Exploratio
               </Button>
 
               {i < options.length - 3 && <Icon name="arrow-right" />}
-            </>
+            </Fragment>
           );
         })}
       </div>


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

N/A

### 📖 Summary of the changes

Fixes a small warning showing up on startup:

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `ExplorationTypeSelector`. See https://reactjs.org/link/warning-keys for more information.
    at ExplorationTypeSelector (webpack-internal:///./pages/ProfilesExplorerView/components/SceneProfilesExplorer/ui/ExplorationTypeSelector.tsx:16:36)
```

![Screenshot 2024-09-06 at 09 08 56](https://github.com/user-attachments/assets/4cc29b1e-a22b-4ed8-bfa1-b67266343995)


### 🧪 How to test?

* Open dev tools
* Load the app
* The error should not show up
