### PR TITLE
fix(Timeseries): Persist scale when data changes

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -12,7 +12,7 @@ import {
 } from '@grafana/scenes';
 import { GraphGradientMode, ScaleDistribution, ScaleDistributionConfig, SortOrder } from '@grafana/schema';
 import { LegendDisplayMode, TooltipDisplayMode, VizLegendOptions } from '@grafana/ui';
-import { cloneDeep, merge } from 'lodash';
+import { merge } from 'lodash';
 import React from 'react';
 
 import { EventTimeseriesDataReceived } from '../domain/events/EventTimeseriesDataReceived';
@@ -98,7 +98,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
 
       if (series?.length) {
         const config = this.state.displayAllValues ? this.getAllValuesConfig(series) : this.getConfig(series);
-        body.setState(config);
+        body.setState(merge(body.state, config));
       }
 
       // we publish the event only after setting the new config so that the subscribers can modify it
@@ -146,7 +146,8 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     body.clearFieldConfigCache();
 
     body.setState({
-      fieldConfig: merge(cloneDeep(body.state.fieldConfig), {
+      menu: this.buildMenu(index),
+      fieldConfig: merge(body.state.fieldConfig, {
         defaults: {
           custom: {
             scaleDistribution,
@@ -154,7 +155,6 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
           },
         },
       }),
-      menu: this.buildMenu(index),
     });
   }
 

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -147,7 +147,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
 
     body.setState({
       menu: this.buildMenu(index),
-      fieldConfig: merge(body.state.fieldConfig, {
+      fieldConfig: merge({}, body.state.fieldConfig, {
         defaults: {
           custom: {
             scaleDistribution,

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries.tsx
@@ -98,7 +98,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
 
       if (series?.length) {
         const config = this.state.displayAllValues ? this.getAllValuesConfig(series) : this.getConfig(series);
-        body.setState(merge(body.state, config));
+        body.setState(merge({}, body.state, config));
       }
 
       // we publish the event only after setting the new config so that the subscribers can modify it


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** is caused by https://github.com/grafana/explore-profiles/pull/249

This PR makes the scale persistent when the timeseries data changes (e.g. when choosing a different time range/adding filters).

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- Go to (e.g.) the "Flame graph view"
- Change the scale to "Log2"
- Choose a different time range
- Add some filters

Expected behaviour: the timeseries should display the data with a "Log2" scale
