### PR TITLE
chore: Upgrade @playwright/test to 1.47.0

### DIFF
--- a/Dockerfile.plugin.e2e
+++ b/Dockerfile.plugin.e2e
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/playwright:v1.47.0
 WORKDIR /app
 
 # required by the e2e test code
-RUN yarn add "@playwright/test@^1.47.0" "dotenv@^16.3.1"
+RUN yarn add "@playwright/test@~1.47.0" "dotenv@^16.3.1"
 
 ENV E2E_BASE_URL="http://localhost:3000"
 

--- a/Dockerfile.plugin.e2e
+++ b/Dockerfile.plugin.e2e
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/playwright:v1.46.0
+FROM mcr.microsoft.com/playwright:v1.47.0
 
 WORKDIR /app
 
 # required by the e2e test code
-RUN yarn add "@playwright/test@^1.46.0" "dotenv@^16.3.1"
+RUN yarn add "@playwright/test@^1.47.0" "dotenv@^16.3.1"
 
 ENV E2E_BASE_URL="http://localhost:3000"
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -99,6 +99,6 @@ In build time (PR and main branch), we run a [Pyroscope server with static data]
 
 ### The build of my PR has failed because Playwright was just updated, how to fix it?
 
-- In a terminal: `yarn upgrade @playwright/test --latest`
+- In a terminal: `yarn up @playwright/test`
 - Open `Dockerfile.plugin.e2e` and upgrade Playwright versions to the latest one
 - Open a PR to verify that the E2E are passing in the build

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@grafana/e2e-selectors": "^10.0.0",
     "@grafana/eslint-config": "^7.0.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@playwright/test": "~1.47.0",
+    "@playwright/test": "^1.47.0",
     "@swc/core": "^1.3.51",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.23",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@grafana/e2e-selectors": "^10.0.0",
     "@grafana/eslint-config": "^7.0.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@playwright/test": "1.47.0",
+    "@playwright/test": "~1.47.0",
     "@swc/core": "^1.3.51",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.23",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@grafana/e2e-selectors": "^10.0.0",
     "@grafana/eslint-config": "^7.0.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@playwright/test": "^1.46.0",
+    "@playwright/test": "1.47.0",
     "@swc/core": "^1.3.51",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,14 +2195,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.46.0":
-  version: 1.46.0
-  resolution: "@playwright/test@npm:1.46.0"
+"@playwright/test@npm:1.47.0":
+  version: 1.47.0
+  resolution: "@playwright/test@npm:1.47.0"
   dependencies:
-    playwright: "npm:1.46.0"
+    playwright: "npm:1.47.0"
   bin:
     playwright: cli.js
-  checksum: 10/710bf451555e67476bf6e911a07ec0e011474f769a10f8073b3b22fe9b81086a83b6821da354900a6d6d14d60e4320b2c9f7249cc5480e3923de56a8501b7ffe
+  checksum: 10/8c1e4386f19edb347323092708700ef46e9cddc82290df1e78120ce686cfd7d18bf15c184d2fad0ea099d7e2e57e7b75ad05d5c3398324657361c46efda8d98c
   languageName: node
   linkType: hard
 
@@ -10229,27 +10229,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.46.0":
-  version: 1.46.0
-  resolution: "playwright-core@npm:1.46.0"
+"playwright-core@npm:1.47.0":
+  version: 1.47.0
+  resolution: "playwright-core@npm:1.47.0"
   bin:
     playwright-core: cli.js
-  checksum: 10/1fd237d01380be0d650ae7df73fb796eae9c208e0746bb110db270139f1d2a96bf3b8856c394a48720b30e145614a10f275ab08627d0c95ba2160dc0402a90cb
+  checksum: 10/181ddf5c29275fc0cfdda223c22cbfc7a74433e1e3aded96c9fb994f7fe98232c035e789986a62201d0c384b2966f1165f212f4f88eec6885ad56c04526c922c
   languageName: node
   linkType: hard
 
-"playwright@npm:1.46.0":
-  version: 1.46.0
-  resolution: "playwright@npm:1.46.0"
+"playwright@npm:1.47.0":
+  version: 1.47.0
+  resolution: "playwright@npm:1.47.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.46.0"
+    playwright-core: "npm:1.47.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/e06f3b53faaf4edf4fcf636b43004dd0db1e45dbdcb2b59037a9810dfce3a59f0386d4826ba7de42f98fe525539fa20dd8f8c46acd1f8e5c57dcb5c1d8d536ce
+  checksum: 10/6051889d33c879847e471633453adeb741ca0542f236b3fabbb64e7ec3f17f1655f879099140e0b01a978d94caa8205b3c9437622e9953d56f5447e4ae85885d
   languageName: node
   linkType: hard
 
@@ -10529,7 +10529,7 @@ __metadata:
     "@grafana/schema": "npm:^10.4.1"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
     "@grafana/ui": "npm:10.4.3"
-    "@playwright/test": "npm:^1.46.0"
+    "@playwright/test": "npm:1.47.0"
     "@react-hook/resize-observer": "npm:^1.2.6"
     "@swc/core": "npm:^1.3.51"
     "@swc/helpers": "npm:^0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,7 +2195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.47.0":
+"@playwright/test@npm:~1.47.0":
   version: 1.47.0
   resolution: "@playwright/test@npm:1.47.0"
   dependencies:
@@ -10529,7 +10529,7 @@ __metadata:
     "@grafana/schema": "npm:^10.4.1"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
     "@grafana/ui": "npm:10.4.3"
-    "@playwright/test": "npm:1.47.0"
+    "@playwright/test": "npm:~1.47.0"
     "@react-hook/resize-observer": "npm:^1.2.6"
     "@swc/core": "npm:^1.3.51"
     "@swc/helpers": "npm:^0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,7 +2195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:~1.47.0":
+"@playwright/test@npm:^1.47.0":
   version: 1.47.0
   resolution: "@playwright/test@npm:1.47.0"
   dependencies:
@@ -10529,7 +10529,7 @@ __metadata:
     "@grafana/schema": "npm:^10.4.1"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
     "@grafana/ui": "npm:10.4.3"
-    "@playwright/test": "npm:~1.47.0"
+    "@playwright/test": "npm:^1.47.0"
     "@react-hook/resize-observer": "npm:^1.2.6"
     "@swc/core": "npm:^1.3.51"
     "@swc/helpers": "npm:^0.5.0"


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

It seems that recent version of @playwright/test ([1.47.0](https://github.com/microsoft/playwright/releases/tag/v1.47.0)) modified where binaries are stored and we end up in version mismatch in [Dockerfile.plugin.e2e](https://github.com/grafana/explore-profiles/blob/daaef03086af712bde9e9d085323b83017f87e96/Dockerfile.plugin.e2e)

```
# (!!!) fixed v1.46.0 image is installed
FROM mcr.microsoft.com/playwright:v1.46.0

# ....

# (!!!) latest 1.47.0 ppm is installed here (^1.46.0)
RUN yarn add "@playwright/test@^1.46.0" "dotenv@^16.3.1"

```

This causes e2e tests to fail ([example](https://github.com/grafana/explore-profiles/actions/runs/10737014796/job/29777704251?pr=153))

```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1134/chrome-linux/chrome
```

![Screenshot 2024-09-06 at 13 24 27](https://github.com/user-attachments/assets/fcc7ccfa-cb9d-4a34-b921-c780433307fd)

Also, based on latest release https://github.com/microsoft/playwright/releases/tag/v1.47.0:

> The :latest tag for Playwright Docker images is no longer being published. Pin to a specific version for better stability and reproducibility.

So I changed the code to use latest patch instead of latest minor.


### 📖 Summary of the changes

<!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->

### 🧪 How to test?

Running e2e tests locally and on CI should pass
