### PR TITLE
refactor: Use relative URLs for API calls

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -26,6 +26,7 @@ import { History } from 'history';
 import React, { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 
+import { PLUGIN_BASE_URL } from '../../../../constants';
 import { SceneExploreAllServices } from '../../components/SceneExploreAllServices/SceneExploreAllServices';
 import { SceneExploreFavorites } from '../../components/SceneExploreFavorites/SceneExploreFavorites';
 import { SceneExploreServiceLabels } from '../../components/SceneExploreServiceLabels/SceneExploreServiceLabels';
@@ -368,9 +369,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
   onClickUserSettings(history: History) {
     reportInteraction('g_pyroscope_app_user_settings_clicked');
 
-    const settingsPathname = new URL(window.location.toString()).pathname.replace('/profiles-explorer', '/settings');
-
-    history.push(settingsPathname);
+    history.push(`${PLUGIN_BASE_URL}/settings`);
   }
 
   useProfilesExplorer = () => {

--- a/src/pages/ProfilesExplorerView/infrastructure/series/http/DataSourceProxyClient.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/http/DataSourceProxyClient.ts
@@ -7,8 +7,8 @@ export class DataSourceProxyClient extends HttpClient {
   constructor(options: { dataSourceUid: string }) {
     const { dataSourceUid } = options;
 
-    let { appSubUrl, bootData } = config;
-    if (appSubUrl.at(-1) !== '/') {
+    let { appSubUrl = '', bootData } = config;
+    if (appSubUrl?.at(-1) !== '/') {
       // ensures that the API pathname is appended correctly (appUrl seems to always have it but better to be extra careful)
       appSubUrl += '/';
     }

--- a/src/pages/ProfilesExplorerView/infrastructure/series/http/DataSourceProxyClient.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/http/DataSourceProxyClient.ts
@@ -7,15 +7,13 @@ export class DataSourceProxyClient extends HttpClient {
   constructor(options: { dataSourceUid: string }) {
     const { dataSourceUid } = options;
 
-    let { appUrl, bootData } = config;
-    if (appUrl.at(-1) !== '/') {
+    let { appSubUrl, bootData } = config;
+    if (appSubUrl.at(-1) !== '/') {
       // ensures that the API pathname is appended correctly (appUrl seems to always have it but better to be extra careful)
-      appUrl += '/';
+      appSubUrl += '/';
     }
 
-    const apiBaseUrl = new URL(`api/datasources/proxy/uid/${dataSourceUid}`, appUrl);
-
-    super(apiBaseUrl.toString(), {
+    super(`${appSubUrl}api/datasources/proxy/uid/${dataSourceUid}`, {
       'content-type': 'application/json',
       'X-Grafana-Org-Id': String(bootData?.user?.orgId || ''),
     });

--- a/src/shared/infrastructure/http/ApiClient.ts
+++ b/src/shared/infrastructure/http/ApiClient.ts
@@ -47,13 +47,13 @@ export class ApiClient extends HttpClient {
   static getBaseUrl() {
     const pyroscopeDataSource = ApiClient.selectDefaultDataSource();
 
-    let appUrl = config.appUrl;
-    if (appUrl.at(-1) !== '/') {
+    let appSubUrl = config.appSubUrl;
+    if (appSubUrl.at(-1) !== '/') {
       // ensures that the API pathname is appended correctly (appUrl seems to always have it but better to be extra careful)
-      appUrl += '/';
+      appSubUrl += '/';
     }
 
-    return new URL(`api/datasources/proxy/uid/${pyroscopeDataSource.uid}`, appUrl);
+    return `${appSubUrl}api/datasources/proxy/uid/${pyroscopeDataSource.uid}`;
   }
 
   constructor() {

--- a/src/shared/infrastructure/http/ApiClient.ts
+++ b/src/shared/infrastructure/http/ApiClient.ts
@@ -47,7 +47,7 @@ export class ApiClient extends HttpClient {
   static getBaseUrl() {
     const pyroscopeDataSource = ApiClient.selectDefaultDataSource();
 
-    let appSubUrl = config.appSubUrl;
+    let appSubUrl = config.appSubUrl || '';
     if (appSubUrl.at(-1) !== '/') {
       // ensures that the API pathname is appended correctly (appUrl seems to always have it but better to be extra careful)
       appSubUrl += '/';

--- a/src/shared/infrastructure/http/__tests__/ApiClient.spec.ts
+++ b/src/shared/infrastructure/http/__tests__/ApiClient.spec.ts
@@ -9,10 +9,14 @@ const TEST_DATA_SOURCES = {
   },
 };
 
-function setupMocks(options?: { appUrl?: string; bootData?: Record<string, any>; dataSources?: Record<string, any> }) {
+function setupMocks(options?: {
+  appSubUrl?: string;
+  bootData?: Record<string, any>;
+  dataSources?: Record<string, any>;
+}) {
   jest.doMock('@grafana/runtime', () => ({
     config: {
-      appUrl: options?.appUrl || 'https://localhost:3000/',
+      appSubUrl: options?.appSubUrl,
       bootData: options?.bootData,
       datasources: {
         ...TEST_DATA_SOURCES,
@@ -62,24 +66,15 @@ describe('ApiClient', () => {
     });
 
     describe.each([
-      ['https://localhost:3000/', 'https://localhost:3000/api/datasources/proxy/uid/grafanacloud-profiles-test'],
-      [
-        'https://firedev001.grafana-dev.net/',
-        'https://firedev001.grafana-dev.net/api/datasources/proxy/uid/grafanacloud-profiles-test',
-      ],
+      ['/', '/api/datasources/proxy/uid/grafanacloud-profiles-test'],
+      ['', '/api/datasources/proxy/uid/grafanacloud-profiles-test'],
       // app URL with pathname
-      [
-        'https://admin-dev-us-central-0.grafana-dev.net/stable-grafana/',
-        'https://admin-dev-us-central-0.grafana-dev.net/stable-grafana/api/datasources/proxy/uid/grafanacloud-profiles-test',
-      ],
+      ['/stable-grafana/', '/stable-grafana/api/datasources/proxy/uid/grafanacloud-profiles-test'],
       // app URL with no slash at the end
-      [
-        'https://admin-dev-us-central-0.grafana-dev.net/stable-grafana',
-        'https://admin-dev-us-central-0.grafana-dev.net/stable-grafana/api/datasources/proxy/uid/grafanacloud-profiles-test',
-      ],
-    ])('when the app URL provided by the platform is "%s"', (appUrl, expectedApiBaseUrl) => {
+      ['/stable-grafana', '/stable-grafana/api/datasources/proxy/uid/grafanacloud-profiles-test'],
+    ])('when the app URL provided by the platform is "%s"', (appSubUrl, expectedApiBaseUrl) => {
       test(`the API base URL is "${expectedApiBaseUrl}"`, () => {
-        setupMocks({ appUrl });
+        setupMocks({ appSubUrl });
 
         const { ApiClient } = require('../ApiClient');
 
@@ -111,9 +106,7 @@ describe('ApiClient', () => {
 
           const apiClient = new ApiClient();
 
-          expect(apiClient.baseUrl).toBe(
-            'https://localhost:3000/api/datasources/proxy/uid/grafanacloud-profiles-test-bis'
-          );
+          expect(apiClient.baseUrl).toBe('/api/datasources/proxy/uid/grafanacloud-profiles-test-bis');
         });
       });
     });
@@ -151,9 +144,7 @@ describe('ApiClient', () => {
 
           const apiClient = new ApiClient();
 
-          expect(apiClient.baseUrl).toBe(
-            'https://localhost:3000/api/datasources/proxy/uid/grafanacloud-profiles-test-local-storage'
-          );
+          expect(apiClient.baseUrl).toBe('/api/datasources/proxy/uid/grafanacloud-profiles-test-local-storage');
         });
       });
 
@@ -186,9 +177,7 @@ describe('ApiClient', () => {
 
           const apiClient = new ApiClient();
 
-          expect(apiClient.baseUrl).toBe(
-            'https://localhost:3000/api/datasources/proxy/uid/grafanacloud-profiles-test-ter'
-          );
+          expect(apiClient.baseUrl).toBe('/api/datasources/proxy/uid/grafanacloud-profiles-test-ter');
         });
       });
 
@@ -213,7 +202,7 @@ describe('ApiClient', () => {
 
           const apiClient = new ApiClient();
 
-          expect(apiClient.baseUrl).toBe('https://localhost:3000/api/datasources/proxy/uid/grafanacloud-profiles-test');
+          expect(apiClient.baseUrl).toBe('/api/datasources/proxy/uid/grafanacloud-profiles-test');
         });
       });
 
@@ -246,7 +235,7 @@ describe('ApiClient', () => {
 
           const apiClient = new ApiClient();
 
-          expect(apiClient.baseUrl).toBe('https://localhost:3000/api/datasources/proxy/uid/grafanacloud-profiles-test');
+          expect(apiClient.baseUrl).toBe('/api/datasources/proxy/uid/grafanacloud-profiles-test');
         });
       });
     });


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

Fixes #188 

### 📖 Summary of the changes

Using relative paths to Grafana API instead of pulling it directly from the config

### 🧪 How to test?

See #188 for more details.
