### PR TITLE
fix(Header): Prevent crash if useChromeHeaderHeight is not available (for Grafana < v11.3)

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
@@ -19,7 +19,7 @@ export type HeaderProps = {
 };
 
 export function Header(props: HeaderProps) {
-  const chromeHeaderHeight = useChromeHeaderHeight();
+  const chromeHeaderHeight = useChromeHeaderHeight?.();
   const styles = useStyles2(getStyles, chromeHeaderHeight ?? 0);
 
   const { data, actions } = useHeader(props);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/explore-profiles/issues/306

Prevent this fatal error to happen:

<img width="873" alt="image" src="https://github.com/user-attachments/assets/f1b3920b-7ec0-4974-8d82-95dff604de29">

Just be gracefully falling back to a 0 value.

### 📖 Summary of the changes

See diff tab.

### 🧪 How to test?

- In Grafana < v11.3, no fatal error should occur
