### PR TITLE
test(EndToEnd): Use constant viewport size

### DIFF
--- a/e2e/config/constants.ts
+++ b/e2e/config/constants.ts
@@ -22,6 +22,8 @@ function getEnvVars(): EnvVars {
 
 export const ENV_VARS = getEnvVars();
 
+export const CHROMIUM_VIEWPORT = { width: 1920, height: 1080 };
+
 export const AUTH_FILE = path.join(process.cwd(), 'e2e', 'auth', 'user.json');
 
 /* Explore Profiles */

--- a/e2e/config/playwright.config.ci.ts
+++ b/e2e/config/playwright.config.ci.ts
@@ -1,7 +1,7 @@
 import { devices } from '@playwright/test';
 import path from 'path';
 
-import { AUTH_FILE, ENV_VARS } from './constants';
+import { AUTH_FILE, CHROMIUM_VIEWPORT, ENV_VARS } from './constants';
 import { config } from './playwright.config.common';
 
 const shouldAuthenticate = !ENV_VARS.E2E_BASE_URL.startsWith('http://localhost');
@@ -18,6 +18,7 @@ const projects = shouldAuthenticate
         testDir: path.join(process.cwd(), 'e2e', 'tests'),
         use: {
           ...devices['Desktop Chrome'],
+          viewport: CHROMIUM_VIEWPORT,
           storageState: AUTH_FILE, // Use prepared auth state.
         },
       },
@@ -27,7 +28,7 @@ const projects = shouldAuthenticate
         name: 'chromium',
         use: {
           ...devices['Desktop Chrome'],
-          viewport: { width: 1920, height: 1080 },
+          viewport: CHROMIUM_VIEWPORT,
         },
       },
     ];

--- a/e2e/config/playwright.config.local.ts
+++ b/e2e/config/playwright.config.local.ts
@@ -19,6 +19,7 @@ const projects = shouldAuthenticate
         testDir: path.join(process.cwd(), 'e2e', 'tests'),
         use: {
           ...devices['Desktop Chrome'],
+          viewport: CHROMIUM_VIEWPORT,
           storageState: AUTH_FILE, // Use prepared auth state.
           failOnUncaughtExceptions,
         },
@@ -29,6 +30,7 @@ const projects = shouldAuthenticate
         name: 'chromium',
         use: {
           ...devices['Desktop Chrome'],
+          viewport: CHROMIUM_VIEWPORT,
           failOnUncaughtExceptions,
         },
       },


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR sets the viewport size as constant so that the E2E tests are executed in the same viewport locally and in CI.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The CI E2E tests should pass
- Locally, the E2E tests should execute with the same viewport size as in CI
