### PR TITLE
docs(*): Make Explore Profiles docs public

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -2,9 +2,6 @@
 cascade:
   FULL_PRODUCT_NAME: Grafana Explore Profiles
   PRODUCT_NAME: Explore Profiles
-  _build:
-    list: false
-  noindex: true
 canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/profiles/
 description: Learn how to use Explore Profiles to understand and troubleshoot
   your applications and services.


### PR DESCRIPTION
### ✨ Description

Makes the docs public for the public preview launch. '

This PR should be merged when Explore Profiles goes live for customers. 

**Related issue(s):**

