### PR TITLE
fix(DiffFlameGraph): Always disable time ranges sync before applying a preset

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/SceneExploreDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/SceneExploreDiffFlameGraph.tsx
@@ -97,6 +97,9 @@ export class SceneExploreDiffFlameGraph extends SceneObjectBase<SceneExploreDiff
         const selectWholeRange = event.payload.wholeRange;
         const { baselinePanel, comparisonPanel } = this.state;
 
+        baselinePanel.toggleTimeRangeSync(false);
+        comparisonPanel.toggleTimeRangeSync(false);
+
         baselinePanel.autoSelectDiffRange(selectWholeRange);
         comparisonPanel.autoSelectDiffRange(selectWholeRange);
       })


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR prevents an unexpected behaviour by always disabling the time ranges sync before applying a preset:

https://github.com/user-attachments/assets/31cd77ec-8ff6-43da-88b4-41453216706d

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

Manually:

- Enable time range sync
- Either choose "Auto-select" when landing on the "Diff flame graph" view or
- Choose a preset
- The sync should be disabled **before** the preset is applied
