### PR TITLE
fix(Settings): Prevent warning to be displayed when no settings is returned by the Settings API

### DIFF
--- a/src/shared/infrastructure/settings/settingsApiClient.ts
+++ b/src/shared/infrastructure/settings/settingsApiClient.ts
@@ -13,14 +13,10 @@ class SettingsApiClient extends ApiClient {
       .fetch('/settings.v1.SettingsService/Get', { method: 'POST', body: JSON.stringify({}) })
       .then((response) => response.json())
       .then((json: ApiResponse) => {
-        if (!json.settings) {
-          return {};
-        }
-
-        const setting = json.settings.find(({ name }) => name === SettingsApiClient.PLUGIN_SETTING_NAME);
+        const setting = json.settings?.find(({ name }) => name === SettingsApiClient.PLUGIN_SETTING_NAME);
 
         if (!setting) {
-          throw new Error('Setting not found!');
+          return {};
         }
 
         return JSON.parse(setting.value);


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
