### PR TITLE
revert: "perf(*): Lazy load page components"

### DIFF
--- a/src/app/components/Routes/Routes.tsx
+++ b/src/app/components/Routes/Routes.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import { Routes as ReactRouterRoutes, Route } from 'react-router-dom';
 
 import { ROUTES } from '../../../constants';
+import { AdHocView } from '../../../pages/AdHocView/AdHocView';
+import { ProfilesExplorerView } from '../../../pages/ProfilesExplorerView/ProfilesExplorerView';
+import { SettingsView } from '../../../pages/SettingsView/SettingsView';
 import { useNavigationLinksUpdate } from './domain/useNavigationLinksUpdate';
-
-const ProfilesExplorerView = React.lazy(() => import('../../../pages/ProfilesExplorerView/ProfilesExplorerView'));
-const AdHocView = React.lazy(() => import('../../../pages/AdHocView/AdHocView'));
-const SettingsView = React.lazy(() => import('../../../pages/SettingsView/SettingsView'));
 
 export function Routes() {
   useNavigationLinksUpdate();

--- a/src/pages/AdHocView/AdHocView.tsx
+++ b/src/pages/AdHocView/AdHocView.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { AdHocTabs } from './ui/AdHocTabs';
 
-export default function AdHocView() {
+export function AdHocView() {
   return (
     <>
       <PageTitle title="Ad hoc view" />

--- a/src/pages/ProfilesExplorerView/ProfilesExplorerView.tsx
+++ b/src/pages/ProfilesExplorerView/ProfilesExplorerView.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 
 import { SceneProfilesExplorer } from './components/SceneProfilesExplorer/SceneProfilesExplorer';
 
-export default function ProfilesExplorerView() {
+export function ProfilesExplorerView() {
   const sceneProfilesExplorer = useMemo(() => new SceneProfilesExplorer(), []);
 
   return <sceneProfilesExplorer.Component model={sceneProfilesExplorer} />;

--- a/src/pages/SettingsView/SettingsView.tsx
+++ b/src/pages/SettingsView/SettingsView.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { useSettingsView } from './domain/useSettingsView';
 
-export default function SettingsView() {
+export function SettingsView() {
   const styles = useStyles2(getStyles);
   const { data, actions } = useSettingsView();
 


### PR DESCRIPTION
Reverts grafana/explore-profiles#322 after deploying in ops and seeing:

![image](https://github.com/user-attachments/assets/8d57a7cb-d19b-43bb-9251-f4c4a1a563b2)

Will need to check our build pipeline if we want this optimization.