### PR TITLE
fix(DiffFlameGraphView): Clear preset option when applying auto-select

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/SceneComparePanel.tsx
@@ -297,6 +297,8 @@ export class SceneComparePanel extends SceneObjectBase<SceneComparePanelState> {
     const { $timeRange, target } = this.state;
     const { from, to } = $timeRange.state.value;
 
+    this.updateTitle('');
+
     if (selectWholeRange) {
       this.setDiffRange(from.toISOString(), to.toISOString());
       return;

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/ScenePresetsPicker/ScenePresetsPicker.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/ScenePresetsPicker/ScenePresetsPicker.tsx
@@ -176,6 +176,8 @@ export class ScenePresetsPicker extends SceneObjectBase<ScenePresetsPickerState>
     }
 
     if (option.value?.startsWith('auto-select-')) {
+      this.setState({ value: null });
+
       this.publishEvent(new EventDiffAutoSelect({ wholeRange: option.value === 'auto-select-whole' }), true);
       return;
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/explore-profiles/issues/309

To prevent confusion, this PR ensures that the preset option is cleared after selecting an "Auto-preset". See the linked issue for more details. 

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- `-`
