### PR TITLE
fix(DiffFlameGraph): Remove non-working pprof export

### DIFF
--- a/src/shared/components/FlameGraph/components/ExportMenu.tsx
+++ b/src/shared/components/FlameGraph/components/ExportMenu.tsx
@@ -11,7 +11,7 @@ export function ExportMenu(props: ExportDataProps) {
     <Menu>
       <Menu.Item label="png" onClick={actions.downloadPng} />
       <Menu.Item label="json" onClick={actions.downloadJson} />
-      <Menu.Item label="pprof" onClick={actions.downloadPprof} />
+      {/* no pprof export, as the underlying API only accepts a single query (see PprofApiClient) */}
       {data.shouldDisplayFlamegraphDotCom && (
         <Menu.Item label="flamegraph.com" onClick={actions.uploadToFlamegraphDotCom} />
       )}

--- a/src/shared/components/FlameGraph/components/domain/useExportMenu.ts
+++ b/src/shared/components/FlameGraph/components/domain/useExportMenu.ts
@@ -1,17 +1,15 @@
 import { reportInteraction } from '@grafana/runtime';
 import { displayError } from '@shared/domain/displayStatus';
-import { useQueryFromUrl } from '@shared/domain/url-params/useQueryFromUrl';
 import { useTimeRangeFromUrl } from '@shared/domain/url-params/useTimeRangeFromUrl';
 import 'compression-streams-polyfill';
 import saveAs from 'file-saver';
 
 import { ExportDataProps } from '../ExportData';
 import { flamegraphDotComApiClient } from '../infrastructure/flamegraphDotComApiClient';
-import { pprofApiClient } from '../infrastructure/pprofApiClient';
 import { getExportFilename } from './getExportFilename';
 
+/* Note: no pprof export, as the underlying API only accepts a single query (see PprofApiClient) */
 export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportDataProps) {
-  const [query] = useQueryFromUrl();
   const [timeRange] = useTimeRangeFromUrl();
 
   const downloadPng = () => {
@@ -44,26 +42,6 @@ export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportD
     saveAs(dataStr, filename);
   };
 
-  const downloadPprof = async function () {
-    reportInteraction('g_pyroscope_export_profile', { format: 'pprof' });
-
-    const customExportName = getExportFilename(timeRange, profile.metadata.appName);
-
-    let response;
-
-    try {
-      response = await pprofApiClient.selectMergeProfile(query, timeRange);
-    } catch (error) {
-      displayError(error, ['Failed to export to pprof!', (error as Error).message]);
-      return;
-    }
-
-    const filename = `${customExportName}.pb.gz`;
-    const data = await new Response(response.stream().pipeThrough(new CompressionStream('gzip'))).blob();
-
-    saveAs(data, filename);
-  };
-
   const uploadToFlamegraphDotCom = async () => {
     reportInteraction('g_pyroscope_export_profile', { format: 'flamegraph.com' });
 
@@ -93,7 +71,6 @@ export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportD
     actions: {
       downloadPng,
       downloadJson,
-      downloadPprof,
       uploadToFlamegraphDotCom,
     },
   };


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR fixes the error that occurs when trying to export a diff flame graph to pprof:

![image](https://github.com/user-attachments/assets/f7908e39-9d1b-4edf-82e0-9d32ca8aa3dc)

### 📖 Summary of the changes

The export relies on using the legacy `query` parameter to fetch the profile in pprof format. But:
- it's incorrect because the diff profile depends on both baseline & comparison queries
- the `query` parameter has been deprecated when migrating the plugin to Scenes

### 🧪 How to test?

The "pprof" export in the export menu should not be present anymore
