### PR TITLE
fix(ExplainFlameGraph): Add tooltip when the LLM plugin is not installed

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/AIButton.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/AIButton.tsx
@@ -20,12 +20,12 @@ export function AIButton({ children, onClick, disabled, interactionName }: AIBut
   let icon: IconName = 'ai';
   let title = '';
 
-  if (error) {
-    icon = 'shield-exclamation';
-    title = 'Grafana LLM plugin missing or not configured!';
-  } else if (isFetching) {
+  if (isFetching) {
     icon = 'fa fa-spinner';
     title = 'Checking the status of the Grafana LLM plugin...';
+  } else if (!isEnabled || error) {
+    icon = 'shield-exclamation';
+    title = 'Grafana LLM plugin missing or not configured!';
   }
 
   return (
@@ -34,8 +34,9 @@ export function AIButton({ children, onClick, disabled, interactionName }: AIBut
       size="md"
       fill="text"
       icon={icon}
-      title={isEnabled ? 'Ask FlameGrot AI' : title}
       disabled={!isEnabled || disabled}
+      tooltip={title}
+      tooltipPlacement="top"
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
         reportInteraction(interactionName);
         onClick(event);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just a quick fix to display the tooltip when the [Grafana LLM plugin](https://github.com/grafana/grafana-llm-app) is not installed: 

![image](https://github.com/user-attachments/assets/1b9887e7-d2d1-4513-8bd2-03e15ddfe91e)

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

Locally, for instance by commenting https://github.com/grafana/explore-profiles/blob/main/samples/provisioning-remote/plugins/app.yaml#L12-L30 and launching `yarn server:remote`
