### PR TITLE
feat(GitHubIntegration): Add info tooltip on connect button

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubRepository.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubRepository.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, LinkButton, Spinner, useStyles2 } from '@grafana/ui';
+import { Button, Icon, Spinner, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { useGitHubContext } from './GitHubContextProvider/useGitHubContext';
@@ -45,9 +45,15 @@ export const GitHubRepository = ({ enableIntegration, repository }: GitHubReposi
   // enableIntegration=true, isLoginInProgress=false
   if (!isLoggedIn) {
     return (
-      <LinkButton icon="github" variant="primary" onClick={login}>
+      <Button
+        icon="github"
+        variant="primary"
+        onClick={login}
+        tooltip={`Once connected, the "${repository.name}" repository will only be accessible from this browser session.`}
+        tooltipPlacement="top"
+      >
         Connect to {repository.name}
-      </LinkButton>
+      </Button>
     );
   }
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubRepository.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubRepository.tsx
@@ -49,7 +49,7 @@ export const GitHubRepository = ({ enableIntegration, repository }: GitHubReposi
         icon="github"
         variant="primary"
         onClick={login}
-        tooltip={`Once connected, the "${repository.name}" repository will only be accessible from this browser session.`}
+        tooltip="Once connected, the GitHub code will be accessible only from this browser session."
         tooltipPlacement="top"
       >
         Connect to {repository.name}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/explore-profiles/issues/35

<img width="520" alt="image" src="https://github.com/user-attachments/assets/c56a1aa9-63df-400b-aaa6-f1fa845b9f2e" />

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

`-`
