### PR TITLE
refactor: prepare Investigations support

### DIFF
--- a/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
@@ -3,6 +3,14 @@ import { SceneQueryRunner } from '@grafana/scenes';
 import { PYROSCOPE_DATA_SOURCE } from '../pyroscope-data-sources';
 import { TimeSeriesQueryRunnerParams } from './TimeSeriesQueryRunnerParams';
 
+export type TimeSeriesQuery = {
+  refId: string;
+  queryType: 'metrics';
+  profileTypeId: string;
+  labelSelector: string;
+  groupBy: string[];
+};
+
 export function buildTimeSeriesQueryRunner({
   serviceName,
   profileMetricId,

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -24,7 +24,7 @@ export type InteractionName =
   | 'g_pyroscope_app_hide_no_data_changed'
   | 'g_pyroscope_app_include_action_clicked'
   | 'g_pyroscope_app_layout_changed'
-  | 'g_pyroscope_app_open_in_explore'
+  | 'g_pyroscope_app_open_in_explore_clicked'
   | 'g_pyroscope_app_optimize_code_clicked'
   | 'g_pyroscope_app_panel_type_changed'
   | 'g_pyroscope_app_profile_metric_selected'
@@ -32,7 +32,7 @@ export type InteractionName =
   | 'g_pyroscope_app_select_action_clicked'
   | 'g_pyroscope_app_service_name_selected'
   | 'g_pyroscope_app_share_link_clicked'
-  | 'g_pyroscope_app_timeseries_scale_change'
+  | 'g_pyroscope_app_timeseries_scale_changed'
   | 'g_pyroscope_app_user_settings_clicked';
 
 type InteractionProperties =


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/explore-profiles/pull/301

A quick preparation PR in order to support Investigations in Explore Profiles.

### 📖 Summary of the changes

The changes are mainly scoped to `SceneLabelValuesTimeseries`

### 🧪 How to test?

- The build should pass
