### PR TITLE
fix(LabelsDataSource): Limit the maximum number of concurrent requets when fetching label values

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "file-saver": "^2.0.5",
     "markdown-to-jsx": "^7.3.2",
     "nanoid": "^4.0.2",
+    "p-limit": "^6.1.0",
     "protobufjs": "^7.2.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9998,6 +9998,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "p-limit@npm:6.1.0"
+  dependencies:
+    yocto-queue: "npm:^1.1.1"
+  checksum: 10/9670cb4426d77c20a477cad0e44e8207248381135650f5b9bfe039c9d93566cd4b05cfc557fe60f2db88c799991c7edc6be436255d287a87a605ee604a71cd91
+  languageName: node
+  linkType: hard
+
 "p-locate@npm:^4.1.0":
   version: 4.1.0
   resolution: "p-locate@npm:4.1.0"
@@ -10581,6 +10590,7 @@ __metadata:
     lint-staged: "npm:^15.0.2"
     markdown-to-jsx: "npm:^7.3.2"
     nanoid: "npm:^4.0.2"
+    p-limit: "npm:^6.1.0"
     prettier: "npm:^2.5.0"
     prettier-package-json: "npm:^2.8.0"
     protobufjs: "npm:^7.2.6"
@@ -14051,6 +14061,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10/f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "yocto-queue@npm:1.1.1"
+  checksum: 10/f2e05b767ed3141e6372a80af9caa4715d60969227f38b1a4370d60bffe153c9c5b33a862905609afc9b375ec57cd40999810d20e5e10229a204e8bde7ef255c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR tries to mitigate a performance issue that arises on the "Labels" view when many labels have high cardinality issues.

Indeed, prior to this PR, we would just naively fetch all the label values with `Promise.all()`.

We now rely on [p-limit](https://github.com/sindresorhus/p-limit) to control the maximum number of concurrent requests to the backend API.

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

Empirically, by checking the browser's "Network" tab and seeing that the number of concurrent requests is limited to 20 (this number can be tweaked with experience, if needed).
