### PR TITLE
fix(ExplorationSelector): Fix background color

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/ui/ExplorationTypeSelector.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/ui/ExplorationTypeSelector.tsx
@@ -95,13 +95,16 @@ const getStyles = (theme: GrafanaTheme2) => ({
       background-color: ${theme.colors.primary.main};
     }
 
+    .arrow.primary {
+      background-color: ${theme.colors.primary.main};
+    }
+
     & button.primary:not(.active),
     & .arrow.primary:not(.active) {
       opacity: 0.7;
     }
 
-    & button.primary:not(.active):hover,
-    & .arrow.primary:not(.active):hover {
+    & button.primary:not(.active):hover {
       opacity: 1;
       background-color: ${theme.colors.primary.main};
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just a small cosmetic fix for the background color of the connecting lines:

| Before | After |
|  ---   |  ---  |
| <img width="444" alt="image" src="https://github.com/user-attachments/assets/9f702612-ec03-4ccc-a869-42664c324144"> | ![image](https://github.com/user-attachments/assets/e60f1a7e-2e42-4ec3-be63-af7640531713) |

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

`-`
