### PR TITLE
revert: Do not preinstall plugins in e2e tests to avoid clashes

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -14,7 +14,6 @@ services:
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
       GF_INSTALL_PLUGINS: grafana-llm-app
-      GF_PLUGINS_PREINSTALL_DISABLED: true
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
 


### PR DESCRIPTION
Reverts grafana/explore-profiles#386

Now Grafana does not start in local, I'm seeing errors in local when running `yarn e2e:ci:server:up`:

```shell
logger=provisioning t=2025-02-06T18:44:19.055521869Z level=error msg="Failed to provision plugins" error="app provisioning error: plugin not installed: \"grafana-pyroscope-app\""
logger=provisioning t=2025-02-06T18:44:19.055542566Z level=error msg="Failed to provision plugins" error="app provisioning error: plugin not installed: \"grafana-pyroscope-app\""
Error: ✗ app provisioning error: plugin not installed: "grafana-pyroscope-app"

```