### PR TITLE
fix(Grid): Fix error message display

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -380,7 +380,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
       children: [
         new SceneCSSGridItem({
           body: new SceneErrorState({
-            message: error.toString(),
+            message: error.message || error.toString(),
           }),
         }),
       ],

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/SceneLabelValuesGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/SceneLabelValuesGrid.tsx
@@ -417,7 +417,7 @@ export class SceneLabelValuesGrid extends SceneObjectBase<SceneLabelValuesGridSt
       children: [
         new SceneCSSGridItem({
           body: new SceneErrorState({
-            message: error.toString(),
+            message: error.message || error.toString(),
           }),
         }),
       ],

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/SceneLabelValuesGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/SceneLabelValuesGrid.tsx
@@ -310,7 +310,7 @@ export class SceneLabelValuesGrid extends SceneObjectBase<SceneLabelValuesGridSt
     }
 
     if (loadingState === LoadingState.Error) {
-      // TODO: check
+      // TODO: check if we need https://github.com/grafana/grafana/blob/d7f7cd1e61eac1e0103e0ca1e2122264aa831ffd/public/app/plugins/datasource/azuremonitor/utils/messageFromError.ts#L30
       this.renderErrorState(errors?.[0] as Error);
       return;
     }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Prevents non-friendly display issues when (e.g.) a variable loading error comes as an object `{refId, message, status}`:

<img width="209" alt="image" src="https://github.com/user-attachments/assets/916f5215-d853-4073-a627-d3cc7b6ce10f" />

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

No more `[object Object]` message displayed if a query fails
