### PR TITLE
docs: Add flame graph AI and intro video to doc

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -50,22 +50,20 @@ cards:
 
 # Explore Profiles
 
+{{< docs/public-preview product="Explore Profiles" >}}
+
 Profiling is a technique used in software development to measure and analyze the runtime behavior of a program.
 By profiling a program, developers can identify which parts of the program consume the most resources, such as CPU time, memory, or I/O operations.
 You can use this information to optimize the program, making it run faster or use fewer resources.
 
 Explore Profiles provides an intuitive interface for exploring your profile data.
-This design lets you navigate the UI and drill down into which labels are most interesting to you.
-This app helps you start at the highest level possible and drill down into a specific root cause analysis.
-You don’t know what’s wrong, but you should be able to find it by drilling down.
-
 Using Explore Profiles, you can:
 
 - View high-level service performance: Get a high-level view of all of your services and how they're functioning
 - Optimize processes: Identify processes or services that you can optimize for better performance
 - Diagnose issues: Determine the root cause of an issue
 
-{{< docs/public-preview product="Explore Profiles" >}}
+{{< youtube id="x9aPw_CbIQc" >}}
 
 ## Explore
 

--- a/docs/sources/choose-a-view/index.md
+++ b/docs/sources/choose-a-view/index.md
@@ -159,6 +159,11 @@ This feature is crucial for identifying performance anomalies and understanding 
 
 The Flame graph view visualizes profiling data of a single service in a flame graph format, allowing easy identification of resource-intensive functions.
 
+On views with a flame graph, you can use **Explain flame graph** to provide an AI flame graph analysis that explains the performance bottleneck, root cause, and recommended fixes.
+For more information, refer to [Flame graph AI](https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/flamegraph-ai/).
+
+You can also use line-level insights from the [GitHub integration](https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/pyroscope-github-integration/).
+
 ![Flame graphs](../images/explore-profiles-flamegraph-2.png)
 
 ### Diff flame graph


### PR DESCRIPTION
### ✨ Description
Adds information about flame graph AI and the GitHub integration doc links to the Concepts page
Adds the intro video to the landing page

**Related issue(s):**

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

<!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->

### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
