### PR TITLE
test(EndToEnd): Add expectation to prevent waiting when a fatal error…

### DIFF
--- a/e2e/fixtures/pages/PyroscopePage.ts
+++ b/e2e/fixtures/pages/PyroscopePage.ts
@@ -19,6 +19,7 @@ export class PyroscopePage {
 
     await this.page.goto(url);
     await this.page.locator('.pyroscope-app').waitFor();
+    await expect(this.getByRole('alert', { name: /fatal error/i })).not.toBeVisible();
   }
 
   locator(selector: string, options?: Record<string, unknown>) {


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Just a quick improvement, to prevent situation like these:

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/799bb18f-fb37-4a8b-95a2-2558536891cb">

where a fatal error occurred during the diff view tests and made the build last for ~15m before failing.

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

- The build should pass
