### PR TITLE
fix(ProfileTypesView): Load last used service name only if it's not provided in the URL

### DIFF
--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
@@ -49,7 +49,7 @@ export class ServiceNameVariable extends QueryVariable {
   onActivate() {
     const { serviceName: serviceNameFromStorage } = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
 
-    if (serviceNameFromStorage) {
+    if (serviceNameFromStorage && !this.state.value) {
       this.setState({ value: serviceNameFromStorage });
     }
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

Fixes: #283

### 📖 Summary of the changes

In https://github.com/grafana/explore-profiles/pull/222 we introduced loading last used service name from local storage. The stored value is applied during `onActivate()` (it was changed in https://github.com/grafana/explore-profiles/pull/233). This however overrides the service name value if it's provided in the URL. The change is to skip loading last used service name if it's already set (e.g. from the URL)

### 🧪 How to test?

See reproduction steps in #283

