### PR TITLE
fix(FunctionDetailsPanel): Fix start ellipsis for file names containing non-alpha chars

### DIFF
--- a/e2e/tests/flame-graph-view/github-integration.spec.ts
+++ b/e2e/tests/flame-graph-view/github-integration.spec.ts
@@ -18,7 +18,8 @@ test.describe('Flame graph view', () => {
     const nodePosition = { x: 30, y: 30 };
     const functionName = 'github.com/grafana/dskit/services.(*BasicService).main';
     const startLine = '153';
-    const file = 'github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/services/basic_service.go';
+    // see ellipsis hack in SceneFunctionDetailsPanel.tsx
+    const fileName = '‎github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/services/basic_service.go';
 
     test('When clicking on a flame graph node and then "Function details", it opens a details panel', async ({
       exploreProfilesPage,
@@ -61,7 +62,7 @@ test.describe('Flame graph view', () => {
 
       const filePathRow = detailsPanel.getByTestId('row-file-path');
       await expect(filePathRow.getByText('File')).toBeVisible();
-      await expect(filePathRow.locator('span')).toHaveText(file);
+      await expect(filePathRow.locator('span')).toHaveText(fileName);
 
       const repositoryRow = detailsPanel.getByTestId('row-repository');
       await expect(repositoryRow.getByText('Repository')).toBeVisible();

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
@@ -171,7 +171,8 @@ export class SceneFunctionDetailsPanel extends SceneObjectBase<SceneFunctionDeta
                 {data.functionDetails.fileName ? (
                   <>
                     <Tooltip content={data.functionDetails.fileName} placement="top">
-                      <span className={styles.textValue}>{formatFileName(data.functionDetails.fileName)}</span>
+                      {/* adding LRM to prevent ellipsis with RTL to fail when the file name starts with non-alpha chars (e.g. "$")  */}
+                      <span className={styles.textValue}>&lrm;{formatFileName(data.functionDetails.fileName)}</span>
                     </Tooltip>
                     <IconButton
                       name="clipboard-alt"

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
@@ -267,9 +267,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     }
   `,
   textValue: css`
+    // hack to have the ellipsis appear at the start of the string
+    direction: rtl;
     text-overflow: ellipsis;
     overflow: hidden;
-    direction: rtl;
     white-space: nowrap;
   `,
 });


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** resolves https://github.com/grafana/explore-profiles/issues/353

### 📖 Summary of the changes

Just adding [this hack](https://stackoverflow.com/questions/27957443/strange-special-characters-issue-in-left-side-ellipsis)

### 🧪 How to test?

- See the issue linked above
