### PR TITLE
ci: Disable e2e when creating a new version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
         required: false
         type: string
         description: commit sha or tag that will be checked out (use it if an existing tag needs to be checked-out)
+      e2e:
+        required: true
+        type: boolean
 
 jobs:
   frontend:
@@ -89,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [frontend]
+    if: ${{ inputs.e2e == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [frontend]
-    if: ${{ inputs.e2e == 'true' }}
+    if: inputs.e2e == true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ github.event.pull_request.head.sha || github.sha }}
+      e2e: true
 
   package:
     name: Package

--- a/.github/workflows/create-new-version.yml
+++ b/.github/workflows/create-new-version.yml
@@ -77,6 +77,7 @@ jobs:
     with:
       version: ${{ needs.create-new-version.outputs.version }}
       ref: ${{ needs.create-new-version.outputs.version }}
+      e2e: false
 
   package:
     needs: [create-new-version, build]


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #295 

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

Newly created flow to create a new version runs redundant e2e tests that should be passing in main.

### 🧪 How to test?

E2E tests should be run for this PR.
