### PR TITLE
fix(DiffView): Disable AI button when no selections

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
@@ -140,7 +140,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
     const { data } = model.useSceneDiffFlameGraph();
     const sidePanel = useToggleSidePanel();
 
-    const isAiButtonDisabled = data.isLoading || data.shouldDisplayInfo || data.noProfileDataAvailable;
+    const isAiButtonDisabled = data.isLoading || data.hasMissingSelections || data.noProfileDataAvailable;
 
     useEffect(() => {
       if (isAiButtonDisabled) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** is caused by https://github.com/grafana/explore-profiles/pull/231/files#diff-b648e06443c5667d8938e238e6b0a8b7579e793379e4fdd1cfc0c0191a7984e6R105

A quick fix to properly disable the "Explain Flame Graph" when no selections are made

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

`-`
