### PR TITLE
fix(QueryBuilder): Prevent invalid filters to be used after parsing URL

### DIFF
--- a/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { useBuildPyroscopeQuery } from '../../useBuildPyroscopeQuery';
 import { ProfilesDataSourceVariable } from '../ProfilesDataSourceVariable';
-import { convertPyroscopeToVariableFilter } from './filters-ops';
+import { convertPyroscopeToVariableFilter, isFilterValid } from './filters-ops';
 
 export class FiltersVariable extends AdHocFiltersVariable {
   static DEFAULT_VALUE = [];
@@ -20,6 +20,9 @@ export class FiltersVariable extends AdHocFiltersVariable {
       filters: FiltersVariable.DEFAULT_VALUE,
       expressionBuilder: (filters) =>
         filters
+          // after parsing the URL search parameters the filters might end up having an invalid operator, which in turn, will
+          // generate an invalid query that will make the API requests fail - we prevent this to happen by sanitizing the filters here
+          .filter(isFilterValid)
           .map(({ key, operator, value }) =>
             operator === OperatorKind['is-empty'] ? `${key}=""` : `${key}${operator}"${value}"`
           )

--- a/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/__tests__/filter-ops.spec.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/__tests__/filter-ops.spec.ts
@@ -1,4 +1,4 @@
-import { clearLabelValue, excludeLabelValue, includeLabelValue } from '../filters-ops';
+import { clearLabelValue, excludeLabelValue, includeLabelValue, isFilterValid } from '../filters-ops';
 
 const FILTER_VEHICLE_IS_BIKE = Object.freeze({ key: 'vehicle', operator: '=', value: 'bike' });
 
@@ -213,5 +213,16 @@ describe('clearLabelValue(filters, filterForClear)', () => {
     ],
   ])('%s', (msg, filters, filterForClear, expectedFilters) => {
     expect(clearLabelValue(filters, filterForClear)).toEqual(expectedFilters);
+  });
+});
+
+describe('isFilterValid(filter)', () => {
+  test.each([
+    [{ key: 'cluster', operator: '', value: 'test' }, false],
+    [{ key: 'cluster', operator: '%', value: 'test' }, false],
+    [{ key: 'cluster', operator: '=', value: 'test' }, true],
+    [{ key: 'cluster', operator: 'is-empty', value: 'test' }, true],
+  ])('"%s" → %s', (filter, expectedResult) => {
+    expect(isFilterValid(filter)).toBe(expectedResult);
   });
 });

--- a/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/filters-ops.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/filters-ops.ts
@@ -121,3 +121,5 @@ export function clearLabelValue(
 
   return [...filtersWithoutFound];
 }
+
+export const isFilterValid = (filter: AdHocVariableFilter) => filter.operator in OperatorKind;


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
- Manually by loading the page after altering the filters URL search parameter
