### PR TITLE
fix(Tracking): Ensure select action type is tracked

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreAllServices/SceneExploreAllServices.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreAllServices/SceneExploreAllServices.tsx
@@ -10,9 +10,6 @@ import React from 'react';
 import { SceneByVariableRepeaterGrid } from '../../components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
-import { EventViewServiceFlameGraph } from '../../domain/events/EventViewServiceFlameGraph';
-import { EventViewServiceLabels } from '../../domain/events/EventViewServiceLabels';
-import { EventViewServiceProfiles } from '../../domain/events/EventViewServiceProfiles';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
@@ -48,9 +45,9 @@ export class SceneExploreAllServices extends SceneObjectBase<SceneExploreAllServ
           panelType: PanelType.TIMESERIES,
         }),
         headerActions: (item) => [
-          new SelectAction({ EventClass: EventViewServiceProfiles, item }),
-          new SelectAction({ EventClass: EventViewServiceLabels, item }),
-          new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
+          new SelectAction({ type: 'view-profiles', item }),
+          new SelectAction({ type: 'view-labels', item }),
+          new SelectAction({ type: 'view-flame-graph', item }),
           new FavAction({ item }),
         ],
       }),

--- a/src/pages/ProfilesExplorerView/components/SceneExploreFavorites/SceneExploreFavorites.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreFavorites/SceneExploreFavorites.tsx
@@ -13,8 +13,6 @@ import { SceneDrawer } from '../../components/SceneDrawer';
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
 import { EventExpandPanel } from '../../domain/events/EventExpandPanel';
-import { EventViewServiceFlameGraph } from '../../domain/events/EventViewServiceFlameGraph';
-import { EventViewServiceLabels } from '../../domain/events/EventViewServiceLabels';
 import { FavoriteVariable } from '../../domain/variables/FavoriteVariable';
 import { vizPanelBuilder } from '../../helpers/vizPanelBuilder';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
@@ -48,14 +46,14 @@ export class SceneExploreFavorites extends SceneObjectBase<SceneExploreFavorites
         sortItemsFn: (a, b) => a.label.localeCompare(b.label),
         headerActions: (item) => {
           const actions: Array<SelectAction | FavAction> = [
-            new SelectAction({ EventClass: EventViewServiceLabels, item, skipVariablesInterpolation: true }),
-            new SelectAction({ EventClass: EventViewServiceFlameGraph, item, skipVariablesInterpolation: true }),
+            new SelectAction({ type: 'view-labels', item, skipVariablesInterpolation: true }),
+            new SelectAction({ type: 'view-flame-graph', item, skipVariablesInterpolation: true }),
           ];
 
           if (item.queryRunnerParams.groupBy) {
             actions.push(
               new SelectAction({
-                EventClass: EventExpandPanel,
+                type: 'expand-panel',
                 item,
                 tooltip: () => 'Expand this panel to view all the data',
                 skipVariablesInterpolation: true,
@@ -102,8 +100,8 @@ export class SceneExploreFavorites extends SceneObjectBase<SceneExploreFavorites
 
   openExpandedPanelDrawer(item: GridItemData) {
     const headerActions = () => [
-      new SelectAction({ EventClass: EventViewServiceLabels, item }),
-      new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
+      new SelectAction({ type: 'view-labels', item }),
+      new SelectAction({ type: 'view-flame-graph', item }),
     ];
 
     this.state.drawer.open({

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneExploreServiceFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneExploreServiceFlameGraph.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
-import { EventViewServiceLabels } from '../../domain/events/EventViewServiceLabels';
 import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
@@ -25,10 +24,7 @@ export class SceneExploreServiceFlameGraph extends SceneObjectBase<SceneExploreS
       key: 'explore-service-flame-graph',
       mainTimeseries: new SceneMainServiceTimeseries({
         item,
-        headerActions: (item) => [
-          new SelectAction({ EventClass: EventViewServiceLabels, item }),
-          new FavAction({ item }),
-        ],
+        headerActions: (item) => [new SelectAction({ type: 'view-labels', item }), new FavAction({ item })],
       }),
       body: new SceneFlameGraph(),
     });

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneExploreServiceLabels.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/SceneExploreServiceLabels.tsx
@@ -13,7 +13,6 @@ import React from 'react';
 import { SceneMainServiceTimeseries } from '../../components/SceneMainServiceTimeseries';
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
-import { EventViewServiceFlameGraph } from '../../domain/events/EventViewServiceFlameGraph';
 import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
@@ -39,10 +38,7 @@ export class SceneExploreServiceLabels extends SceneObjectBase<SceneExploreServi
             minHeight: SceneMainServiceTimeseries.MIN_HEIGHT,
             body: new SceneMainServiceTimeseries({
               item,
-              headerActions: (item) => [
-                new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
-                new FavAction({ item }),
-              ],
+              headerActions: (item) => [new SelectAction({ type: 'view-flame-graph', item }), new FavAction({ item })],
             }),
           }),
           new SceneFlexItem({

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/SceneGroupByLabels.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/SceneGroupByLabels.tsx
@@ -20,7 +20,6 @@ import { FavAction } from '../../../../domain/actions/FavAction';
 import { SelectAction } from '../../../../domain/actions/SelectAction';
 import { EventExpandPanel } from '../../../../domain/events/EventExpandPanel';
 import { EventSelectLabel } from '../../../../domain/events/EventSelectLabel';
-import { EventViewServiceFlameGraph } from '../../../../domain/events/EventViewServiceFlameGraph';
 import {
   clearLabelValue,
   excludeLabelValue,
@@ -227,8 +226,8 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
         };
       },
       headerActions: (item) => [
-        new SelectAction({ EventClass: EventSelectLabel, item }),
-        new SelectAction({ EventClass: EventExpandPanel, item }),
+        new SelectAction({ type: 'select-label', item }),
+        new SelectAction({ type: 'expand-panel', item }),
         new FavAction({ item }),
       ],
     });
@@ -261,7 +260,7 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
       label,
       headerActions: (item) => [
         new SelectAction({
-          EventClass: EventViewServiceFlameGraph,
+          type: 'view-flame-graph',
           item,
           tooltip: (item, model) => {
             const { queryRunnerParams, label } = item;
@@ -317,7 +316,7 @@ export class SceneGroupByLabels extends SceneObjectBase<SceneGroupByLabelsState>
     const profileMetricId = getSceneVariableValue(this, 'profileMetricId');
     const title = `${serviceName} · ${getProfileMetricLabel(profileMetricId)} · ${item.label}`;
 
-    const headerActions = () => [new SelectAction({ EventClass: EventSelectLabel, item }), new FavAction({ item })];
+    const headerActions = () => [new SelectAction({ type: 'select-label', item }), new FavAction({ item })];
 
     this.state.drawer.open({
       title,

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceProfileTypes/SceneExploreServiceProfileTypes.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceProfileTypes/SceneExploreServiceProfileTypes.tsx
@@ -10,8 +10,6 @@ import React from 'react';
 import { SceneByVariableRepeaterGrid } from '../../components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
-import { EventViewServiceFlameGraph } from '../../domain/events/EventViewServiceFlameGraph';
-import { EventViewServiceLabels } from '../../domain/events/EventViewServiceLabels';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
@@ -48,8 +46,8 @@ export class SceneExploreServiceProfileTypes extends SceneObjectBase<SceneExplor
           panelType: PanelType.TIMESERIES,
         }),
         headerActions: (item) => [
-          new SelectAction({ EventClass: EventViewServiceLabels, item }),
-          new SelectAction({ EventClass: EventViewServiceFlameGraph, item }),
+          new SelectAction({ type: 'view-labels', item }),
+          new SelectAction({ type: 'view-flame-graph', item }),
           new FavAction({ item }),
         ],
       }),

--- a/src/pages/ProfilesExplorerView/domain/variables/GroupByVariable/GroupByVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/GroupByVariable/GroupByVariable.tsx
@@ -61,7 +61,7 @@ export class GroupByVariable extends QueryVariable {
   };
 
   onChange = (newValue: string) => {
-    reportInteraction('g_pyroscope_app_group_by_label_clicked', { label: newValue });
+    reportInteraction('g_pyroscope_app_group_by_label_clicked');
 
     prepareHistoryEntry();
     this.changeValueTo(newValue);

--- a/src/shared/domain/__tests__/reportInteraction.spec.ts
+++ b/src/shared/domain/__tests__/reportInteraction.spec.ts
@@ -20,33 +20,62 @@ describe('reportInteraction(interactionName, properties)', () => {
     window.location = originalLocation;
   });
 
-  it('calls Grafana\'s reportInteraction with a new "page" property', () => {
+  it('calls Grafana\'s reportInteraction with a new "meta" property', () => {
     Object.defineProperty(window, 'location', {
-      value: 'http://localhost:3000/a/grafana-pyroscope-app/test-page-1',
+      value: new URL('http://localhost:3000/a/grafana-pyroscope-app/test-page-1'),
       writable: true,
     });
 
     reportInteraction('g_pyroscope_app_exploration_type_clicked');
 
     expect(grafanaReportInteraction).toHaveBeenCalledWith('g_pyroscope_app_exploration_type_clicked', {
-      page: 'test-page-1',
-      version: '1.0.0',
+      props: undefined,
+      meta: {
+        page: 'test-page-1',
+        appRelease: '1.0.0',
+        appVersion: 'dev',
+      },
+    });
+  });
+  describe('if the current URL corresponds to the "profiles-explorer" page', () => {
+    it('adds a "view" meta', () => {
+      Object.defineProperty(window, 'location', {
+        value: new URL('http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer?explorationType=flame-graph'),
+        writable: true,
+      });
+
+      reportInteraction('g_pyroscope_app_exploration_type_clicked');
+
+      expect(grafanaReportInteraction).toHaveBeenCalledWith('g_pyroscope_app_exploration_type_clicked', {
+        props: undefined,
+        meta: {
+          appRelease: '1.0.0',
+          appVersion: 'dev',
+          page: 'profiles-explorer',
+          view: 'flame-graph',
+        },
+      });
     });
   });
 
   describe('if some extra properties are passed', () => {
     it('calls Grafana\'s reportInteraction with these properties as well as a new "page" property', () => {
       Object.defineProperty(window, 'location', {
-        value: 'http://localhost:3000/a/grafana-pyroscope-app/test-page-2',
+        value: new URL('http://localhost:3000/a/grafana-pyroscope-app/test-page-2'),
         writable: true,
       });
 
       reportInteraction('g_pyroscope_app_exploration_type_clicked', { explorationType: 'unit-tests' });
 
       expect(grafanaReportInteraction).toHaveBeenCalledWith('g_pyroscope_app_exploration_type_clicked', {
-        page: 'test-page-2',
-        version: '1.0.0',
-        explorationType: 'unit-tests',
+        props: {
+          explorationType: 'unit-tests',
+        },
+        meta: {
+          appRelease: '1.0.0',
+          appVersion: 'dev',
+          page: 'test-page-2',
+        },
       });
     });
   });


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR fixes a couple of issues related to tracking. The major one being that, because the symbol names are minified in production, so are the classes names. Thus the `SelectAction` Scene object can't rely on it.

### 📖 Summary of the changes

See diff tab for specific comments

### 🧪 How to test?

The build should pass
