### PR TITLE
refactor(*): Use the Intl API for sorting items

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/domain/sortFavGridItems.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/domain/sortFavGridItems.ts
@@ -1,3 +1,5 @@
+import { localeCompare } from '@shared/domain/localeCompare';
+
 import { FavAction } from '../../..//domain/actions/FavAction';
 import { FavoritesDataSource } from '../../../infrastructure/favorites/FavoritesDataSource';
 import { GridItemData } from '../types/GridItemData';
@@ -7,7 +9,7 @@ export const sortFavGridItems: (a: GridItemData, b: GridItemData) => number = fu
   const bIsFav = FavoritesDataSource.exists(FavAction.buildFavorite(b));
 
   if (aIsFav && bIsFav) {
-    return a.label.localeCompare(b.label);
+    return localeCompare(a.label, b.label);
   }
 
   if (bIsFav) {

--- a/src/pages/ProfilesExplorerView/components/SceneExploreFavorites/SceneExploreFavorites.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreFavorites/SceneExploreFavorites.tsx
@@ -5,6 +5,7 @@ import {
   SceneObjectBase,
   SceneVariableSet,
 } from '@grafana/scenes';
+import { localeCompare } from '@shared/domain/localeCompare';
 import React from 'react';
 
 import { SceneByVariableRepeaterGrid } from '../../components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
@@ -43,7 +44,7 @@ export class SceneExploreFavorites extends SceneObjectBase<SceneExploreFavorites
             panelType,
           };
         },
-        sortItemsFn: (a, b) => a.label.localeCompare(b.label),
+        sortItemsFn: (a, b) => localeCompare(a.label, b.label),
         headerActions: (item) => {
           const actions: Array<SelectAction | FavAction> = [
             new SelectAction({ type: 'view-labels', item, skipVariablesInterpolation: true }),

--- a/src/pages/ProfilesExplorerView/domain/variables/ProfileMetricVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ProfileMetricVariable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2, VariableRefresh } from '@grafana/data';
 import { MultiValueVariable, QueryVariable, SceneComponentProps, VariableValueOption } from '@grafana/scenes';
 import { Cascader, CascaderOption, Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import { localeCompare } from '@shared/domain/localeCompare';
 import { prepareHistoryEntry } from '@shared/domain/prepareHistoryEntry';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
@@ -99,7 +100,7 @@ export class ProfileMetricVariable extends QueryVariable {
       optionsMap.set(group, nameSpaceServices);
     }
 
-    return Array.from(optionsMap.values()).sort((a, b) => b.label.localeCompare(a.label));
+    return Array.from(optionsMap.values()).sort((a, b) => localeCompare(b.label, a.label));
   }
 
   onSelect = (newValue: string) => {

--- a/src/pages/ProfilesExplorerView/infrastructure/series/formatSeriesToProfileMetrics.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/formatSeriesToProfileMetrics.ts
@@ -1,4 +1,5 @@
 import { MetricFindValue } from '@grafana/data';
+import { localeCompare } from '@shared/domain/localeCompare';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 
 import { PyroscopeSeries } from './http/SeriesApiClient';
@@ -11,7 +12,7 @@ export function formatSeriesToProfileMetrics(
     const profileMetricsMap = pyroscopeSeries.services.get(serviceName) || new Map();
 
     return Array.from(profileMetricsMap.values())
-      .sort((a, b) => b.group.localeCompare(a.group))
+      .sort((a, b) => localeCompare(b.group, a.group))
       .map(({ id, type, group }) => ({
         value: id,
         text: `${type} (${group})`,
@@ -20,7 +21,7 @@ export function formatSeriesToProfileMetrics(
 
   return Array.from(pyroscopeSeries.profileMetrics.keys())
     .map((id) => getProfileMetric(id as ProfileMetricId))
-    .sort((a, b) => b.group.localeCompare(a.group))
+    .sort((a, b) => localeCompare(b.group, a.group))
     .map(({ id, type, group }) => ({
       value: id,
       text: `${type} (${group})`,

--- a/src/pages/ProfilesExplorerView/infrastructure/series/formatSeriesToServices.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/formatSeriesToServices.ts
@@ -1,4 +1,5 @@
 import { MetricFindValue } from '@grafana/data';
+import { localeCompare } from '@shared/domain/localeCompare';
 
 import { PyroscopeSeries } from './http/SeriesApiClient';
 
@@ -7,7 +8,7 @@ export function formatSeriesToServices(pyroscopeSeries: PyroscopeSeries, profile
     const servicesSet = pyroscopeSeries.profileMetrics.get(profileMetricId) || new Set();
 
     return Array.from(servicesSet)
-      .sort((a, b) => a.localeCompare(b))
+      .sort(localeCompare)
       .map((serviceName) => ({
         text: serviceName,
         value: serviceName,
@@ -15,7 +16,7 @@ export function formatSeriesToServices(pyroscopeSeries: PyroscopeSeries, profile
   }
 
   return Array.from(pyroscopeSeries.services.keys())
-    .sort((a, b) => a.localeCompare(b))
+    .sort(localeCompare)
     .map((serviceName) => ({
       text: serviceName,
       value: serviceName,

--- a/src/shared/components/QueryBuilder/ui/selects/MultipleEditionSelect.tsx
+++ b/src/shared/components/QueryBuilder/ui/selects/MultipleEditionSelect.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
 import { MultiSelect, useStyles2 } from '@grafana/ui';
+import { localeCompare } from '@shared/domain/localeCompare';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { Suggestion, Suggestions } from '../../domain/types';
@@ -17,7 +18,7 @@ const placeSelectedValuesFirst = (values: Suggestions) => (a: Suggestion, b: Sug
   const bIsSelected = values.some((v) => v.value === b.value);
 
   if (aIsSelected && bIsSelected) {
-    return a.value.localeCompare(b.value);
+    return localeCompare(a.value, b.value);
   }
 
   if (bIsSelected) {

--- a/src/shared/domain/localeCompare.ts
+++ b/src/shared/domain/localeCompare.ts
@@ -1,0 +1,3 @@
+const collator = new Intl.Collator('en', { sensitivity: 'case' });
+
+export const localeCompare = collator.compare;


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** see https://github.com/grafana/grafana/pull/96862 for performance impact

A PR just to modernize our code base by using the [Intl APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator).

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

- The build should pass
