### PR TITLE
fix(SceneComparePanel): Temporarily disable time range sync

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
@@ -21,6 +21,7 @@ import {
   VariableDependencyConfig,
 } from '@grafana/scenes';
 import { IconButton, useStyles2 } from '@grafana/ui';
+import { SceneTimePickerWithoutSync } from '@shared/components/SceneTimePickerWithoutSync/SceneTimePickerWithoutSync';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 import { omit } from 'lodash';
 import React from 'react';
@@ -84,7 +85,6 @@ export class SceneComparePanel extends SceneObjectBase<SceneComparePanelState> {
     const title = target === CompareTarget.BASELINE ? 'Baseline' : 'Comparison';
     const color =
       target === CompareTarget.BASELINE ? BASELINE_COLORS.COLOR.toString() : COMPARISON_COLORS.COLOR.toString();
-
     super({
       key: `${target}-panel`,
       target,
@@ -92,7 +92,7 @@ export class SceneComparePanel extends SceneObjectBase<SceneComparePanelState> {
       title,
       color,
       $timeRange: new SceneTimeRange({ key: `${target}-panel-timerange`, ...buildTimeRange('now-1h', 'now') }),
-      timePicker: new SceneTimePicker({ isOnCanvas: true }),
+      timePicker: new SceneTimePickerWithoutSync({ isOnCanvas: true }),
       refreshPicker: new SceneRefreshPicker({ isOnCanvas: true }),
       timeseriesPanel: SceneComparePanel.buildTimeSeriesPanel({ target, filterKey, title, color }),
       timeRangeSyncEnabled: false,

--- a/src/shared/components/SceneTimePickerWithoutSync/SceneTimePickerWithoutSync.tsx
+++ b/src/shared/components/SceneTimePickerWithoutSync/SceneTimePickerWithoutSync.tsx
@@ -1,0 +1,35 @@
+import { SceneComponentProps, sceneGraph, SceneTimePicker } from '@grafana/scenes';
+import { TimeRangePicker } from '@grafana/ui';
+import React from 'react';
+
+export class SceneTimePickerWithoutSync extends SceneTimePicker {
+  public static Component = function SceneTimePickerRenderer({
+    model,
+  }: SceneComponentProps<SceneTimePickerWithoutSync>) {
+    const { hidePicker, isOnCanvas } = model.useState();
+    const timeRange = sceneGraph.getTimeRange(model);
+    const timeZone = timeRange.getTimeZone();
+    const timeRangeState = timeRange.useState();
+
+    if (hidePicker) {
+      return null;
+    }
+
+    return (
+      <TimeRangePicker
+        isOnCanvas={isOnCanvas ?? true}
+        value={timeRangeState.value}
+        onChange={timeRange.onTimeRangeChange}
+        timeZone={timeZone}
+        fiscalYearStartMonth={timeRangeState.fiscalYearStartMonth}
+        onMoveBackward={model.onMoveBackward}
+        onMoveForward={model.onMoveForward}
+        onZoom={model.onZoom}
+        onChangeTimeZone={timeRange.onTimeZoneChange}
+        onChangeFiscalYearStartMonth={model.onChangeFiscalYearStartMonth}
+        // disable the sync
+        isSynced={false}
+      />
+    );
+  };
+}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

Temporarily disable time range sync introduced in https://github.com/grafana/grafana/pull/94074 until scenes allow to control it.

### 📖 Summary of the changes

Modifies SceneTimePicker to pass `isSync` property disabling the sync.

### 🧪 How to test?

Check if there's no additional sync button in Diff Flame Graph view
