### PR TITLE
fix(DiffView): Fix incorrect preset label

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/ScenePresetsPicker/ScenePresetsPicker.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/ScenePresetsPicker/ScenePresetsPicker.tsx
@@ -118,8 +118,8 @@ export class ScenePresetsPicker extends SceneObjectBase<ScenePresetsPickerState>
           },
         },
         {
-          value: 'auto-select-half',
-          label: 'Auto-select (half range)',
+          value: 'auto-select-25',
+          label: 'Auto-select (25% range)',
         },
         {
           value: 'auto-select-whole',


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** is caused by https://github.com/grafana/explore-profiles/pull/254

### 📖 Summary of the changes

The logic was changed in the linked PR, but the corresponding preset option was not updated. This PR fixes it.

### 🧪 How to test?

`-`
