### PR TITLE
fix(DiffView): Ensure ranges are initialized when landing

### DIFF
--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
@@ -31,8 +31,6 @@ export class ServiceNameVariable extends QueryVariable {
   static QUERY_PROFILE_METRIC_DEPENDENT = '$dataSource and only $profileMetricId services';
 
   constructor(state?: ServiceNameVariableState) {
-    const { serviceName: serviceNameFromStorage } = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
-
     super({
       key: 'serviceName',
       name: 'serviceName',
@@ -41,7 +39,6 @@ export class ServiceNameVariable extends QueryVariable {
       query: ServiceNameVariable.QUERY_DEFAULT,
       loading: true,
       refresh: VariableRefresh.onTimeRangeChanged,
-      value: serviceNameFromStorage,
       ...state,
     });
 
@@ -49,6 +46,12 @@ export class ServiceNameVariable extends QueryVariable {
   }
 
   onActivate() {
+    const { serviceName: serviceNameFromStorage } = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
+
+    if (serviceNameFromStorage) {
+      this.setState({ value: serviceNameFromStorage });
+    }
+
     this.subscribeToState((newState, prevState) => {
       if (newState.value && newState.value !== prevState.value) {
         const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

I've noticed a weird bug on the "Diff flame graph view" where ranges were not preserved. Here are 2 short videos before/after:

| Before (currently in main) | After (what this PR fixes) |
|  ---   |  ---  |
| https://github.com/user-attachments/assets/2823fbc8-cd60-459c-a464-dc5ba2990d28 | https://github.com/user-attachments/assets/2e1be5cb-9fa8-40a8-9976-6920b4c2a250 |

Through `git bisect` I was able to pinpoint [this commit](https://github.com/grafana/explore-profiles/commit/39176600a4c260aa33499635954df5174fc6a54a) as the culprit.

### 📖 Summary of the changes

To be totally honest, I still don't fully understand why it happened and why this PR fixes it.

### 🧪 How to test?

- The build should pass
- Locally, after checking out this PR
