### PR TITLE
Use ?? operator instead of || operator

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
@@ -49,7 +49,7 @@ export function useCodeContainer(dataSourceUid: string, functionDetails: Functio
       isLoadingCode: isFetching,
       unit: functionDetails.unit,
       githubUrl: fileInfo?.URL ? buildGithubUrlForFunction(fileInfo.URL, functionDetails.startLine) : undefined,
-      lines: lines.map((line) => ({ ...line, line: line.line || '???' })),
+      lines: lines.map((line) => ({ ...line, line: line.line ?? '???' })),
       noCodeAvailable: Boolean(fetchError) || !lines.some((line) => line.line),
     },
     actions: {


### PR DESCRIPTION
### ✨ Description

In code view, blank lines were being rendered as `???` instead of and empty line. This PR fixes the logic to make sure blank lines are rendered correctly.

Before:

<img width="1238" alt="Screenshot 2024-10-30 at 2 56 12 PM" src="https://github.com/user-attachments/assets/1844a2a3-f4d6-495f-8fc2-35ba29232c08">

After:

<img width="1239" alt="Screenshot 2024-10-30 at 2 55 42 PM" src="https://github.com/user-attachments/assets/dc38b199-fa64-43e7-930f-f17793396ca9">

