### PR TITLE
ci(Docker): Disable all plugin preinstalls to prevent clashes

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -13,8 +13,9 @@ services:
       - ./samples/provisioning:/etc/grafana/provisioning
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
+    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      GF_PLUGINS_PREINSTALL_DISABLED: true 
       GF_INSTALL_PLUGINS: grafana-llm-app
-      GF_PLUGINS_PREINSTALL_DISABLED: true
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
 

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -13,6 +13,8 @@ services:
       - ./samples/provisioning-local:/etc/grafana/provisioning
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
+    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      GF_PLUGINS_PREINSTALL_DISABLED: true
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID

--- a/docker-compose.remote.yaml
+++ b/docker-compose.remote.yaml
@@ -14,6 +14,8 @@ services:
     volumes:
       - ./dist:/var/lib/grafana/plugins/grafana-pyroscope-app
     environment:
+    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      GF_PLUGINS_PREINSTALL_DISABLED: true
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - ./samples/provisioning:/etc/grafana/provisioning
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
+    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      GF_PLUGINS_PREINSTALL_DISABLED: true
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** follow-up of https://github.com/grafana/explore-profiles/pull/386

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

Locally:
- Update the npm package version in `package.json` to e.g. `1.0.0`
- In a terminal, execute e.g. `yarn server:static`
- Grafana starts correctly and, on the UI, clicking on the info tooltip in the app header shows "Explore Profiles v1.0.0"