### PR TITLE
docs: Update readme markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Explore Profiles is a native Grafana application designed to integrate seamlessly with [Pyroscope](https://github.com/grafana/pyroscope), the open-source continuous profiling platform, providing a smooth, query-less experience for browsing and analyzing profiling data.
 
-> \***\*NOTE:\*\*** Explore Profiles is presently undergoing active development and is offered in a preview state. Subsequent updates are likely to incorporate significant changes that may impact existing functionality.
+> [!IMPORTANT]
+> Explore Profiles is presently undergoing active development and is offered in a preview state. Subsequent updates are likely to incorporate significant changes that may impact existing functionality.
 
 ## Install Explore Profiles
 


### PR DESCRIPTION
Related https://github.com/grafana/explore-profiles/pull/182

This leverages a more stylized version of markdown admonition.

Options are:

## NOTE

<img width="1090" alt="Screenshot 2024-09-18 at 3 08 55 PM" src="https://github.com/user-attachments/assets/13128ec0-0423-4858-a9c5-00b6b4987c3b">

This is fine, but lacks emphasis.

## IMPORTANT

<img width="1090" alt="Screenshot 2024-09-18 at 3 09 03 PM" src="https://github.com/user-attachments/assets/dd6071be-9d90-4ab8-abc9-8c50462d8769">

Strikes a nice balance between emphasis but doesn't make it seem "dangerous".

## WARNING

<img width="1090" alt="Screenshot 2024-09-18 at 3 09 11 PM" src="https://github.com/user-attachments/assets/13304af9-cfd6-478c-94e7-3de5c034dbe9">

Technically the appropriate level according to GitHub's [recommendation](https://github.com/orgs/community/discussions/16925#discussion-4085374), but I think it suggests using Explore Profiles is "dangerous," which is strictly not true as it remains quite stable.


