### PR TITLE
fix(QueryBuilder): Filters with regex values can be edited in place

### DIFF
--- a/src/shared/components/QueryBuilder/domain/helpers/__tests__/queryToFilters.spec.ts
+++ b/src/shared/components/QueryBuilder/domain/helpers/__tests__/queryToFilters.spec.ts
@@ -79,6 +79,28 @@ const cases: TestCase[] = [
       },
     ],
   ],
+  [
+    ' process_cpu:cpu:nanoseconds:cpu:nanoseconds{service_name="core-requests",free_text=~"one,two"}',
+    [
+      {
+        id: expect.any(String),
+        type: FilterKind['attribute-operator-value'],
+        active: true,
+        attribute: {
+          label: 'free_text',
+          value: 'free_text',
+        },
+        operator: {
+          label: '=~',
+          value: '=~',
+        },
+        value: {
+          label: 'one,two',
+          value: 'one,two',
+        },
+      },
+    ],
+  ],
   // TODO: uncomment when we'll support the "in" operator
   // [
   //   'process_cpu:wall:nanoseconds:wall:nanoseconds{service_name="core-requests",action="count",pod_id=~"83|84"}',

--- a/src/shared/components/QueryBuilder/domain/helpers/queryToFilters.ts
+++ b/src/shared/components/QueryBuilder/domain/helpers/queryToFilters.ts
@@ -2,11 +2,10 @@ import { nanoid } from 'nanoid';
 
 import { FilterKind, Filters, OperatorKind } from '../types';
 
-export const parseRawFilters = (rawFilters: string) =>
-  rawFilters.split(',').map((f) => {
-    const parts = f.match(/\W*([^=!~]+)(=|!=|=~|!~)"(.*)"/);
-    return parts === null ? null : [parts[1], parts[2], parts[3]];
-  });
+export const parseRawFilters = (rawFilters: string): string[][] => {
+  const matches = rawFilters.matchAll(/(\w+)(=|!=|=~|!~)"([^"]*)"/g);
+  return Array.from(matches).map(([, attribute, operator, value]) => [attribute, operator, value]);
+};
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export function queryToFilters(query: string): Filters {
@@ -23,11 +22,7 @@ export function queryToFilters(query: string): Filters {
 
   const rawFilters = parseRawFilters(rawLabels[1]);
 
-  // [[_, service_name, =, ebpf/gcp-logs-ops/grafana-agent] [_, namespace, =, gcp-logs-ops]] or [null, null]
-  if (rawFilters.some((m) => m === null)) {
-    // let's be strict on parsing
-    return [];
-  }
+  // [[service_name, =, ebpf/gcp-logs-ops/grafana-agent], [namespace, =, gcp-logs-ops]]
 
   return (rawFilters as string[][])
     .filter(([attribute]) => attribute !== 'service_name')

--- a/src/shared/components/QueryBuilder/domain/states/loadLabelValues.ts
+++ b/src/shared/components/QueryBuilder/domain/states/loadLabelValues.ts
@@ -21,8 +21,11 @@ export const loadLabelValues: StateNodeConfig<
 
       return {
         ...defaultContext.suggestions,
-        // See https://github.com/grafana/pyroscope-app-plugin/issues/335
-        disabled: isPrivateLabel(targetFilter!.attribute!.value),
+        disabled:
+          // don't fetch for these operators, an input will appear in the UI instead of a select
+          ['=~', '!~'].includes(targetFilter!.operator!.value) ||
+          // See https://github.com/grafana/pyroscope-app-plugin/issues/335
+          isPrivateLabel(targetFilter!.attribute!.value),
         isVisible: true,
         isLoading: true,
       };

--- a/src/shared/components/QueryBuilder/domain/types.ts
+++ b/src/shared/components/QueryBuilder/domain/types.ts
@@ -48,6 +48,7 @@ export enum FilterPartKind {
 export type Suggestion = {
   value: string;
   label: string;
+  description?: string;
 };
 
 export type Suggestions = Suggestion[];

--- a/src/shared/components/QueryBuilder/infrastructure/operatorsRepository.ts
+++ b/src/shared/components/QueryBuilder/infrastructure/operatorsRepository.ts
@@ -3,10 +3,10 @@ import { Suggestions } from '../domain/types';
 class OperatorsRepository {
   async list(): Promise<Suggestions> {
     return [
-      { value: '=', label: '=' },
-      { value: '!=', label: '!=' },
-      { value: '=~', label: '=~' },
-      { value: '!~', label: '!~' },
+      { value: '=', label: '=', description: 'Equals' },
+      { value: '!=', label: '!=', description: 'Not equal' },
+      { value: '=~', label: '=~', description: 'Matches regex' },
+      { value: '!~', label: '!~', description: 'Does not match regex' },
       { value: 'is-empty', label: 'is empty' },
       // TODO: enable after exhaustive testing
       // { value: 'in', label: 'in' },

--- a/src/shared/components/QueryBuilder/ui/constants.ts
+++ b/src/shared/components/QueryBuilder/ui/constants.ts
@@ -1,10 +1,10 @@
 export const MESSAGES = {
-  FILTER_ADD: 'Add a filter...',
+  FILTER_ADD: 'Filter by label values...',
   SELECT_LABEL: 'Select a label...',
   SELECT_OPERATOR: 'Select an operator...',
   SELECT_VALUE: 'Select a value...',
   SELECT_VALUES: 'Select values...',
-  TYPE_VALUE: 'Type a value...',
+  TYPE_VALUE: 'Type a regex...',
   LOADING: 'Loading...',
   ERROR_LOAD: 'An unexpected error occurred while loading! Please try again.',
   SUGGESTIONS_NONE: 'No suggestions available.',

--- a/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
+++ b/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
@@ -33,7 +33,7 @@ export function SingleEditionInput({ placeholder, defaultValue, onFocus, onChang
     }
   });
 
-  // we have to implement a customized version of the input because the <Input /> from the Sage Design system does not
+  // we have to implement a customized version of the input because the <Input /> from the Saga Design system does not
   // allow any `ref` prop to be passed
   return (
     <div className={cx(styles.wrapper, defaultValue && styles.wrapperForEdition)}>

--- a/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
+++ b/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
@@ -33,6 +33,8 @@ export function SingleEditionInput({ placeholder, defaultValue, onFocus, onChang
     }
   });
 
+  // we have to implement a customized version of the input because the <Input /> from the Sage Design system does not
+  // allow any `ref` prop to be passed
   return (
     <div className={cx(styles.wrapper, defaultValue && styles.wrapperForEdition)}>
       <div className={styles.inputWrapper}>

--- a/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
+++ b/src/shared/components/QueryBuilder/ui/inputs/SingleEditionInput.tsx
@@ -1,0 +1,102 @@
+import { css, cx } from '@emotion/css';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+import React, { useEffect, useRef } from 'react';
+
+type SingleEditionInputProps = {
+  placeholder: string;
+  onChange: (suggestion: SelectableValue<string>) => void;
+  ref?: React.Ref<HTMLInputElement>;
+  defaultValue?: string;
+  onFocus?: () => void;
+};
+
+export function SingleEditionInput({ placeholder, defaultValue, onFocus, onChange }: SingleEditionInputProps) {
+  const styles = useStyles2(getStyles);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.code === 'Enter') {
+      const value = (e.target as HTMLInputElement).value.trim();
+      onChange({ value, label: value });
+    }
+  };
+
+  const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const value = (e.target as HTMLInputElement).value.trim();
+    onChange({ value, label: value });
+  };
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  });
+
+  return (
+    <div className={cx(styles.wrapper, defaultValue && styles.wrapperForEdition)}>
+      <div className={styles.inputWrapper}>
+        <input
+          ref={inputRef}
+          className={styles.input}
+          placeholder={placeholder}
+          defaultValue={defaultValue}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
+          onBlur={onBlur}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css`
+    display: flex;
+    width: 100%;
+    height: ${theme.spacing(theme.components.height.md)};
+    border-radius: ${theme.shape.radius.default};
+
+    position: relative;
+    left: -4px;
+    border-left: 0;
+  `,
+  wrapperForEdition: css`
+    position: absolute;
+    left: 0;
+  `,
+  inputWrapper: css`
+    position: relative;
+    flex-grow: 1;
+    z-index: 1;
+  `,
+  input: css`
+    position: relative;
+    z-index: 0;
+    flex-grow: 1;
+    width: 100%;
+    height: 100%;
+    line-height: ${theme.typography.body.lineHeight};
+    border: 1px solid ${theme.components.input.borderColor};
+    border-radius: ${theme.shape.radius.default};
+    padding: ${theme.spacing(0, 1, 0, 1)};
+
+    &:hover {
+      border-color: ${theme.components.input.borderHover};
+    }
+
+    &:focus {
+      outline: 2px dotted transparent;
+      outline-offset: 2px;
+      box-shadow: 0 0 0 2px ${theme.colors.background.canvas}, 0 0 0px 4px ${theme.colors.primary.main};
+      transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1);
+      transition-duration: 0.2s;
+      transition-property: outline, outline-offset, box-shadow;
+    }
+
+    &::placeholder {
+      color: ${theme.colors.text.disabled};
+      opacity: 1;
+    }
+  `,
+});

--- a/src/shared/components/QueryBuilder/ui/selects/SingleEditionSelect.tsx
+++ b/src/shared/components/QueryBuilder/ui/selects/SingleEditionSelect.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { Suggestion } from '../../domain/types';
 import { MESSAGES } from '../constants';
+import { SingleEditionInput } from '../inputs/SingleEditionInput';
 
 export const getStyles = () => ({
   editionSelect: css`
@@ -12,6 +13,7 @@ export const getStyles = () => ({
     z-index: 1;
     min-width: 160px;
     box-shadow: none;
+
     & input:focus {
       outline: none !important;
     }
@@ -27,6 +29,12 @@ export type EditionSelectProps = {
 
 export function SingleEditionSelect({ selection, suggestions, onChange, onCloseMenu }: EditionSelectProps) {
   const styles = useStyles2(getStyles);
+
+  if (suggestions.allowCustomValue) {
+    return (
+      <SingleEditionInput defaultValue={selection.value} placeholder={suggestions.placeholder} onChange={onChange} />
+    );
+  }
 
   return (
     <Select

--- a/src/shared/components/QueryBuilder/ui/selects/SingleSelect.tsx
+++ b/src/shared/components/QueryBuilder/ui/selects/SingleSelect.tsx
@@ -4,6 +4,7 @@ import { Select, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { MESSAGES } from '../constants';
+import { SingleEditionInput } from '../inputs/SingleEditionInput';
 
 export const getStyles = () => ({
   select: css`
@@ -22,6 +23,10 @@ type SingleSelectProps = {
 
 export function SingleSelect({ suggestions, onFocus, onChange, onKeyDown, onCloseMenu }: SingleSelectProps) {
   const styles = useStyles2(getStyles);
+
+  if (suggestions.allowCustomValue) {
+    return <SingleEditionInput placeholder={suggestions.placeholder} onFocus={onFocus} onChange={onChange} />;
+  }
 
   return (
     <Select


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** solves https://github.com/grafana/explore-profiles/issues/206, relates to https://github.com/grafana/grafana/issues/93664

The issue stems from the fact that the `Select` component from the [Saga design system](https://developers.grafana.com/ui/canary/index.html?path=/story/forms-select--basic) does not initialize its input with the value passed as prop. 

### 📖 Summary of the changes

To circumvent the problem, this PR replaces the `Select` component by an HTML `input`. 

See the diff tab for specific comments.

### 🧪 How to test?

Manually, by checking this PR ; here's a short video:

https://github.com/user-attachments/assets/041f85eb-f0da-49b8-8566-f87aa6d9f423




