### PR TITLE
fix(Labels): Fix error with bar gauges viz and new Grafana version

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesBarGauge.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesBarGauge.tsx
@@ -100,9 +100,9 @@ export class SceneLabelValuesBarGauge extends SceneObjectBase<SceneLabelValuesBa
         namePlacement: BarGaugeNamePlacement.Top,
         minVizHeight: 36,
         maxVizHeight: 36,
-        // namePlacement: BarGaugeNamePlacement.Left,
-        // minVizHeight: 20,
-        // maxVizHeight: 20,
+        legend: {
+          showLegend: false,
+        },
       },
       fieldConfig: {
         defaults: {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR to prevent an error to occur on the "Labels" view after selecting the "Totals"  panel type:

<img width="858" alt="image" src="https://github.com/user-attachments/assets/f4c329a6-58cc-443d-9007-eca0d7dd73f9">

<img width="512" alt="image" src="https://github.com/user-attachments/assets/631c7753-a8f6-4304-a24d-25022d5bd63b">

### 📖 Summary of the changes

The cause of the error is due to the new Grafana version (v11.3.0-75623), which requires the `legend` option to be set, as we can see in the stack trace:

<img width="489" alt="image" src="https://github.com/user-attachments/assets/c497d910-d480-4a0a-80b0-4207e68c3ea9">

### 🧪 How to test?

- Locally, with the Grafana v11.3.0-75623
