### PR TITLE
feat(Settings): Add collector settings to settings view

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,8 @@ enableGlobalCache: true
 
 nodeLinker: node-modules
 
+npmScopes:
+  buf:
+    npmRegistryServer: "https://buf.build/gen/npm/v1/"
+
 yarnPath: .yarn/releases/yarn-4.3.1.cjs

--- a/docker-compose.remote.yaml
+++ b/docker-compose.remote.yaml
@@ -12,11 +12,17 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
+      - ./grafana.ini:/etc/grafana/grafana.ini
       - ./dist:/var/lib/grafana/plugins/grafana-pyroscope-app
+      # TODO(simonswine): DO NOT MERGE, this should be a regular app dependency instaed, but first https://github.com/grafana/grafana-collector-app/pull/639 needs to merge.
+      - ../grafana-collector-app/dist:/var/lib/grafana/plugins/grafana-collector-app
+
     environment:
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
+      AGM_API_KEY: $AGM_API_KEY
+      FLEET_API_KEY: $FLEET_API_KEY
 
   qdrant:
     image: qdrant/qdrant

--- a/grafana.ini
+++ b/grafana.ini
@@ -1,0 +1,10 @@
+[navigation.app_sections]
+"grafana-collector-app"="connections 1"
+[feature_toggles]
+"collectorApp"="true"
+"k8sAlloyInstructions"="true"
+"fleetManagement" = "true"
+
+[navigation.app_standalone_pages]
+"/connections/add-new-connection": "connections"
+"/connections/infrastructure": "connections"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
     "version": "standard-changelog && git add CHANGELOG.md"
   },
   "dependencies": {
+    "@buf/pyroscope_api.connectrpc_query-es": "2.0.1-20250124153826-9ae1034efb3f.1",
+    "@bufbuild/protobuf": "^2.2.3",
+    "@connectrpc/connect": "^2.0.1",
+    "@connectrpc/connect-query": "^2.0.1",
+    "@connectrpc/connect-web": "^2.0.1",
     "@emotion/css": "11.10.6",
     "@grafana/data": "11.3.2",
     "@grafana/faro-web-sdk": "^1.10.0",

--- a/samples/provisioning-remote/plugins/app.yaml
+++ b/samples/provisioning-remote/plugins/app.yaml
@@ -28,3 +28,27 @@ apps:
 
     secureJsonData:
       openAIKey: $OPENAI_API_KEY
+
+  - type: grafana-collector-app
+    # <int> Org ID. Default to 1, unless org_name is specified
+    org_id: 1
+    # <string> Org name. Overrides org_id unless org_id not specified
+    org_name: Main Org.
+    # <bool> disable the app. Default to false.
+    disabled: false
+    jsonData:
+      hmPromClusterId: 1
+      hmInstanceId: 18103
+      orgId: '1'
+      region: 'dev-us'
+      stackId: '3726'
+      grafanaComUrl: 'http://host.docker.internal:3040'
+      agmClusterUrl: 'https://fleet-management-dev-001.grafana-dev.net'
+      integrationsApiUrl: 'https://integrations-api-dev.grafana.net'
+      environment: 'dev'
+      isLocalDev: true
+    secureJsonData:
+      # This is a key that is seeded into the Auth API database
+      apiToken: $FLEET_API_KEY
+      # token is not required when running the API locally
+      agmApiKey: $AGM_API_KEY

--- a/src/extensions/IntegrationExtension.tsx
+++ b/src/extensions/IntegrationExtension.tsx
@@ -1,0 +1,7 @@
+export enum CollectorSelectionMode {
+  SelectCollectors = 'select-collectors',
+  MatchCollectors = 'match-collectors',
+}
+export interface IntegrationExtensionProps {
+  collectorSelectionMode?: CollectorSelectionMode;
+}

--- a/src/pages/SettingsView/AddRuleModal.tsx
+++ b/src/pages/SettingsView/AddRuleModal.tsx
@@ -1,0 +1,92 @@
+// a modal for adding a new rule
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, ConfirmModal, Field, FieldSet, Input, Stack, useStyles2 } from '@grafana/ui';
+import React, { useState } from 'react';
+
+type AddRuleModalProps = {
+  onRuleAdd(name: string): void;
+};
+
+const RULE_NAME_ERROR_MESSAGE =
+  'Rule name is not valid, it must consist of one or more alphanumeric characters (a through z lower-case), digits or hyphens.';
+const validateRuleName = (name: string): string | boolean => {
+  const regex = /^[a-z0-9\-]+$/;
+  return regex.test(name) || RULE_NAME_ERROR_MESSAGE;
+};
+
+export function AddRuleModal({ onRuleAdd }: AddRuleModalProps) {
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  const [validName, setValidName] = useState<string | boolean>(true);
+  const [name, setName] = useState<string>();
+
+  const styles = useStyles2(getStyles);
+
+  function onNameChange(event: React.ChangeEvent<HTMLInputElement>) {
+    onNameValue(event.currentTarget.value);
+  }
+  function onNameValue(ruleName: string) {
+    setName(ruleName);
+    setValidName(validateRuleName(ruleName));
+  }
+  return (
+    <Stack gap={5} alignItems="flex-end" justifyContent="end">
+      <Button icon={'plus'} onClick={() => setShowModal(true)}>
+        Add rule
+      </Button>
+      {showModal && (
+        <ConfirmModal
+          isOpen
+          title={`Add new rule`}
+          body={
+            <FieldSet className={styles.ct}>
+              <Field
+                invalid={validName !== true}
+                error={validName !== true ? validName : ''}
+                label="Rule name"
+                className={styles.name}
+              >
+                <Input name="rule_name" onChange={onNameChange} placeholder="Add the rule name" />
+              </Field>
+            </FieldSet>
+          }
+          confirmText={'Add'}
+          confirmButtonVariant="primary"
+          onConfirm={() => {
+            if (name !== undefined) {
+              onRuleAdd(name);
+            }
+            setShowModal(false);
+            setValidName(true);
+            setName(undefined);
+          }}
+          dismissVariant="secondary"
+          onDismiss={() => {
+            setShowModal(false);
+            setValidName(true);
+            setName(undefined);
+          }}
+        />
+      )}
+    </Stack>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    name: css({
+      width: '50%',
+    }),
+    ct: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    }),
+    iconError: css`
+      height: 32px;
+      align-self: center;
+      color: ${theme.colors.error.text};
+    `,
+  };
+}

--- a/src/pages/SettingsView/AddServiceModal.tsx
+++ b/src/pages/SettingsView/AddServiceModal.tsx
@@ -1,0 +1,110 @@
+// a modal for adding a new service
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, Cascader, ConfirmModal, FieldSet, Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import React, { useMemo, useState } from 'react';
+
+import { buildServiceNameCascaderOptions } from '../ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/useBuildServiceNameOptions';
+import { useServiceList } from './domain/useServiceList';
+
+type AddServiceModalProps = {
+  onServiceAdd(name: string, enabled: boolean): void;
+};
+
+const SERVICE_NAME_ERROR_MESSAGE =
+  'Service name is not valid, it must consist of one or more UTF-8 letters (A through Z, both upper- and lower-case), digits, underscores or slashes.';
+const validateServiceName = (name: string): string | boolean => {
+  const regex = /^[A-Za-z0-9_\-\/]+$/;
+  return regex.test(name) || SERVICE_NAME_ERROR_MESSAGE;
+};
+
+export function AddServiceModal({ onServiceAdd }: AddServiceModalProps) {
+  const { isFetching, error, serviceNames } = useServiceList();
+
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  const [validName, setValidName] = useState<string | boolean>(true);
+  const [name, setName] = useState<string>();
+
+  const styles = useStyles2(getStyles);
+
+  const cascaderOptions = useMemo(() => buildServiceNameCascaderOptions(serviceNames), [serviceNames]);
+
+  function onNameValue(serviceName: string) {
+    setName(serviceName);
+    setValidName(validateServiceName(serviceName));
+  }
+  return (
+    <>
+      <Button icon={'plus'} onClick={() => setShowModal(true)}>
+        Add service
+      </Button>
+      {showModal && (
+        <ConfirmModal
+          isOpen
+          title={`Add service`}
+          body={
+            <FieldSet label={'Add new service'} className={styles.ct}>
+              {error && (
+                <Tooltip theme="error" content={error.toString()}>
+                  <Icon className={styles.iconError} name="exclamation-triangle" size="xl" />
+                </Tooltip>
+              )}
+              {!validName && (
+                <Tooltip theme="error" content={validName.toString()}>
+                  <Icon className={styles.iconError} name="exclamation-triangle" size="xl" />
+                </Tooltip>
+              )}
+              {!error && (
+                <Cascader
+                  aria-label="Services list"
+                  width={32}
+                  separator="/"
+                  displayAllSelectedLevels
+                  placeholder={isFetching ? 'Loading services...' : `Select a service (${cascaderOptions.length})`}
+                  options={cascaderOptions}
+                  changeOnSelect={false}
+                  onSelect={onNameValue}
+                />
+              )}
+            </FieldSet>
+          }
+          confirmText={'Add'}
+          confirmButtonVariant="primary"
+          onConfirm={() => {
+            if (name !== undefined) {
+              onServiceAdd(name, false);
+            }
+            setShowModal(false);
+            setValidName(true);
+            setName(undefined);
+          }}
+          dismissVariant="secondary"
+          onDismiss={() => {
+            setShowModal(false);
+            setValidName(true);
+            setName(undefined);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    name: css({
+      width: '50%',
+    }),
+    ct: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    }),
+    iconError: css`
+      height: 32px;
+      align-self: center;
+      color: ${theme.colors.error.text};
+    `,
+  };
+}

--- a/src/pages/SettingsView/CollectorRuleView.tsx
+++ b/src/pages/SettingsView/CollectorRuleView.tsx
@@ -1,0 +1,274 @@
+import { ServiceData } from '@buf/pyroscope_api.bufbuild_es/settings/v1/setting_pb';
+import { css } from '@emotion/css';
+import { dateTimeFormatTimeAgo, GrafanaTheme2 } from '@grafana/data';
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Collapse,
+  Column,
+  Field,
+  Icon,
+  IconButton,
+  Input,
+  InteractiveTable,
+  Stack,
+  Switch,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { CollectorSelectionMode } from '../../extensions/IntegrationExtension';
+import { AddServiceModal } from './AddServiceModal';
+import { DeleteRuleModal } from './DeleteRuleModal';
+import { DeployIntegration } from './DeployIntegration';
+import { CollectorRulesController, getRule } from './domain/useCollectorRulesView';
+
+type ServiceCell = { original: ServiceData };
+type ServiceCellProps = { row: ServiceCell };
+
+function filterServices(services: ServiceData[], filter: string): ServiceData[] {
+  return services.filter((service) => {
+    return service.name?.toLowerCase().includes(filter?.toLocaleLowerCase());
+  });
+}
+
+function formatDate(unixMill: bigint): string {
+  return unixMill > 0 ? dateTimeFormatTimeAgo(new Date(Number(unixMill))) : 'N/A';
+}
+
+type CollectorRuleProps = {
+  controller: CollectorRulesController;
+  ruleName: string;
+  collapsed: boolean;
+};
+
+const deployNeedsSave = 'In order to deploy the rule using fleet management, save the rule first.';
+
+/**
+ * Displays an onboarding dialog instructing how to push data only when data is not present
+ */
+export function CollectorRuleView({ ruleName, controller, collapsed }: CollectorRuleProps) {
+  const { data, actions } = controller;
+
+  const [filter, setFilter] = useState<string>('');
+
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+
+  const [showSettings, setShowSettings] = useState<boolean>(!collapsed);
+
+  const [showDeploy, setShowDeploy] = useState<boolean>(false);
+
+  const rule = useMemo(() => {
+    const r = getRule(data, ruleName);
+    if (r === undefined) {
+      throw new TypeError('the rule is expected to exist');
+    }
+    return {
+      ...r,
+    };
+  }, [data, ruleName]);
+
+  const filteredData = useMemo(() => filterServices(rule.rule.services, filter), [filter, rule]);
+
+  // when settings are modified, collapse the deploy section
+  useEffect(() => {
+    if (rule.modified) {
+      setShowDeploy(false);
+    }
+  }, [rule]);
+
+  function onServiceEnabledChange(service: ServiceData, enabled: boolean) {
+    actions.updateServiceEnabled(ruleName, service.name, enabled);
+  }
+
+  function onServiceAdd(serviceName: string, enabled: boolean) {
+    actions.updateServiceEnabled(ruleName, serviceName, enabled);
+  }
+
+  function onServiceRemove(service: ServiceData) {
+    actions.removeService(ruleName, service.name);
+  }
+
+  function onEBPFCollectionChange(ev: React.ChangeEvent<HTMLInputElement>) {
+    actions.updateEBPFCollectionEnabled(ruleName, ev.currentTarget.checked);
+  }
+
+  function onJavaCollectionChange(ev: React.ChangeEvent<HTMLInputElement>) {
+    actions.updateJavaCollectionEnabled(ruleName, ev.currentTarget.checked);
+    // TODO: Handle
+  }
+
+  const columns: Array<Column<ServiceData>> = [
+    {
+      id: 'name',
+      sortType: 'string',
+      header: 'Name',
+    },
+    {
+      id: 'enabled',
+      header: 'Active',
+      sortType: (r1: ServiceCell, r2: ServiceCell) => Number(r2.original.enabled) - Number(r1.original.enabled),
+      cell: ({ row: { original: service } }: ServiceCellProps) => (
+        <Switch
+          value={service.enabled}
+          onChange={(ev: React.FormEvent<HTMLInputElement>) => {
+            onServiceEnabledChange(service, ev.currentTarget.checked);
+          }}
+        />
+      ),
+    },
+    {
+      id: 'actions',
+      header: '',
+      cell: ({ row: { original: service } }: ServiceCellProps) => (
+        <div className={styles.editButtons}>
+          <Tooltip content="Delete">
+            <Button
+              icon={'trash-alt'}
+              variant={'secondary'}
+              fill="text"
+              onClick={() => {
+                onServiceRemove(service);
+              }}
+            />
+          </Tooltip>
+        </div>
+      ),
+    },
+  ];
+
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Card>
+      <Card.Heading>{ruleName}</Card.Heading>
+      <Card.Description>
+        <Collapse isOpen={showSettings} onToggle={() => setShowSettings(!showSettings)} label="Configure rule">
+          <Stack grow={1} direction={'column'}>
+            <Field
+              label="eBPF Collection"
+              description="Enable Profile collection using eBPF profiler."
+              className={styles.collectorRuleField}
+            >
+              <Checkbox name="ebpf-collection" onChange={onEBPFCollectionChange} value={rule.rule.ebpf?.enabled} />
+            </Field>
+            <Field
+              label="Java Collection"
+              description="Enable Profile collection using Java process attachment."
+              className={styles.collectorRuleField}
+            >
+              <Checkbox name="java-collection" onChange={onJavaCollectionChange} value={rule.rule.java?.enabled} />
+            </Field>
+            <Stack gap={2} alignItems="flex-end" justifyContent="end">
+              <div className={styles.search}>
+                <Input
+                  onChange={(ev: React.FormEvent<HTMLInputElement>) => setFilter(ev.currentTarget.value)}
+                  prefix={<Icon name="search" />}
+                  placeholder="Search by service name"
+                  aria-label="Search services"
+                />
+                <AddServiceModal onServiceAdd={onServiceAdd} />
+              </div>
+            </Stack>
+            <Stack gap={2}>
+              <InteractiveTable<ServiceData>
+                data={filteredData}
+                pageSize={100}
+                getRowId={(service: ServiceData) => service.name}
+                columns={columns}
+              />
+            </Stack>
+          </Stack>
+        </Collapse>
+        <Collapse
+          label={
+            <Tooltip content={rule.modified ? deployNeedsSave : 'Deploy the rule using fleet management'}>
+              <span>Deploy rule</span>
+            </Tooltip>
+          }
+          isOpen={showDeploy}
+          onToggle={() => setShowDeploy(!showDeploy)}
+        >
+          <p>Panel data</p>
+          <Stack grow={1} direction={'column'}>
+            {rule.modified && <Alert title={deployNeedsSave} />}
+            {!rule.modified && (
+              <DeployIntegration
+                collectorSelectionMode={CollectorSelectionMode.MatchCollectors}
+                name={`pyroscope-collection-${ruleName}`}
+                configuration={rule.rule.configuration}
+                version="v1"
+              />
+            )}
+          </Stack>
+        </Collapse>
+      </Card.Description>
+      <Card.Meta>
+        {[`${rule.rule.services.length} services`, `Last updated: ${formatDate(rule.rule.lastUpdated)}`]}
+      </Card.Meta>
+      <Card.Actions>
+        <Button
+          variant={rule.modified ? 'primary' : 'secondary'}
+          disabled={!rule.modified}
+          onClick={() => {
+            setIsSaving(true);
+            actions.saveRule(ruleName);
+            setIsSaving(false);
+          }}
+          type={'submit'}
+        >
+          {rule.modified ? (isSaving ? 'Saving...' : 'Save') : 'Saved'}
+        </Button>
+        <Button
+          disabled={rule.modified}
+          onClick={() => {
+            setShowDeploy(true);
+          }}
+          type={'submit'}
+        >
+          Deploy
+        </Button>
+      </Card.Actions>
+      <Card.SecondaryActions>
+        {/* TODO(simonswine): Unsure if this is the best way of doing this */}
+        <IconButton
+          onClick={(e) => {
+            e.preventDefault();
+            window.location.href = '/a/grafana-collector-app/fleet-management?tab=remote-configuration';
+          }}
+          key="link"
+          name="link"
+          tooltip="Open this rule in fleet management"
+        />
+        <DeleteRuleModal
+          ruleName={ruleName}
+          onRuleDelete={(ruleName: string) => controller.actions.deleteRule(ruleName)}
+        />
+      </Card.SecondaryActions>
+    </Card>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    ct: css({}),
+    collectorRule: css({}),
+    collectorRuleField: css({
+      width: '50%',
+    }),
+    editButtons: css({
+      display: 'flex',
+      columnGap: theme.spacing(0.5),
+      justifyContent: 'flex-end',
+    }),
+    search: css({
+      width: '100%',
+      marginBottom: theme.spacing(2),
+      display: 'flex',
+      columnGap: theme.spacing(1),
+    }),
+  };
+}

--- a/src/pages/SettingsView/CollectorSettingsView.tsx
+++ b/src/pages/SettingsView/CollectorSettingsView.tsx
@@ -1,0 +1,40 @@
+import { Space } from '@grafana/ui';
+import { displayError } from '@shared/domain/displayStatus';
+import React, { useMemo, useState } from 'react';
+
+import { AddRuleModal } from './AddRuleModal';
+import { CollectorRuleView } from './CollectorRuleView';
+import { useCollectorRulesView } from './domain/useCollectorRulesView';
+
+export function CollectorSettingsView() {
+  const controller = useCollectorRulesView();
+
+  const { isFetching, data, fetchError } = controller;
+
+  const [ruleUncollapsed, setRuleUncollapsed] = useState<string | undefined>(undefined);
+
+  const ruleNames = useMemo(() => data.data.map((r) => r.rule.name), [data]);
+
+  if (fetchError) {
+    displayError(fetchError, [
+      'Error while retrieving the collector plugin settings!',
+      'Please try to reload the page, sorry for the inconvenience.',
+    ]);
+  }
+
+  return (
+    <>
+      <AddRuleModal
+        onRuleAdd={(ruleName: string) => {
+          setRuleUncollapsed(ruleName);
+          controller.actions.addRule(ruleName);
+        }}
+      />
+      <Space v={2} />
+      {!isFetching &&
+        ruleNames.map((name) => (
+          <CollectorRuleView key={name} controller={controller} ruleName={name} collapsed={ruleUncollapsed !== name} />
+        ))}
+    </>
+  );
+}

--- a/src/pages/SettingsView/DeleteRuleModal.tsx
+++ b/src/pages/SettingsView/DeleteRuleModal.tsx
@@ -1,0 +1,39 @@
+import { ConfirmModal, IconButton } from '@grafana/ui';
+import React, { useState } from 'react';
+
+type Props = {
+  ruleName: string;
+  onRuleDelete: (ruleName: string) => Promise<void>;
+};
+
+export const DeleteRuleModal = ({ onRuleDelete, ruleName }: Props) => {
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  const body = (
+    <>
+      <div>
+        Deleting this rule is permanent and cannot be undone. Existing deployed pipelines will remain in the
+        fleet-management app.
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      <IconButton key="delete" onClick={() => setShowModal(true)} name="trash-alt" tooltip="Delete this rule" />
+      <ConfirmModal
+        isOpen={showModal}
+        title={`Delete rule '${ruleName}'`}
+        body={body}
+        confirmText="Delete"
+        onConfirm={() => {
+          onRuleDelete(ruleName);
+          setShowModal(false);
+        }}
+        onDismiss={() => setShowModal(false)}
+        confirmButtonVariant="destructive"
+        dismissVariant="secondary"
+      />
+    </>
+  );
+};

--- a/src/pages/SettingsView/DeployIntegration.tsx
+++ b/src/pages/SettingsView/DeployIntegration.tsx
@@ -1,0 +1,47 @@
+import { usePluginComponent } from '@grafana/runtime';
+import { Alert, LoadingPlaceholder } from '@grafana/ui';
+import React, { FC } from 'react';
+
+import { CollectorSelectionMode } from '../../extensions/IntegrationExtension';
+
+export const DeployIntegration: FC<{
+  name: string;
+  version: string;
+  configuration: string;
+  collectorSelectionMode?: CollectorSelectionMode;
+}> = ({ name, collectorSelectionMode, version, configuration }) => {
+  const { component: DeployIntegrationComponent, isLoading } = usePluginComponent<{
+    code: Array<{ block: string; platform: string }>;
+    name: String;
+    version: string;
+    collectorSelectionMode?: CollectorSelectionMode;
+  }>('grafana-collector-app/deploy-integration/v1');
+
+  const showLoadingBar = false;
+
+  const code = [
+    {
+      block: configuration,
+      platform: 'linux',
+    },
+  ];
+
+  if (isLoading || showLoadingBar) {
+    return <LoadingPlaceholder text="loading..."></LoadingPlaceholder>;
+  } else if (DeployIntegrationComponent) {
+    return (
+      <DeployIntegrationComponent
+        code={code}
+        name={name}
+        collectorSelectionMode={collectorSelectionMode}
+        version={version}
+      />
+    );
+  }
+
+  return (
+    <Alert title="" severity="warning">
+      Deploy integration UI is not available. Please check if you run the latest Grafana on this instance.
+    </Alert>
+  );
+};

--- a/src/pages/SettingsView/SettingsView.tsx
+++ b/src/pages/SettingsView/SettingsView.tsx
@@ -1,126 +1,46 @@
+import { TransportProvider } from '@connectrpc/connect-query';
+import { createConnectTransport } from '@connectrpc/connect-web';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, FieldSet, InlineField, InlineFieldRow, InlineSwitch, Input, useStyles2 } from '@grafana/ui';
-import { displayError } from '@shared/domain/displayStatus';
+import { Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
+import { ApiClient } from '@shared/infrastructure/http/ApiClient';
 import { PageTitle } from '@shared/ui/PageTitle';
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React, { useState } from 'react';
 
-import { useSettingsView } from './domain/useSettingsView';
+import { CollectorSettingsView } from './CollectorSettingsView';
+import { UISettingsView } from './UISettingsView';
+
+const queryClient = new QueryClient();
 
 export default function SettingsView() {
   const styles = useStyles2(getStyles);
-  const { data, actions } = useSettingsView();
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
 
-  if (data.fetchError) {
-    displayError(data.fetchError, [
-      'Error while retrieving the plugin settings!',
-      'Please try to reload the page, sorry for the inconvenience.',
-    ]);
-  }
-
-  function onSubmit(event: React.FormEvent) {
-    event.preventDefault();
-    actions.saveSettings();
-  }
+  const finalTransport = createConnectTransport({
+    baseUrl: ApiClient.getBaseUrl(),
+  });
 
   return (
-    <>
-      <PageTitle title="Profiles settings (tenant)" />
-      <form className={styles.settingsForm} onSubmit={onSubmit}>
-        <>
-          <FieldSet label="Flame graph" data-testid="flamegraph-settings">
-            <InlineFieldRow>
-              <InlineField label="Collapsed flame graphs" labelWidth={24}>
-                <InlineSwitch
-                  label="Toggle collapsed flame graphs"
-                  name="collapsed-flamegraphs"
-                  value={data.collapsedFlamegraphs}
-                  onChange={actions.toggleCollapsedFlamegraphs}
-                />
-              </InlineField>
-            </InlineFieldRow>
-            <InlineFieldRow>
-              <InlineField label="Maximum number of nodes" tooltip="" labelWidth={24}>
-                <Input name="max-nodes" type="number" min="1" value={data.maxNodes} onChange={actions.updateMaxNodes} />
-              </InlineField>
-            </InlineFieldRow>
-          </FieldSet>
-          <FieldSet label="Function details" data-testid="function-details-settings">
-            <InlineFieldRow>
-              <InlineField
-                label="Enable function details"
-                labelWidth={24}
-                tooltip={
-                  <div className={styles.tooltip}>
-                    <p>
-                      The function details feature enables mapping of resource usage to lines of source code. If the
-                      GitHub integration is configured, then the source code will be downloaded from GitHub.
-                    </p>
-                    <p>
-                      <a
-                        href="https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/pyroscope-github-integration/"
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
-                        Learn more
-                      </a>
-                    </p>
-                  </div>
-                }
-                interactive
-              >
-                <InlineSwitch
-                  label="Toggle function details"
-                  name="function-details-feature"
-                  value={data.enableFunctionDetails}
-                  onChange={actions.toggleEnableFunctionDetails}
-                />
-              </InlineField>
-            </InlineFieldRow>
-          </FieldSet>
-
-          <div className={styles.buttons}>
-            <Button variant="primary" type="submit">
-              Save settings
-            </Button>
-            <Button variant="secondary" onClick={actions.goBack} aria-label="Back to Explore Profiles">
-              Back to Explore Profiles
-            </Button>
-          </div>
-        </>
-      </form>
-    </>
+    <TransportProvider transport={finalTransport}>
+      <QueryClientProvider client={queryClient}>
+        <PageTitle title="Profiles settings (tenant)" />
+        <TabsBar>
+          <Tab label=" UI" active={activeTabIndex === 0} onChangeTab={() => setActiveTabIndex(0)} />
+          <Tab label=" Collection Rules" active={activeTabIndex === 1} onChangeTab={() => setActiveTabIndex(1)} />
+        </TabsBar>
+        <TabContent className={styles.tabContent}>
+          {activeTabIndex === 0 && <UISettingsView />}
+          {activeTabIndex === 1 && <CollectorSettingsView />}
+        </TabContent>
+      </QueryClientProvider>
+    </TransportProvider>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  settingsForm: css`
-    & > fieldset {
-      border: 0 none;
-      border-bottom: 1px solid ${theme.colors.border.weak};
-      padding-left: 0;
-    }
-
-    & > fieldset > legend {
-      font-size: ${theme.typography.h4.fontSize};
-    }
-  `,
-  buttons: css`
-    display: flex;
-    gap: ${theme.spacing(1)};
-  `,
-  tooltip: css`
-    p {
-      margin: ${theme.spacing(1)};
-    }
-
-    a {
-      color: ${theme.colors.text.link};
-    }
-
-    em {
-      font-style: normal;
-      font-weight: ${theme.typography.fontWeightBold};
-    }
+  tabContent: css`
+    padding: ${theme.spacing(2)};
+    margin: ${theme.spacing(2)};
   `,
 });

--- a/src/pages/SettingsView/UISettingsView.tsx
+++ b/src/pages/SettingsView/UISettingsView.tsx
@@ -1,0 +1,124 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, FieldSet, InlineField, InlineFieldRow, InlineSwitch, Input, useStyles2 } from '@grafana/ui';
+import { displayError } from '@shared/domain/displayStatus';
+import React from 'react';
+
+import { useSettingsView } from './domain/useSettingsView';
+
+export function UISettingsView() {
+  const styles = useStyles2(getStyles);
+  const { data, actions } = useSettingsView();
+
+  if (data.fetchError) {
+    displayError(data.fetchError, [
+      'Error while retrieving the plugin settings!',
+      'Please try to reload the page, sorry for the inconvenience.',
+    ]);
+  }
+
+  function onSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    actions.saveSettings();
+  }
+
+  return (
+    <>
+      <form className={styles.settingsForm} onSubmit={onSubmit}>
+        <>
+          <FieldSet label="Flame graph" data-testid="flamegraph-settings">
+            <InlineFieldRow>
+              <InlineField label="Collapsed flame graphs" labelWidth={24}>
+                <InlineSwitch
+                  label="Toggle collapsed flame graphs"
+                  name="collapsed-flamegraphs"
+                  value={data.collapsedFlamegraphs}
+                  onChange={actions.toggleCollapsedFlamegraphs}
+                />
+              </InlineField>
+            </InlineFieldRow>
+            <InlineFieldRow>
+              <InlineField label="Maximum number of nodes" tooltip="" labelWidth={24}>
+                <Input name="max-nodes" type="number" min="1" value={data.maxNodes} onChange={actions.updateMaxNodes} />
+              </InlineField>
+            </InlineFieldRow>
+          </FieldSet>
+          <FieldSet label="Function details" data-testid="function-details-settings">
+            <InlineFieldRow>
+              <InlineField
+                label="Enable function details"
+                labelWidth={24}
+                tooltip={
+                  <div className={styles.tooltip}>
+                    <p>
+                      The function details feature enables mapping of resource usage to lines of source code. If the
+                      GitHub integration is configured, then the source code will be downloaded from GitHub.
+                    </p>
+                    <p>
+                      <a
+                        href="https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/pyroscope-github-integration/"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      >
+                        Learn more
+                      </a>
+                    </p>
+                  </div>
+                }
+                interactive
+              >
+                <InlineSwitch
+                  label="Toggle function details"
+                  name="function-details-feature"
+                  value={data.enableFunctionDetails}
+                  onChange={actions.toggleEnableFunctionDetails}
+                />
+              </InlineField>
+            </InlineFieldRow>
+          </FieldSet>
+
+          <div className={styles.buttons}>
+            <Button variant="primary" type="submit">
+              Save settings
+            </Button>
+            <Button variant="secondary" onClick={actions.goBack} aria-label="Back to Explore Profiles">
+              Back to Explore Profiles
+            </Button>
+          </div>
+        </>
+      </form>
+    </>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  settingsForm: css`
+    & > fieldset {
+      border: 0 none;
+      border-bottom: 1px solid ${theme.colors.border.weak};
+      padding-left: 0;
+    }
+
+    & > fieldset > legend {
+      font-size: ${theme.typography.h4.fontSize};
+    }
+  `,
+  buttons: css`
+    display: flex;
+    gap: ${theme.spacing(1)};
+  `,
+  tooltip: css`
+    p {
+      margin: ${theme.spacing(1)};
+    }
+
+    a {
+      color: ${theme.colors.text.link};
+    }
+
+    em {
+      font-style: normal;
+      font-weight: ${theme.typography.fontWeightBold};
+    }
+  `,
+});

--- a/src/pages/SettingsView/domain/__tests__/useCollectorRulesView.spec.ts
+++ b/src/pages/SettingsView/domain/__tests__/useCollectorRulesView.spec.ts
@@ -1,0 +1,248 @@
+import { CollectorRules } from '@shared/infrastructure/settings/CollectorRules';
+import { useFetchCollectorRules } from '@shared/infrastructure/settings/useFetchCollectorRules';
+import { act, renderHook } from '@testing-library/react';
+
+import { useCollectorRulesView } from '../useCollectorRulesView';
+
+// appEvents dependency
+const appEvents = {
+  publish: jest.fn(),
+};
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: () => appEvents,
+}));
+
+const noRules = () => [] as CollectorRules;
+
+const sampleRule = () =>
+  [
+    {
+      rule: {
+        name: 'existing-rule',
+        services: [
+          { name: 'my-service', enabled: true },
+          { name: 'other-service', enabled: false },
+        ],
+        java: { enabled: true },
+        ebpf: { enabled: false },
+      },
+      modified: false,
+    },
+  ] as CollectorRules;
+
+jest.mock('@shared/infrastructure/settings/useFetchCollectorRules', () => ({
+  useFetchCollectorRules: jest.fn(),
+}));
+const mockRules = useFetchCollectorRules as jest.Mock;
+
+// tests
+describe('useCollectorRulesView()', () => {
+  describe('without rules stored', () => {
+    beforeEach(() => {
+      mockRules.mockReturnValue({
+        error: null,
+        rules: noRules(),
+      });
+    });
+    it('returns an object with "data" and "actions" fields', () => {
+      const { result } = renderHook(() => useCollectorRulesView());
+
+      expect(result.current.data).toEqual({ data: [] });
+      expect(result.current.fetchError).toEqual(null);
+      expect(result.current.actions.getRule).toEqual(expect.any(Function));
+    });
+
+    describe('actions.addRule()', () => {
+      it('adds the expected rule with defaults', () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { data, actions } = result.current;
+
+        expect(data.data.length).toBe(0);
+
+        act(() => {
+          actions.addRule('my-rule');
+        });
+
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0]).toStrictEqual({
+          rule: {
+            name: 'my-rule',
+            services: [],
+            java: { enabled: true },
+            ebpf: { enabled: true },
+          },
+          modified: true,
+        });
+      });
+    });
+  });
+
+  describe('with rules stored', () => {
+    beforeEach(() => {
+      mockRules.mockReturnValue({
+        error: null,
+        rules: sampleRule(),
+      });
+    });
+    it('returns the existing rule', () => {
+      const { result } = renderHook(() => useCollectorRulesView());
+
+      expect(result.current.data.data.length).toEqual(1);
+      expect(result.current.fetchError).toEqual(null);
+      expect(result.current.actions.getRule('existing-rule')).toEqual({
+        modified: false,
+        rule: {
+          java: { enabled: true },
+          ebpf: { enabled: false },
+          name: 'existing-rule',
+          services: [
+            { enabled: true, name: 'my-service' },
+            { enabled: false, name: 'other-service' },
+          ],
+        },
+      });
+    });
+    describe('actions.updateServiceEnabled()', () => {
+      it('adds new enabled service', () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { actions } = result.current;
+
+        act(() => {
+          actions.updateServiceEnabled('existing-rule', 'my-new-service', true);
+        });
+
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0].rule.services).toEqual([
+          { name: 'my-service', enabled: true },
+          { name: 'other-service', enabled: false },
+          { name: 'my-new-service', enabled: true },
+        ]);
+      });
+      it('updates existing services', () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { actions } = result.current;
+
+        act(() => {
+          actions.updateServiceEnabled('existing-rule', 'my-service', false);
+          actions.updateServiceEnabled('existing-rule', 'other-service', true);
+        });
+
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0].rule.services).toEqual([
+          { name: 'my-service', enabled: false },
+          { name: 'other-service', enabled: true },
+        ]);
+      });
+    });
+    describe('actions.updateEBPFCollectionEnabled()', () => {
+      it('it enables ebpf', () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { actions } = result.current;
+
+        act(() => {
+          actions.updateEBPFCollectionEnabled('existing-rule', true);
+        });
+
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0].rule.ebpf).toEqual({ enabled: true });
+      });
+      it('it disables ebpf', () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { actions } = result.current;
+
+        act(() => {
+          actions.updateEBPFCollectionEnabled('existing-rule', false);
+        });
+
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0].rule.ebpf).toEqual({ enabled: false });
+      });
+    });
+    describe('actions.updateJavaCollectionEnabled()', () => {
+      it('it enables java', () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { actions } = result.current;
+
+        act(() => {
+          actions.updateJavaCollectionEnabled('existing-rule', true);
+        });
+
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0].rule.java).toEqual({ enabled: true });
+      });
+      it('it disables java', () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { actions } = result.current;
+
+        act(() => {
+          actions.updateJavaCollectionEnabled('existing-rule', false);
+        });
+
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0].rule.java).toEqual({ enabled: false });
+      });
+    });
+    describe('actions.saveRule()', () => {
+      const mockMutate = jest.fn();
+      beforeEach(() => {
+        mockMutate.mockReset();
+        mockMutate.mockImplementation((...args) => {
+          mockMutate.mock.calls.push(args);
+          return {
+            configuration: '// mock',
+            generation: 1234,
+            lastUpdated: 666,
+          };
+        });
+        mockRules.mockReturnValue({
+          error: null,
+          rules: sampleRule(),
+          mutate: mockMutate,
+        });
+      });
+      it('it saves a modified rule', async () => {
+        const { result } = renderHook(() => useCollectorRulesView());
+
+        const { actions } = result.current;
+
+        await act(async () => {
+          // add new service
+          actions.updateServiceEnabled('existing-rule', 'my-new-service', true);
+
+          // toggle my service
+          actions.updateServiceEnabled('existing-rule', 'my-service', false);
+
+          // toggle collection from java to ebpf
+          actions.updateEBPFCollectionEnabled('existing-rule', true);
+          actions.updateJavaCollectionEnabled('existing-rule', false);
+
+          await actions.saveRule('existing-rule');
+        });
+
+        expect(mockMutate).toHaveBeenCalledWith({
+          name: 'existing-rule',
+          ebpf: { enabled: true },
+          java: { enabled: false },
+          services: [
+            { name: 'my-service', enabled: false },
+            { name: 'other-service', enabled: false },
+            { name: 'my-new-service', enabled: true },
+          ],
+        });
+        expect(result.current.data.data.length).toBe(1);
+        expect(result.current.data.data[0].rule.configuration).toEqual('// mock');
+        expect(result.current.data.data[0].rule.generation).toEqual(1234);
+        expect(result.current.data.data[0].rule.lastUpdated).toEqual(666);
+      });
+    });
+  });
+});

--- a/src/pages/SettingsView/domain/useCollectorRulesView.ts
+++ b/src/pages/SettingsView/domain/useCollectorRulesView.ts
@@ -1,0 +1,202 @@
+import {
+  DeleteCollectionRuleRequest,
+  EBPFSettings,
+  GetCollectionRuleResponse,
+  JavaSettings,
+  ServiceData,
+  UpsertCollectionRuleRequest,
+} from '@buf/pyroscope_api.bufbuild_es/settings/v1/setting_pb';
+import { displayError, displaySuccess } from '@shared/domain/displayStatus';
+import { CollectorRule, CollectorRulesState } from '@shared/infrastructure/settings/CollectorRules';
+import { useFetchCollectorRules } from '@shared/infrastructure/settings/useFetchCollectorRules';
+import { useEffect, useState } from 'react';
+
+export interface CollectorRulesController {
+  actions: CollectorRulesActions;
+  data: CollectorRulesState;
+  isFetching: boolean;
+  fetchError: Error | null;
+}
+
+export interface CollectorRulesActions {
+  addRule: (ruleName: string) => void;
+  getRule: (ruleName: string) => CollectorRule | undefined;
+  saveRule: (ruleName: string) => Promise<void>;
+  deleteRule: (ruleName: string) => Promise<void>;
+  updateServiceEnabled: (ruleName: string, serviceName: string, enabled: boolean) => void;
+  removeService: (ruleName: string, serviceName: string) => void;
+  updateJavaCollectionEnabled: (ruleName: string, enabled: boolean) => void;
+  updateEBPFCollectionEnabled: (ruleName: string, enabled: boolean) => void;
+}
+
+export function getRule(s: CollectorRulesState, ruleName: string): CollectorRule | undefined {
+  return s.data.find((rule) => rule.rule.name === ruleName);
+}
+export function useCollectorRulesView() {
+  const { rules, isFetching, error: fetchError, mutate, mutateDelete } = useFetchCollectorRules();
+
+  const [currentState, setCurrentState] = useState<CollectorRulesState>({
+    data: rules ?? [],
+  } as CollectorRulesState);
+
+  useEffect(() => {
+    if (rules) {
+      setCurrentState({
+        data: [...rules],
+      });
+    }
+  }, [rules]);
+
+  return {
+    isFetching,
+    fetchError,
+    data: { ...currentState },
+    actions: {
+      getRule(ruleName: string) {
+        return getRule(currentState, ruleName);
+      },
+      addRule(ruleName: string) {
+        const rule = this.getRule(ruleName);
+        // rule already exists
+        if (rule) {
+          // TODO: Needs error
+          return;
+        }
+
+        setCurrentState({
+          ...currentState,
+          data: [
+            ...currentState.data,
+            {
+              rule: {
+                name: ruleName,
+                services: [] as ServiceData[],
+                java: { enabled: true } as JavaSettings,
+                ebpf: { enabled: true } as EBPFSettings,
+              } as GetCollectionRuleResponse,
+              modified: true,
+            },
+          ],
+        });
+      },
+      async saveRule(ruleName: string) {
+        const rule = this.getRule(ruleName);
+        if (!rule) {
+          return;
+        }
+
+        try {
+          const res = await mutate({
+            name: rule.rule.name,
+            ebpf: rule.rule.ebpf,
+            java: rule.rule.java,
+            services: rule.rule.services,
+          } as UpsertCollectionRuleRequest);
+
+          setCurrentState({
+            ...currentState,
+            data: currentState.data.map((r) =>
+              r.rule.name === ruleName
+                ? {
+                    ...rule,
+                    rule: {
+                      ...rule.rule,
+                      lastUpdated: res.lastUpdated,
+                      configuration: res.configuration,
+                      generation: res.generation,
+                    },
+                    modified: false,
+                  }
+                : r
+            ),
+          });
+
+          displaySuccess(['Rule successfully saved!']);
+        } catch (error) {
+          displayError(error as Error, [
+            'Error while saving the collecor rule!',
+            'Please try again later, sorry for the inconvenience.',
+          ]);
+        }
+      },
+      async deleteRule(ruleName: string) {
+        const rule = this.getRule(ruleName);
+        if (!rule) {
+          return;
+        }
+
+        try {
+          // only delete if it has been saved
+          if (rule.rule.lastUpdated > 0) {
+            await mutateDelete({
+              name: rule.rule.name,
+            } as DeleteCollectionRuleRequest);
+          }
+          setCurrentState({
+            ...currentState,
+            data: currentState.data.filter((r) => r.rule.name !== ruleName),
+          });
+          displaySuccess(['Rule successfully deleted!']);
+        } catch (error) {
+          displayError(error as Error, [
+            'Error while deleting the collector rule!',
+            'Please try again later, sorry for the inconvenience.',
+          ]);
+        }
+      },
+      updateServiceEnabled(ruleName: string, serviceName: string, enabled: boolean) {
+        const rule = this.getRule(ruleName);
+        if (!rule) {
+          return;
+        }
+        const service = rule.rule.services.find((service) => service.name === serviceName);
+        if (!service) {
+          rule.rule.services.push({ name: serviceName, enabled } as ServiceData);
+        } else {
+          service.enabled = enabled;
+        }
+        rule.modified = true;
+        setCurrentState({
+          ...currentState,
+          data: currentState.data.map((r) => (r.rule.name === ruleName ? rule : r)),
+        });
+      },
+      removeService(ruleName: string, serviceName: string) {
+        const rule = this.getRule(ruleName);
+        if (!rule) {
+          return;
+        }
+        rule.rule.services = rule.rule.services.filter((service) => service.name !== serviceName);
+        rule.modified = true;
+        setCurrentState({
+          ...currentState,
+          data: currentState.data.map((r) => (r.rule.name === ruleName ? rule : r)),
+        });
+      },
+      updateEBPFCollectionEnabled(ruleName: string, enabled: boolean) {
+        const rule = this.getRule(ruleName);
+        if (!rule) {
+          return;
+        }
+        rule.rule.ebpf = { ...(rule.rule.ebpf || ({} as EBPFSettings)), enabled: enabled };
+        rule.modified = true;
+        setCurrentState({
+          ...currentState,
+          data: currentState.data.map((r) => (r.rule.name === ruleName ? rule : r)),
+        });
+      },
+      updateJavaCollectionEnabled(ruleName: string, enabled: boolean) {
+        const rule = this.getRule(ruleName);
+        if (!rule) {
+          return;
+        }
+        rule.rule.java = { ...(rule.rule.java || ({} as JavaSettings)), enabled: enabled };
+        rule.modified = true;
+        setCurrentState({
+          ...currentState,
+          data: currentState.data.map((r) => (r.rule.name === ruleName ? rule : r)),
+        });
+      },
+    } as CollectorRulesActions,
+  } as CollectorRulesController;
+}

--- a/src/pages/SettingsView/domain/useServiceList.ts
+++ b/src/pages/SettingsView/domain/useServiceList.ts
@@ -1,0 +1,27 @@
+import { QuerierService } from '@buf/pyroscope_api.bufbuild_es/querier/v1/querier_pb';
+import { useQuery } from '@connectrpc/connect-query';
+import { useEffect, useMemo, useState } from 'react';
+
+export function useServiceList() {
+  const now = useMemo(() => Date.now(), []);
+
+  const { isFetching, error, data } = useQuery(QuerierService.method.labelValues, {
+    name: 'service_name',
+    start: BigInt(now - 3600 * 1000),
+    end: BigInt(now),
+  });
+
+  const [serviceNames, setServiceNames] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (data) {
+      setServiceNames(data?.names ?? []);
+    }
+  }, [data]);
+
+  return {
+    isFetching,
+    error: error,
+    serviceNames: serviceNames,
+  };
+}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -8,7 +8,10 @@
   "preload": true,
   "dependencies": {
     "grafanaDependency": ">=11.3.2",
-    "plugins": []
+    "plugins": [],
+    "extensions": {
+      "exposedComponents": ["grafana-collector-app/deploy-integration/v1"]
+    }
   },
   "info": {
     "keywords": ["app", "pyroscope", "profiling", "explore", "profiles", "performance"],

--- a/src/shared/infrastructure/settings/CollectorRules.ts
+++ b/src/shared/infrastructure/settings/CollectorRules.ts
@@ -1,0 +1,12 @@
+import { GetCollectionRuleResponse } from '@buf/pyroscope_api.bufbuild_es/settings/v1/setting_pb';
+
+export type CollectorRule = {
+  rule: GetCollectionRuleResponse;
+  modified: boolean;
+};
+
+export type CollectorRules = CollectorRule[];
+
+export type CollectorRulesState = {
+  data: CollectorRules;
+};

--- a/src/shared/infrastructure/settings/useFetchCollectorRules.ts
+++ b/src/shared/infrastructure/settings/useFetchCollectorRules.ts
@@ -1,0 +1,53 @@
+import {
+  CollectionRulesService,
+  DeleteCollectionRuleRequest,
+  DeleteCollectionRuleResponse,
+  GetCollectionRuleResponse,
+  UpsertCollectionRuleRequest,
+} from '@buf/pyroscope_api.bufbuild_es/settings/v1/setting_pb';
+import { useMutation, useQuery } from '@connectrpc/connect-query';
+import { useMemo } from 'react';
+
+import { CollectorRule, CollectorRules } from './CollectorRules';
+
+type FetchParams = {};
+
+type FetchResponse = {
+  isFetching: boolean;
+  error: Error | null;
+  rules?: CollectorRules;
+  mutate: (rule: UpsertCollectionRuleRequest) => Promise<GetCollectionRuleResponse>;
+  mutateDelete: (rule: DeleteCollectionRuleRequest) => Promise<DeleteCollectionRuleResponse>;
+};
+
+/**
+ * Fetches the plugin settings and, if none/only some have been stored previously, returns adequate default values for the rest of the application
+ */
+export function useFetchCollectorRules({}: FetchParams = {}): FetchResponse {
+  const { isFetching, error, data } = useQuery(CollectionRulesService.method.listCollectionRules, {});
+
+  const rules = useMemo(
+    () =>
+      data
+        ? data.rules.map((r) => {
+            return {
+              rule: r,
+              modified: false,
+            } as CollectorRule;
+          })
+        : undefined,
+    [data]
+  );
+
+  const { mutateAsync: mutate } = useMutation(CollectionRulesService.method.upsertCollectionRule, {});
+
+  const { mutateAsync: mutateDelete } = useMutation(CollectionRulesService.method.deleteCollectionRule, {});
+
+  return {
+    isFetching,
+    error,
+    rules,
+    mutate,
+    mutateDelete,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,6 +676,103 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@buf/googleapis_googleapis.bufbuild_es@npm:2.2.3-20220908150232-8d7204855ec1.1":
+  version: 2.2.3-20220908150232-8d7204855ec1.1
+  resolution: "@buf/googleapis_googleapis.bufbuild_es@npm:2.2.3-20220908150232-8d7204855ec1.1"
+  peerDependencies:
+    "@bufbuild/protobuf": ^2.2.3
+  checksum: 10/ba83a4ad777a16ef78e593b8f79a798c7441ddf1dcfff8f5dd990690b38b4cfb3798ead1e7e43a9506a68cf508dd6071d8d3d12f22fc3cc83cb78af61ca0ccca
+  languageName: node
+  linkType: hard
+
+"@buf/googleapis_googleapis.connectrpc_query-es@npm:2.0.1-20220908150232-8d7204855ec1.1":
+  version: 2.0.1-20220908150232-8d7204855ec1.1
+  resolution: "@buf/googleapis_googleapis.connectrpc_query-es@npm:2.0.1-20220908150232-8d7204855ec1.1"
+  dependencies:
+    "@buf/googleapis_googleapis.bufbuild_es": "npm:2.2.3-20220908150232-8d7204855ec1.1"
+  peerDependencies:
+    "@bufbuild/protobuf": ^2.2.3
+    "@connectrpc/connect-query": ^2.0.1
+  checksum: 10/c487fb91cc10e572880c31911a8603dfa24d46bbdf3bec1f0f8bf19adfe223de515f4ee5b85406281bf696cae3346e06b801738da829aa7a3406cfe4e44adefa
+  languageName: node
+  linkType: hard
+
+"@buf/pyroscope_api.bufbuild_es@npm:2.2.3-20250124153826-9ae1034efb3f.1":
+  version: 2.2.3-20250124153826-9ae1034efb3f.1
+  resolution: "@buf/pyroscope_api.bufbuild_es@npm:2.2.3-20250124153826-9ae1034efb3f.1"
+  dependencies:
+    "@buf/googleapis_googleapis.bufbuild_es": "npm:2.2.3-20220908150232-8d7204855ec1.1"
+  peerDependencies:
+    "@bufbuild/protobuf": ^2.2.3
+  checksum: 10/98e7f361cd329fcfd9a31783f6e26dd59b25dd7289354946896cd21e0c71608da4d33fa274fd33cb2e72f9727196ef8f388e847102bb6f1448f58f1340ee471a
+  languageName: node
+  linkType: hard
+
+"@buf/pyroscope_api.connectrpc_query-es@npm:2.0.1-20250124153826-9ae1034efb3f.1":
+  version: 2.0.1-20250124153826-9ae1034efb3f.1
+  resolution: "@buf/pyroscope_api.connectrpc_query-es@npm:2.0.1-20250124153826-9ae1034efb3f.1"
+  dependencies:
+    "@buf/googleapis_googleapis.connectrpc_query-es": "npm:2.0.1-20220908150232-8d7204855ec1.1"
+    "@buf/pyroscope_api.bufbuild_es": "npm:2.2.3-20250124153826-9ae1034efb3f.1"
+  peerDependencies:
+    "@bufbuild/protobuf": ^2.2.3
+    "@connectrpc/connect-query": ^2.0.1
+  checksum: 10/7f69396268841119cfd417d6f445babc0e7edec575e856b7f6d89dc82d0116924537b2273f57b504d09c7ec7868f528ee11ebd880de342722ba4c33db00f6c43
+  languageName: node
+  linkType: hard
+
+"@bufbuild/protobuf@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "@bufbuild/protobuf@npm:2.2.3"
+  checksum: 10/30bf3ac56338159dadaa87dce5372d19ff50dc32d06293bdf655e35ebc1766435b485714d3b73a3b7070ce29f58891a9e2b0f453a2d7deef583797b4a420273c
+  languageName: node
+  linkType: hard
+
+"@connectrpc/connect-query-core@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@connectrpc/connect-query-core@npm:2.0.1"
+  peerDependencies:
+    "@bufbuild/protobuf": 2.x
+    "@connectrpc/connect": ^2.0.0
+    "@tanstack/query-core": 5.x
+  checksum: 10/d8642e66fac0aac10713018e8eec9e1ba20fa91093145842aba34a51a36602ad652d1a7317cbe0de12d37fe0c594a664cba4bfdf4d9daf1ecf539284e9b2cd10
+  languageName: node
+  linkType: hard
+
+"@connectrpc/connect-query@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@connectrpc/connect-query@npm:2.0.1"
+  dependencies:
+    "@connectrpc/connect-query-core": "npm:^2.0.1"
+  peerDependencies:
+    "@bufbuild/protobuf": 2.x
+    "@connectrpc/connect": ^2.0.0
+    "@tanstack/react-query": 5.x
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  checksum: 10/4648aa37b7d40aa202b6057ca5067dae3f9a77d12868f0043883518e40a85a678f03e227e66253830f8bb81d40f3899b0d9c4a05a28adeb131b4638754599dbf
+  languageName: node
+  linkType: hard
+
+"@connectrpc/connect-web@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@connectrpc/connect-web@npm:2.0.1"
+  peerDependencies:
+    "@bufbuild/protobuf": ^2.2.0
+    "@connectrpc/connect": 2.0.1
+  checksum: 10/d975e104a989b8aa6dbab75f5294b41636dc8d4594d6b5219316acf2c1185a7074327f3a7b49763a4d37edb46befd670f94e573162df5c93e3dcc9109d01309e
+  languageName: node
+  linkType: hard
+
+"@connectrpc/connect@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@connectrpc/connect@npm:2.0.1"
+  peerDependencies:
+    "@bufbuild/protobuf": ^2.2.0
+  checksum: 10/6e1093e6d890af10c8497acfed3ad27e60dacc7f41511ff5824bac6f2b00bd4a6ede07d261ce8097bff314a1e0aebd27e1e01eb2fb83cfbdaafd273c8ae75ae3
+  languageName: node
+  linkType: hard
+
 "@conventional-changelog/git-client@npm:^1.0.0":
   version: 1.0.1
   resolution: "@conventional-changelog/git-client@npm:1.0.1"
@@ -12036,6 +12133,11 @@ __metadata:
   resolution: "pyroscope-app-plugin@workspace:."
   dependencies:
     "@babel/core": "npm:^7.21.4"
+    "@buf/pyroscope_api.connectrpc_query-es": "npm:2.0.1-20250124153826-9ae1034efb3f.1"
+    "@bufbuild/protobuf": "npm:^2.2.3"
+    "@connectrpc/connect": "npm:^2.0.1"
+    "@connectrpc/connect-query": "npm:^2.0.1"
+    "@connectrpc/connect-web": "npm:^2.0.1"
     "@emotion/css": "npm:11.10.6"
     "@grafana/data": "npm:11.3.2"
     "@grafana/e2e-selectors": "npm:^10.0.0"


### PR DESCRIPTION
This PR adds collector rules to the Explore profiles app.

The Pyroscope settings API stores those rules and will generate Alloy configuration (PR: https://github.com/grafana/pyroscope/pull/3865/), that then can be used by an extension of the Collector app (PR: 
https://github.com/grafana/grafana-collector-app/pull/639, thanks for your help @jarben).

Also see the design document: [DesignDoc: Allow to remote control of profiling targets from Grafana Cloud](https://docs.google.com/document/d/1LCY5jiqoRdapJ8B91QLLCbCEpnpsc9-sTAFjnR3Fe54/edit?tab=t.0)




Note: This also tries to use generated APIs from the backend (as per #354), it still uses JSON as the transport protocol though. Happy to remove this if this is not wanted. This increases the Assert sizes:

```
Before: modules by path ../node_modules/ 1.84 MiB 184 modules
Before: modules by path ./ 913 KiB (javascript) 602 KiB (asset)
After:  modules by path ../node_modules/ 2.24 MiB 221 modules
After:  modules by path ./ 929 KiB (javascript) 602 KiB (asset)
```


https://github.com/user-attachments/assets/af7da2b6-7be9-476c-bcea-f5f6729dabfd

