### PR TITLE
test(EndToEnd): Add new script to upgrade Playwright

### DIFF
--- a/Dockerfile.plugin.e2e
+++ b/Dockerfile.plugin.e2e
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/playwright:v1.47.0
+FROM mcr.microsoft.com/playwright:v1.47.1
 
 WORKDIR /app
 
 # required by the e2e test code
-RUN yarn add "@playwright/test@^1.47.0" "dotenv@^16.3.1"
+RUN yarn add "@playwright/test@^1.47.1" "dotenv@^16.3.1"
 
 ENV E2E_BASE_URL="http://localhost:3000"
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -99,6 +99,8 @@ In build time (PR and main branch), we run a [Pyroscope server with static data]
 
 ### The build of my PR has failed because Playwright was just updated, how to fix it?
 
-- In a terminal: `yarn up @playwright/test`
-- Open `Dockerfile.plugin.e2e` and upgrade Playwright versions to the latest one
-- Open a PR to verify that the E2E are passing in the build
+- Identify the current Playwright version, e.g. `1.46.0`
+- Identify the new Playwright version, e.g. `1.47.0`
+- In a terminal, execute: `./scripts/upgrade-playwright 1.46.0 1.47.0`
+- Launch the E2E tests locally with Docker to verify that the new version works: `yarn e2e:ci:server:up && yarn e2e:ci`
+- Push the modified files to the PR

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@grafana/e2e-selectors": "^10.0.0",
     "@grafana/eslint-config": "^7.0.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@playwright/test": "^1.47.0",
+    "@playwright/test": "^1.47.1",
     "@swc/core": "^1.3.51",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.23",

--- a/scripts/upgrade-playwright
+++ b/scripts/upgrade-playwright
@@ -1,0 +1,14 @@
+OLD_VERSION=$1
+NEW_VERSION=$2
+
+if [ -z "$OLD_VERSION" ] || [ -z "$NEW_VERSION" ]; then
+    echo "Error: Please provide both the old and new Playwright versions!"
+    echo "\nUsage: upgrade-playwright [old version number] [new version number]"
+    exit 1
+fi
+
+yarn up @playwright/test@^$NEW_VERSION 
+
+find Dockerfile.plugin.e2e -type f -exec sed -i "" "s/$OLD_VERSION/$NEW_VERSION/g" {} \;
+
+yarn e2e:ci:prepare

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,14 +2195,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.47.0":
-  version: 1.47.0
-  resolution: "@playwright/test@npm:1.47.0"
+"@playwright/test@npm:^1.47.1":
+  version: 1.47.1
+  resolution: "@playwright/test@npm:1.47.1"
   dependencies:
-    playwright: "npm:1.47.0"
+    playwright: "npm:1.47.1"
   bin:
     playwright: cli.js
-  checksum: 10/8c1e4386f19edb347323092708700ef46e9cddc82290df1e78120ce686cfd7d18bf15c184d2fad0ea099d7e2e57e7b75ad05d5c3398324657361c46efda8d98c
+  checksum: 10/d26656451cbd4cbb865c6acb25958a25171b3714907e1595301f21655b1be8f521dbd2197eecfa5b34325626c94b8ab535b8571478880633679e63ebfb6775b9
   languageName: node
   linkType: hard
 
@@ -10238,27 +10238,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.47.0":
-  version: 1.47.0
-  resolution: "playwright-core@npm:1.47.0"
+"playwright-core@npm:1.47.1":
+  version: 1.47.1
+  resolution: "playwright-core@npm:1.47.1"
   bin:
     playwright-core: cli.js
-  checksum: 10/181ddf5c29275fc0cfdda223c22cbfc7a74433e1e3aded96c9fb994f7fe98232c035e789986a62201d0c384b2966f1165f212f4f88eec6885ad56c04526c922c
+  checksum: 10/b5ee08e1a934237fca0f0f52a677e5d49e45578e14b48a886927428bdf453f355a120548ae2f3f97e28a9d5e23a213120f6d8f10e18ee3f9112b10716888dac4
   languageName: node
   linkType: hard
 
-"playwright@npm:1.47.0":
-  version: 1.47.0
-  resolution: "playwright@npm:1.47.0"
+"playwright@npm:1.47.1":
+  version: 1.47.1
+  resolution: "playwright@npm:1.47.1"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.47.0"
+    playwright-core: "npm:1.47.1"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/6051889d33c879847e471633453adeb741ca0542f236b3fabbb64e7ec3f17f1655f879099140e0b01a978d94caa8205b3c9437622e9953d56f5447e4ae85885d
+  checksum: 10/f4340f28485bd83a856a365a03af2013b3203c8134a075d05f1a834665e1204b98141c335d5c5c1600720c9e07db702db3dbff5ef138fc1c31d5feec3ac0057f
   languageName: node
   linkType: hard
 
@@ -10538,7 +10538,7 @@ __metadata:
     "@grafana/schema": "npm:^10.4.1"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
     "@grafana/ui": "npm:10.4.3"
-    "@playwright/test": "npm:^1.47.0"
+    "@playwright/test": "npm:^1.47.1"
     "@react-hook/resize-observer": "npm:^1.2.6"
     "@swc/core": "npm:^1.3.51"
     "@swc/helpers": "npm:^0.5.0"


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just a small PR to simplify Playwright's ugrades.

### 📖 Summary of the changes

This PR: 
- adds the new `upgrade-playwright` script
- uses it to upgrade Playwright to the latest version v1.47.1

### 🧪 How to test?

`-`
