### PR TITLE
docs(*): Fix issues in Explore Profiles docs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -2,6 +2,9 @@
 cascade:
   FULL_PRODUCT_NAME: Grafana Explore Profiles
   PRODUCT_NAME: Explore Profiles
+  _build:
+    list: false
+  noindex: true
 canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/profiles/
 description: Learn how to use Explore Profiles to understand and troubleshoot
   your applications and services.

--- a/docs/sources/get-started/index.md
+++ b/docs/sources/get-started/index.md
@@ -11,7 +11,7 @@ weight: 300
 
 # Get started with Explore Profiles
 
-{{< docs/public-preview product="public-preview-feature" >}}
+{{< docs/public-preview product="Explore Profiles" >}}
 
 Profiles can help you identify errors in your apps and services.
 Using this information, you can optimize and streamline your apps.


### PR DESCRIPTION
### ✨ Description

Hides the Explore Profiles doc again until next week. Corrects the product name in a public preview amonition. 


