### PR TITLE
chore: Add and use usePrevious hook to fix side-effect errors

### DIFF
--- a/src/shared/components/QueryBuilder/QueryBuilder.tsx
+++ b/src/shared/components/QueryBuilder/QueryBuilder.tsx
@@ -1,7 +1,8 @@
 import { css, cx } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
 import { Button, useStyles2 } from '@grafana/ui';
-import React, { memo, useCallback, useEffect, useRef } from 'react';
+import { usePrevious } from '@shared/components/QueryBuilder/ui/hooks';
+import React, { memo, useCallback, useEffect } from 'react';
 import { StateListener } from 'xstate/lib/interpreter';
 
 import { Actor } from './domain/stateMachine';
@@ -223,18 +224,18 @@ function useSelectHandlers(actor: Actor, suggestions: QueryBuilderContext['sugge
     (document.querySelector(`#${queryBuilderId} input`) as HTMLInputElement)?.blur();
   }, [queryBuilderId]);
 
-  const isVisibleRef = useRef(suggestions.isVisible);
+  const previousSuggestionsIsVisible = usePrevious(suggestions.isVisible);
 
-  if (!suggestions.isVisible && isVisibleRef.current) {
-    // ensures that the input is blurred when a filter has been completed.
-    // we could have used blurInputOnSelect but this allows us to handle properly the case of
-    // editing a complete filter operator from (e.g.) =~ to = (and vice-versa).
-    // indeed, in such cases, we know if the input should be blurred only after selecting a
-    // suggestion, when the select is already rendered.
-    blurInput();
-  }
-
-  isVisibleRef.current = suggestions.isVisible;
+  useEffect(() => {
+    if (!suggestions.isVisible && previousSuggestionsIsVisible) {
+      // ensures that the input is blurred when a filter has been completed.
+      // we could have used blurInputOnSelect but this allows us to handle properly the case of
+      // editing a complete filter operator from (e.g.) =~ to = (and vice-versa).
+      // indeed, in such cases, we know if the input should be blurred only after selecting a
+      // suggestion, when the select is already rendered.
+      blurInput();
+    }
+  }, [suggestions.isVisible, previousSuggestionsIsVisible, blurInput]);
 
   return {
     onFocus,

--- a/src/shared/components/QueryBuilder/ui/hooks.ts
+++ b/src/shared/components/QueryBuilder/ui/hooks.ts
@@ -1,0 +1,15 @@
+/**
+ * This is the same use react-use: usePrevious()
+ * If more react-use like hooks are needed, we can consider adding react-use as a dependency
+ */
+import { useEffect, useRef } from 'react';
+
+export function usePrevious<T>(state: T): T | undefined {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = state;
+  });
+
+  return ref.current;
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

N/A

### 📖 Summary of the changes

Fixes a warning thrown after selecting a filter:

```
Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
```

https://github.com/user-attachments/assets/b63a5cc9-67e4-42d7-a625-2806995bac22

We're calling blur() during the rendering which in this case should not lead to any nasty errors, but still it's a side effect so it's a bit cleaner if done after rendering finishes.

## Technical details

I've added `usePrevious` which is the same as the one coming with react-use. We can also consider adding react-use as a dependency if we take advantage of other hooks as well.

### 🧪 How to test?

* Add a quick filter 
* The error should not show up in the dev console