### PR TITLE
ci: Do not preinstall plugins in e2e tests to avoid clashes

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -14,6 +14,7 @@ services:
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
       GF_INSTALL_PLUGINS: grafana-llm-app
+      GF_PLUGINS_PREINSTALL_DISABLED: true
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
 


### PR DESCRIPTION
### ✨ Description

**Related issue(s):**

This is to avoid errors like:

```
logger=plugin.installer t=2025-02-06T13:11:18.562300148Z level=info msg="Updating plugin" pluginId=grafana-pyroscope-app from=0.1.20 to=0.1.19
logger=plugin.backgroundinstaller t=2025-02-06T13:11:18.568296686Z level=error msg="Failed to install plugin" pluginId=grafana-pyroscope-app version= error="unlinkat /var/lib/grafana/plugins/grafana-pyroscope-app: device or resource busy"
```

when updating a plugin on top of the preinstalled plugin

### 📖 Summary of the changes

<!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->

### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
