### PR TITLE
docs: Update README.md to call out profiles as being in preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Explore Profiles is a native Grafana application designed to integrate seamlessly with [Pyroscope](https://github.com/grafana/pyroscope), the open-source continuous profiling platform, providing a smooth, query-less experience for browsing and analyzing profiling data.
 
+> \***\*NOTE:\*\*** Explore Profiles is presently undergoing active development and is offered in a preview state. Subsequent updates are likely to incorporate significant changes that may impact existing functionality.
+
 ## Install Explore Profiles
 
 Explore Profiles is distributed as a Grafana Plugin. You can find it in the official [Grafana Plugin Directory](https://grafana.com/grafana/plugins/grafana-pyroscope-app/).


### PR DESCRIPTION
This aligns with how we're going to message explore profiles at ObsCon, which is "in public preview for all grafana cloud and grafana open source users".
