### PR TITLE
ci: Prevent signing and publishing the plugin in forked repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
         run: npx @grafana/levitate@latest is-compatible --path src/module.ts --target @grafana/data,@grafana/ui,@grafana/runtime
 
       # The plugin is signed here so it's possible to use the artifact produced by the job directly
+      # However we do it only for build running from main to allow run it in forks (see https://github.com/grafana/explore-profiles/issues/366)
       - name: Setup plugin signing
+        if: github.event_name == 'push'
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ops
@@ -73,6 +75,7 @@ jobs:
 
       # create MANIFEST in dist
       - name: Sign plugin
+        if: github.event_name == 'push'
         run: yarn sign
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
         run: npx @grafana/levitate@latest is-compatible --path src/module.ts --target @grafana/data,@grafana/ui,@grafana/runtime
 
       # The plugin is signed here so it's possible to use the artifact produced by the job directly
-      # However we do it only for build running from main to allow run it in forks (see https://github.com/grafana/explore-profiles/issues/366)
+      # Forks are not allowed to get is signed so we skip this step (and job to upload the artifact)
+      # See also https://github.com/grafana/explore-profiles/issues/366)
       - name: Setup plugin signing
-        if: github.event_name == 'push'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           vault_instance: ops
@@ -75,7 +76,7 @@ jobs:
 
       # create MANIFEST in dist
       - name: Sign plugin
-        if: github.event_name == 'push'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: yarn sign
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ env.SIGN_PLUGIN_ACCESS_POLICY_TOKEN }}
@@ -148,6 +149,7 @@ jobs:
     # to push the package automatically without approval
     name: Package and publish plugin
     needs: [end-to-end]
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     environment: ${{ github.event_name == 'push' && 'gcs-no-approval' || 'gcs' }}
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
### ✨ Description

Fixes #366

### 📖 Summary of the changes

Make sure signing the plugin happens only in main to allow running CI in forks.

### 🧪 How to test?

Run the job, e.g. https://github.com/grafana/explore-profiles/actions/runs/13041161764/job/36383129066 to see signing is being skipped:

<img width="355" alt="Screenshot 2025-01-29 at 22 57 28" src="https://github.com/user-attachments/assets/9b07f570-9034-4b89-9bb3-c61a782fda34" />
