### PR TITLE
ci: Use refs for reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
   deploy-main-to-dev-and-ops:
     name: Deploy to dev / ops
     needs: [package]
-    uses: grafana/explore-profiles/.github/workflows/deploy.yml
+    uses: grafana/explore-profiles/.github/workflows/deploy.yml@main
     # Make
     if: github.event_name == 'push'
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
   deploy-main-to-dev-and-ops:
     name: Deploy to dev / ops
     needs: [package]
-    uses: grafana/explore-profiles/.github/workflows/deploy.yml@main
+    uses: ./.github/workflows/deploy.yml
     # Make
     if: github.event_name == 'push'
     secrets: inherit

--- a/.github/workflows/deploy-existing-version.yml
+++ b/.github/workflows/deploy-existing-version.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ inputs.version }}
 
   deploy:
-    uses: grafana/explore-profiles/.github/workflows/deploy.yml@main
+    uses: ./.github/workflows/deploy.yml
     needs: [verify]
     secrets: inherit
     strategy:

--- a/.github/workflows/deploy-existing-version.yml
+++ b/.github/workflows/deploy-existing-version.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ inputs.version }}
 
   deploy:
-    uses: grafana/explore-profiles/.github/workflows/deploy.yml
+    uses: grafana/explore-profiles/.github/workflows/deploy.yml@main
     needs: [verify]
     secrets: inherit
     strategy:


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #346 

Fixes incorrect paths / refs updated in [the last commit](https://github.com/grafana/explore-profiles/pull/364) of https://github.com/grafana/explore-profiles/pull/364. It was supposed to use main branch workflows but:
- the ref needs to be specified if `owner/repo` format is used
- the ref can be skipped for workflows in the same repo but path needs to be relative

See docs in: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow

### 📖 Summary of the changes

<!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->

- Use a relative path to a reusable workflow

### 🧪 How to test?

Workflows should be running for the PR (https://github.com/grafana/explore-profiles/actions/runs/13114010650)
