### PR TITLE
fix(GitHubIntegration): Handle function details for inlining

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/__tests__/convertPprofToFunctionDetails.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/__tests__/convertPprofToFunctionDetails.spec.ts
@@ -27,6 +27,7 @@ function buildJsonPprof(fnName: string, location: Location[]): PprofProfile {
     function: [
       { id: '1', name: '3', systemName: '3', filename: '9', startLine: '6' },
       { id: '2', name: '4', systemName: '4', filename: '10', startLine: '37' },
+      { id: '3', name: '11', systemName: '11', filename: '12', startLine: '1337' },
     ],
     mapping: [
       {
@@ -98,6 +99,8 @@ function buildJsonPprof(fnName: string, location: Location[]): PprofProfile {
       'cpu',
       '/opt/homebrew/Cellar/go/1.21.1/libexec/src/net/http/server.go',
       '/pyroscope/pkg/util/http.go',
+      'iAmALittleInlinedFunction',
+      '/little/func.go',
     ],
     defaultSampleType: '',
   });
@@ -127,6 +130,39 @@ describe('convertPprofToFunctionDetails(fnName, profile)', () => {
       const result = convertPprofToFunctionDetails(
         fnName,
         buildJsonPprof(fnName, [{ id: '1', mappingId: '1', line: [{ functionId: '1', line: '42' }] }])
+      );
+
+      expect(result).toEqual([
+        {
+          name: fnName,
+          version: {
+            git_ref: 'main',
+            repository: 'github.com/grafana/pyroscope',
+          },
+          startLine: 6,
+          fileName: '/opt/homebrew/Cellar/go/1.21.1/libexec/src/net/http/server.go',
+          callSites: expect.any(Map),
+          unit: 'nanoseconds',
+          commit: PLACEHOLDER_COMMIT_DATA,
+        },
+      ]);
+    });
+
+    it('returns function details of function that has inlined another: name, version, startLine, fileName, callSites, unit, commit', () => {
+      const fnName = 'net/http.HandlerFunc.ServeHTTP';
+
+      const result = convertPprofToFunctionDetails(
+        fnName,
+        buildJsonPprof(fnName, [
+          {
+            id: '1',
+            mappingId: '1',
+            line: [
+              { functionId: '3', line: '1339' },
+              { functionId: '1', line: '42' },
+            ],
+          },
+        ])
       );
 
       expect(result).toEqual([
@@ -384,7 +420,7 @@ describe('convertPprofToFunctionDetails(fnName, profile)', () => {
               [134, { cum: 1650000000, flat: 1650000000, line: 134 }],
               [120, { cum: 560000000, flat: 0, line: 120 }],
               [137, { cum: 820000000, flat: 820000000, line: 137 }],
-              [142, { cum: 400000000, flat: 10000000, line: 142 }],
+              [142, { cum: 430000000, flat: 10000000, line: 142 }],
               [149, { cum: 70000000, flat: 70000000, line: 149 }],
               [132, { cum: 340000000, flat: 340000000, line: 132 }],
               [121, { cum: 370000000, flat: 0, line: 121 }],

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/convertPprofToFunctionDetails.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/convertPprofToFunctionDetails.ts
@@ -1,4 +1,4 @@
-import { Function, Location, Mapping, PprofProfile, Sample } from '@shared/types/PprofProfile';
+import { Function, Line, Location, Mapping, PprofProfile, Sample } from '@shared/types/PprofProfile';
 
 import { PLACEHOLDER_COMMIT_DATA } from '../components/GitHubContextProvider/infrastructure/PrivateVcsClient';
 import { CallSiteProps, FunctionDetails } from './types/FunctionDetails';
@@ -21,6 +21,33 @@ const buildDetails = (profile: PprofProfile, func: Function, mapping?: Mapping) 
   };
 };
 
+// sums up the value for a particular callsite
+function addCallSiteValue(details: FunctionDetails, line: Line, value: number, index: number): FunctionDetails {
+  const lineNumber = Number(line.line);
+  const callSite = details.callSites.get(lineNumber) || {
+    line: Number(line.line),
+    flat: 0,
+    cum: 0,
+  };
+
+  // if the function we're interested in is at the leaf node (index=0), we have its flat value...
+  const flat = index === 0 ? value : 0; // value of the location itself
+
+  // ...if not, that's its cum value
+  // locations above the leaf node don't contribute to the sample value (their self is 0)
+  // this is what the API returns
+  const cum = value; // value of the location plus all its descendants
+
+  callSite.flat += flat;
+  callSite.cum += cum;
+
+  details.callSites.set(lineNumber, callSite);
+
+  return details;
+}
+
+// This reimplements functionality simliar to the upstream project:
+// https://github.com/google/pprof/blob/997b0b79cac0f8c2f2566c506212de67a6edc5ff/internal/report/source.go#L318
 function convertSample(
   fnName: string,
   profile: PprofProfile,
@@ -57,28 +84,7 @@ function convertSample(
 
       const details = versions.get(location.mappingId) || buildDetails(profile, func, mappings.get(location.mappingId));
 
-      const lineNumber = Number(line.line);
-
-      const callSite = details.callSites.get(lineNumber) || {
-        line: Number(line.line),
-        flat: 0,
-        cum: 0,
-      };
-
-      // if the function we're interested in is at the leaf node (index=0), we have its flat value...
-      const flat = index === 0 ? Number(sample.value[0]) : 0; // value of the location itself
-
-      // ...if not, that's its cum value
-      // locations above the leaf node don't contribute to the sample value (their self is 0)
-      // this is what the API returns
-      const cum = Number(sample.value[0]); // value of the location plus all its descendants
-
-      callSite.flat += flat;
-      callSite.cum += cum;
-
-      details.callSites.set(lineNumber, callSite);
-
-      versions.set(location.mappingId, details);
+      versions.set(location.mappingId, addCallSiteValue(details, line, Number(sample.value[0]), index));
     });
   });
 }

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/convertPprofToFunctionDetails.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/convertPprofToFunctionDetails.ts
@@ -38,46 +38,48 @@ function convertSample(
       return;
     }
 
-    const func = functions.get(location.line[0].functionId);
-    if (!func) {
-      return;
-    }
+    location.line.forEach((line) => {
+      const func = functions.get(line.functionId);
+      if (!func) {
+        return;
+      }
 
-    if (profile.stringTable[Number(func.name)] !== fnName) {
-      return;
-    }
+      if (profile.stringTable[Number(func.name)] !== fnName) {
+        return;
+      }
 
-    // https://github.com/google/pprof/blob/main/doc/README.md#details
-    if (locationIdSet.has(locationId)) {
-      return;
-    }
+      // https://github.com/google/pprof/blob/main/doc/README.md#details
+      if (locationIdSet.has(locationId)) {
+        return;
+      }
 
-    locationIdSet.add(locationId);
+      locationIdSet.add(locationId);
 
-    const details = versions.get(location.mappingId) || buildDetails(profile, func, mappings.get(location.mappingId));
+      const details = versions.get(location.mappingId) || buildDetails(profile, func, mappings.get(location.mappingId));
 
-    const lineNumber = Number(location.line[0].line);
+      const lineNumber = Number(line.line);
 
-    const callSite = details.callSites.get(lineNumber) || {
-      line: Number(location.line[0].line),
-      flat: 0,
-      cum: 0,
-    };
+      const callSite = details.callSites.get(lineNumber) || {
+        line: Number(line.line),
+        flat: 0,
+        cum: 0,
+      };
 
-    // if the function we're interested in is at the leaf node (index=0), we have its flat value...
-    const flat = index === 0 ? Number(sample.value[0]) : 0; // value of the location itself
+      // if the function we're interested in is at the leaf node (index=0), we have its flat value...
+      const flat = index === 0 ? Number(sample.value[0]) : 0; // value of the location itself
 
-    // ...if not, that's its cum value
-    // locations above the leaf node don't contribute to the sample value (their self is 0)
-    // this is what the API returns
-    const cum = Number(sample.value[0]); // value of the location plus all its descendants
+      // ...if not, that's its cum value
+      // locations above the leaf node don't contribute to the sample value (their self is 0)
+      // this is what the API returns
+      const cum = Number(sample.value[0]); // value of the location plus all its descendants
 
-    callSite.flat += flat;
-    callSite.cum += cum;
+      callSite.flat += flat;
+      callSite.cum += cum;
 
-    details.callSites.set(lineNumber, callSite);
+      details.callSites.set(lineNumber, callSite);
 
-    versions.set(location.mappingId, details);
+      versions.set(location.mappingId, details);
+    });
   });
 }
 

--- a/src/shared/types/PprofProfile.ts
+++ b/src/shared/types/PprofProfile.ts
@@ -22,7 +22,7 @@ export type Location = {
   line: Line[];
 };
 
-type Line = {
+export type Line = {
   functionId: string;
   line: string;
 };


### PR DESCRIPTION
When this code looked up function detail, it only took a look at the first line of a location. A location with multiple lines happens when functions are inlined, the last entry represents the caller into which the preceding entries were inlined into.

This corrects this problem and allows to find function detail in this case as well.

Reported by @colega 
