### PR TITLE
ci: Run test coverage only in pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         run: yarn test:ci
 
       - name: Report test coverage
+        if: ${{ github.event_name == 'pull_request' }}
         uses: MishaKav/jest-coverage-comment@v1.0.27
         with:
           title: Unit test coverage


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #295

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

This is to avoid errors in main:

> [Build and test / Frontend build](https://github.com/grafana/explore-profiles/actions/runs/13267415669/job/37038277530#step:8:26)
Resource not accessible by integration - https://docs.github.com/rest/commits/comments#create-a-commit-comment

Example: https://github.com/grafana/explore-profiles/actions/runs/13267415669

### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
