### PR TITLE
feat(Timeseries): Add open in Explore menu item

### DIFF
--- a/src/pages/ProfilesExplorerView/helpers/__tests__/getExploreUrl.spec.ts
+++ b/src/pages/ProfilesExplorerView/helpers/__tests__/getExploreUrl.spec.ts
@@ -1,0 +1,48 @@
+function setup(appSubUrl?: string) {
+  jest.doMock('@grafana/runtime', () => ({
+    reportInteraction: jest.fn(),
+    config: {
+      appSubUrl,
+    },
+  }));
+
+  return require('../getExploreUrl');
+}
+
+describe('getExploreUrl(rawTimeRange, query, datasource)', () => {
+  test('If "appSubUrl" is not defined in the Grafana runtime config', () => {
+    const { getExploreUrl } = setup(undefined);
+
+    const rawTimeRange = { from: 'now-5m', to: 'now' };
+    const query = {
+      refId: 'test1',
+      queryType: 'metrics',
+      profileTypeId: 'block:delay:nanoseconds:contentions:count',
+      labelSelector: '{}',
+      groupBy: [],
+    };
+    const datasource = 'grafanacloud-profiles-sedemo';
+    const expectedUrl =
+      '/explore?panes=%7B%22pyroscope-explore%22:%7B%22range%22:%7B%22from%22:%22now-5m%22,%22to%22:%22now%22%7D,%22queries%22:%5B%7B%22refId%22:%22test1%22,%22queryType%22:%22metrics%22,%22profileTypeId%22:%22block:delay:nanoseconds:contentions:count%22,%22labelSelector%22:%22%7B%7D%22,%22groupBy%22:%5B%5D,%22datasource%22:%22grafanacloud-profiles-sedemo%22%7D%5D,%22panelsState%22:%7B%7D,%22datasource%22:%22grafanacloud-profiles-sedemo%22%7D%7D&schemaVersion=1';
+
+    expect(getExploreUrl(rawTimeRange, query, datasource)).toBe(expectedUrl);
+  });
+
+  test('If "appSubUrl" is defined in the Grafana runtime config', () => {
+    const { getExploreUrl } = setup('http://text:4242');
+
+    const rawTimeRange = { from: 'now-5m', to: 'now' };
+    const query = {
+      refId: 'test1',
+      queryType: 'metrics',
+      profileTypeId: 'block:delay:nanoseconds:contentions:count',
+      labelSelector: '{}',
+      groupBy: [],
+    };
+    const datasource = 'grafanacloud-profiles-sedemo';
+    const expectedUrl =
+      'http://text:4242/explore?panes=%7B%22pyroscope-explore%22:%7B%22range%22:%7B%22from%22:%22now-5m%22,%22to%22:%22now%22%7D,%22queries%22:%5B%7B%22refId%22:%22test1%22,%22queryType%22:%22metrics%22,%22profileTypeId%22:%22block:delay:nanoseconds:contentions:count%22,%22labelSelector%22:%22%7B%7D%22,%22groupBy%22:%5B%5D,%22datasource%22:%22grafanacloud-profiles-sedemo%22%7D%5D,%22panelsState%22:%7B%7D,%22datasource%22:%22grafanacloud-profiles-sedemo%22%7D%7D&schemaVersion=1';
+
+    expect(getExploreUrl(rawTimeRange, query, datasource)).toBe(expectedUrl);
+  });
+});

--- a/src/pages/ProfilesExplorerView/helpers/getExploreUrl.ts
+++ b/src/pages/ProfilesExplorerView/helpers/getExploreUrl.ts
@@ -1,0 +1,21 @@
+import { RawTimeRange, toURLRange, urlUtil } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { SceneDataQuery } from '@grafana/scenes';
+
+export function getExploreUrl(rawTimeRange: RawTimeRange, query: SceneDataQuery, datasource: string): string {
+  const exploreState = JSON.stringify({
+    ['pyroscope-explore']: {
+      range: toURLRange(rawTimeRange),
+      queries: [{ ...query, datasource }],
+      panelsState: {},
+      datasource,
+    },
+  });
+
+  const subUrl = config.appSubUrl ?? '';
+
+  return urlUtil.renderUrl(`${subUrl}/explore`, {
+    panes: exploreState,
+    schemaVersion: 1,
+  });
+}

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -24,6 +24,7 @@ export type InteractionName =
   | 'g_pyroscope_app_hide_no_data_changed'
   | 'g_pyroscope_app_include_action_clicked'
   | 'g_pyroscope_app_layout_changed'
+  | 'g_pyroscope_app_open_in_explore'
   | 'g_pyroscope_app_optimize_code_clicked'
   | 'g_pyroscope_app_panel_type_changed'
   | 'g_pyroscope_app_profile_metric_selected'
@@ -31,6 +32,7 @@ export type InteractionName =
   | 'g_pyroscope_app_select_action_clicked'
   | 'g_pyroscope_app_service_name_selected'
   | 'g_pyroscope_app_share_link_clicked'
+  | 'g_pyroscope_app_timeseries_scale_change'
   | 'g_pyroscope_app_user_settings_clicked';
 
 type InteractionProperties =
@@ -51,7 +53,9 @@ type InteractionProperties =
   // g_pyroscope_app_panel_type_changed
   | { panelType: PanelType }
   // g_pyroscope_app_select_action_clicked
-  | { type: string };
+  | { type: string }
+  // g_pyroscope_app_timeseries_scale_change
+  | { scale: string };
 
 const PROFILES_EXPLORER_PAGE_NAME = ROUTES.PROFILES_EXPLORER_VIEW.slice(1);
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/explore-profiles/issues/299, blocks https://github.com/grafana/explore-profiles/pull/301

This PR adds a new "Open in Explore" menu item to each time series in the app:

<img width="568" alt="image" src="https://github.com/user-attachments/assets/d6a422b4-fd71-4346-894a-f99575763370">

### 📖 Summary of the changes

This is a preliminary PR before adding the support to Investigations. I took the opportunity to add some missing tracking (for the type of scale).

See diff tab for specific comments.

### 🧪 How to test?

The build should pass
