### PR TITLE
fix(Filters): Ensure filters are always cleared when changing the data source or the service

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
@@ -160,7 +160,7 @@ export class SceneMainServiceTimeseries extends SceneObjectBase<SceneMainService
 
   resetTimeseries(resetFilters = false) {
     if (resetFilters) {
-      sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable).setState({ filters: [] });
+      sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable).reset();
     }
 
     (this.state.body as SceneLabelValuesTimeseries)?.updateItem({

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -146,6 +146,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
   }
 
   onActivate() {
+    const varSub = this.subscribeToVariableChanges();
     const eventsSub = this.subscribeToEvents();
 
     if (!this.state.explorationType) {
@@ -156,6 +157,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
 
     return () => {
       eventsSub.unsubscribe();
+      varSub.unsubscribe();
     };
   }
 
@@ -190,6 +192,31 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
         ]);
       }
     }
+  }
+
+  subscribeToVariableChanges() {
+    const dataSourceSub = sceneGraph
+      .findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable)
+      .subscribeToState((newState, prevState) => {
+        if (newState.value && newState.value !== prevState.value) {
+          FiltersVariable.resetAll(this);
+        }
+      });
+
+    const serviceNameSub = sceneGraph
+      .findByKeyAndType(this, 'serviceName', ServiceNameVariable)
+      .subscribeToState((newState, prevState) => {
+        if (newState.value && newState.value !== prevState.value) {
+          FiltersVariable.resetAll(this);
+        }
+      });
+
+    return {
+      unsubscribe() {
+        serviceNameSub.unsubscribe();
+        dataSourceSub.unsubscribe();
+      },
+    };
   }
 
   subscribeToEvents() {

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -276,9 +276,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
         nextExplorationType as ExplorationType
       )
     ) {
-      sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable).setState({
-        filters: FiltersVariable.DEFAULT_VALUE,
-      });
+      sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable).reset();
     }
   }
 

--- a/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
@@ -1,4 +1,4 @@
-import { AdHocFiltersVariable, SceneComponentProps, sceneGraph } from '@grafana/scenes';
+import { AdHocFiltersVariable, SceneComponentProps, sceneGraph, SceneObject } from '@grafana/scenes';
 import { CompleteFilters, OperatorKind } from '@shared/components/QueryBuilder/domain/types';
 import { QueryBuilder } from '@shared/components/QueryBuilder/QueryBuilder';
 import { reportInteraction } from '@shared/domain/reportInteraction';
@@ -32,12 +32,22 @@ export class FiltersVariable extends AdHocFiltersVariable {
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
+  reset() {
+    this.setState({ filters: FiltersVariable.DEFAULT_VALUE });
+  }
+
+  static resetAll(sceneObject: SceneObject) {
+    ['filters', 'filtersBaseline', 'filtersComparison'].forEach((filterKey) => {
+      sceneGraph.findByKeyAndType(sceneObject, filterKey, FiltersVariable).reset();
+    });
+  }
+
   onActivate() {
     // VariableDependencyConfig does not work :man_shrug: (never called)
     const dataSourceSub = sceneGraph
       .findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable)
       .subscribeToState(() => {
-        this.setState({ filters: [] });
+        this.reset();
       });
 
     return () => {

--- a/src/pages/ProfilesExplorerView/domain/variables/ProfilesDataSourceVariable.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ProfilesDataSourceVariable.ts
@@ -2,6 +2,8 @@ import { DataSourceVariable } from '@grafana/scenes';
 import { ApiClient } from '@shared/infrastructure/http/ApiClient';
 import { userStorage } from '@shared/infrastructure/userStorage';
 
+import { FiltersVariable } from './FiltersVariable/FiltersVariable';
+
 export class ProfilesDataSourceVariable extends DataSourceVariable {
   constructor() {
     super({
@@ -25,6 +27,8 @@ export class ProfilesDataSourceVariable extends DataSourceVariable {
         const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
         storage.dataSource = newState.value;
         userStorage.set(userStorage.KEYS.PROFILES_EXPLORER, storage);
+
+        FiltersVariable.resetAll(this);
       }
     });
   }

--- a/src/pages/ProfilesExplorerView/domain/variables/ProfilesDataSourceVariable.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ProfilesDataSourceVariable.ts
@@ -2,8 +2,6 @@ import { DataSourceVariable } from '@grafana/scenes';
 import { ApiClient } from '@shared/infrastructure/http/ApiClient';
 import { userStorage } from '@shared/infrastructure/userStorage';
 
-import { FiltersVariable } from './FiltersVariable/FiltersVariable';
-
 export class ProfilesDataSourceVariable extends DataSourceVariable {
   constructor() {
     super({
@@ -27,8 +25,6 @@ export class ProfilesDataSourceVariable extends DataSourceVariable {
         const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
         storage.dataSource = newState.value;
         userStorage.set(userStorage.KEYS.PROFILES_EXPLORER, storage);
-
-        FiltersVariable.resetAll(this);
       }
     });
   }

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2, VariableRefresh } from '@grafana/data';
-import {
-  MultiValueVariable,
-  QueryVariable,
-  SceneComponentProps,
-  sceneGraph,
-  VariableValueOption,
-} from '@grafana/scenes';
+import { MultiValueVariable, QueryVariable, SceneComponentProps, VariableValueOption } from '@grafana/scenes';
 import { Cascader, Icon, Tooltip, useStyles2 } from '@grafana/ui';
 import { prepareHistoryEntry } from '@shared/domain/prepareHistoryEntry';
 import { reportInteraction } from '@shared/domain/reportInteraction';
@@ -58,6 +52,8 @@ export class ServiceNameVariable extends QueryVariable {
         const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
         storage.serviceName = newState.value;
         userStorage.set(userStorage.KEYS.PROFILES_EXPLORER, storage);
+
+        FiltersVariable.resetAll(this);
       }
     });
   }
@@ -87,14 +83,8 @@ export class ServiceNameVariable extends QueryVariable {
     if (!this.state.skipUrlSync) {
       prepareHistoryEntry();
     }
-    this.changeValueTo(newValue);
 
-    // manually reset filters - we should listen to the variables changes but it leads to unwanted behaviour
-    // (filters set in the URL search parameters are resetted when the user lands on the page)
-    ['filters', 'filtersBaseline', 'filtersComparison'].forEach((filterKey) => {
-      const filtersVariable = sceneGraph.findByKeyAndType(this, filterKey, FiltersVariable);
-      filtersVariable.setState({ filters: [] });
-    });
+    this.changeValueTo(newValue);
   };
 
   static Component = ({ model }: SceneComponentProps<MultiValueVariable & { selectNewValue?: any }>) => {

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
@@ -10,7 +10,6 @@ import React, { useMemo } from 'react';
 import { lastValueFrom } from 'rxjs';
 
 import { PYROSCOPE_SERIES_DATA_SOURCE } from '../../../infrastructure/pyroscope-data-sources';
-import { FiltersVariable } from '../FiltersVariable/FiltersVariable';
 import { buildServiceNameCascaderOptions } from './domain/useBuildServiceNameOptions';
 
 type ServiceNameVariableState = {
@@ -52,8 +51,6 @@ export class ServiceNameVariable extends QueryVariable {
         const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
         storage.serviceName = newState.value;
         userStorage.set(userStorage.KEYS.PROFILES_EXPLORER, storage);
-
-        FiltersVariable.resetAll(this);
       }
     });
   }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

Before this PR, the filters were not always reset when changing the data source.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

Manually, for instance:

1. Go to the "Diff flame graph" view and add baseline and comparison filters
2. Go to the "All services" view
3. Change the data source
4. Go back to the "Diff flame graph" view
5. The filters have been cleared

Also:
- The filters should be cleared when changing the service in the "Labels" view and coming back to the "Diff flame graph" view
