### PR TITLE
fix(QueryRunners): Prevent invalid queries to run

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/infrastructure/buildCompareTimeSeriesQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/infrastructure/buildCompareTimeSeriesQueryRunner.ts
@@ -1,12 +1,14 @@
 import { SceneQueryRunner } from '@grafana/scenes';
-import { PYROSCOPE_DATA_SOURCE } from 'src/pages/ProfilesExplorerView/infrastructure/pyroscope-data-sources';
+
+import { PYROSCOPE_DATA_SOURCE } from '../../../../../infrastructure/pyroscope-data-sources';
+import { withPreventInvalidQuery } from '../../../../../infrastructure/withPreventInvalidQuery';
 
 export function buildCompareTimeSeriesQueryRunner({
   filterKey,
 }: {
   filterKey: 'filtersBaseline' | 'filtersComparison';
 }) {
-  return new SceneQueryRunner({
+  const queryRunner = new SceneQueryRunner({
     datasource: PYROSCOPE_DATA_SOURCE,
     queries: [
       {
@@ -17,4 +19,6 @@ export function buildCompareTimeSeriesQueryRunner({
       },
     ],
   });
+
+  return withPreventInvalidQuery(queryRunner);
 }

--- a/src/pages/ProfilesExplorerView/infrastructure/flame-graph/buildFlameGraphQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/flame-graph/buildFlameGraphQueryRunner.ts
@@ -2,6 +2,7 @@ import { SceneQueryRunner } from '@grafana/scenes';
 
 import { PYROSCOPE_DATA_SOURCE } from '../pyroscope-data-sources';
 import { TimeSeriesQueryRunnerParams } from '../timeseries/TimeSeriesQueryRunnerParams';
+import { withPreventInvalidQuery } from '../withPreventInvalidQuery';
 
 type FlameGraphQueryRunnerParams = TimeSeriesQueryRunnerParams & {
   maxNodes?: number;
@@ -13,7 +14,7 @@ export function buildFlameGraphQueryRunner({ filters, maxNodes }: FlameGraphQuer
 
   const selector = completeFilters.map(({ key, operator, value }) => `${key}${operator}"${value}"`).join(',');
 
-  return new SceneQueryRunner({
+  const queryRunner = new SceneQueryRunner({
     datasource: PYROSCOPE_DATA_SOURCE,
     queries: [
       {
@@ -25,4 +26,6 @@ export function buildFlameGraphQueryRunner({ filters, maxNodes }: FlameGraphQuer
       },
     ],
   });
+
+  return withPreventInvalidQuery(queryRunner);
 }

--- a/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
@@ -1,6 +1,7 @@
 import { SceneQueryRunner } from '@grafana/scenes';
 
 import { PYROSCOPE_DATA_SOURCE } from '../pyroscope-data-sources';
+import { withPreventInvalidQuery } from '../withPreventInvalidQuery';
 import { TimeSeriesQueryRunnerParams } from './TimeSeriesQueryRunnerParams';
 
 export type TimeSeriesQuery = {
@@ -22,7 +23,7 @@ export function buildTimeSeriesQueryRunner({
 
   const selector = completeFilters.map(({ key, operator, value }) => `${key}${operator}"${value}"`).join(',');
 
-  return new SceneQueryRunner({
+  const queryRunner = new SceneQueryRunner({
     datasource: PYROSCOPE_DATA_SOURCE,
     queries: [
       {
@@ -34,4 +35,6 @@ export function buildTimeSeriesQueryRunner({
       },
     ],
   });
+
+  return withPreventInvalidQuery(queryRunner);
 }

--- a/src/pages/ProfilesExplorerView/infrastructure/withPreventInvalidQuery.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/withPreventInvalidQuery.ts
@@ -1,8 +1,28 @@
 import { LoadingState } from '@grafana/data';
 import { sceneGraph, SceneQueryRunner } from '@grafana/scenes';
+import { parseQuery } from '@shared/domain/url-params/parseQuery';
+import { logger } from '@shared/infrastructure/tracking/logger';
 
 export function withPreventInvalidQuery(queryRunner: SceneQueryRunner) {
   queryRunner.addActivationHandler(() => {
+    const { profileTypeId, labelSelector } = queryRunner.state.queries[0];
+
+    if (!profileTypeId) {
+      queryRunner.setState({
+        queries: [{ refId: 'null' }],
+        data: buildErrorData(queryRunner, 'Missing profile type!'),
+      });
+      return;
+    }
+
+    if (!labelSelector) {
+      queryRunner.setState({
+        queries: [{ refId: 'null' }],
+        data: buildErrorData(queryRunner, 'Missing label selector!'),
+      });
+      return;
+    }
+
     if (!sceneGraph.interpolate(queryRunner, '$profileMetricId')) {
       queryRunner.setState({
         queries: [{ refId: 'null' }],
@@ -11,7 +31,9 @@ export function withPreventInvalidQuery(queryRunner: SceneQueryRunner) {
       return;
     }
 
-    if (!sceneGraph.interpolate(queryRunner, '$serviceName')) {
+    const parsed = parseQuery(sceneGraph.interpolate(queryRunner, `$profileTypeId${labelSelector})`));
+
+    if (!parsed.serviceId) {
       queryRunner.setState({
         queries: [{ refId: 'null' }],
         data: buildErrorData(queryRunner, 'Missing service name!'),
@@ -22,9 +44,15 @@ export function withPreventInvalidQuery(queryRunner: SceneQueryRunner) {
   return queryRunner;
 }
 
-const buildErrorData = (queryRunner: SceneQueryRunner, errorMsg: string) => ({
-  state: LoadingState.Error,
-  errors: [new Error(errorMsg)],
-  series: [],
-  timeRange: sceneGraph.getTimeRange(queryRunner).state.value,
-});
+function buildErrorData(queryRunner: SceneQueryRunner, errorMsg: string) {
+  const error = new Error(errorMsg);
+
+  logger.error(error);
+
+  return {
+    state: LoadingState.Error,
+    errors: [error],
+    series: [],
+    timeRange: sceneGraph.getTimeRange(queryRunner).state.value,
+  };
+}

--- a/src/pages/ProfilesExplorerView/infrastructure/withPreventInvalidQuery.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/withPreventInvalidQuery.ts
@@ -1,0 +1,30 @@
+import { LoadingState } from '@grafana/data';
+import { sceneGraph, SceneQueryRunner } from '@grafana/scenes';
+
+export function withPreventInvalidQuery(queryRunner: SceneQueryRunner) {
+  queryRunner.addActivationHandler(() => {
+    if (!sceneGraph.interpolate(queryRunner, '$profileMetricId')) {
+      queryRunner.setState({
+        queries: [{ refId: 'null' }],
+        data: buildErrorData(queryRunner, 'Missing profile type!'),
+      });
+      return;
+    }
+
+    if (!sceneGraph.interpolate(queryRunner, '$serviceName')) {
+      queryRunner.setState({
+        queries: [{ refId: 'null' }],
+        data: buildErrorData(queryRunner, 'Missing service name!'),
+      });
+    }
+  });
+
+  return queryRunner;
+}
+
+const buildErrorData = (queryRunner: SceneQueryRunner, errorMsg: string) => ({
+  state: LoadingState.Error,
+  errors: [new Error(errorMsg)],
+  series: [],
+  timeRange: sceneGraph.getTimeRange(queryRunner).state.value,
+});


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/explore-profiles/issues/314

| Before | After |
|  ---   |  ---  |
| <img width="1402" alt="image" src="https://github.com/user-attachments/assets/48872e5b-3663-4d0b-bab6-9f3d21b8750a" /> | <img width="1407" alt="image" src="https://github.com/user-attachments/assets/68632927-6d7d-4deb-9f68-c935073a159e" />|

### 📖 Summary of the changes

This PR adds an activation handler to each query runner being instantiated. The handler is validating the query being passed so that, if either no service name or profile type is defined, no query is executed.

### 🧪 How to test?

See the the linked issue above:
- The Network tab should not show any `query=ds=xxx` (failing) HTTP requests.
- The UI should not show any error icon on the timeseries panels, "No data" should be displayed instead

Be careful to remove the last selected service name from the browser's local storage before testing. Make also sure that the URL parameters have been removed before loading the page.
