### PR TITLE
fix(FlameGraph): Always render an error message when loading fails

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -13,8 +13,8 @@ services:
       - ./samples/provisioning:/etc/grafana/provisioning
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
-    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
-      GF_PLUGINS_PREINSTALL_DISABLED: true 
+      # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      GF_PLUGINS_PREINSTALL_DISABLED: true
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -13,7 +13,7 @@ services:
       - ./samples/provisioning-local:/etc/grafana/provisioning
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
-    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
       GF_PLUGINS_PREINSTALL_DISABLED: true
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY

--- a/docker-compose.remote.yaml
+++ b/docker-compose.remote.yaml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./dist:/var/lib/grafana/plugins/grafana-pyroscope-app
     environment:
-    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
       GF_PLUGINS_PREINSTALL_DISABLED: true
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./samples/provisioning:/etc/grafana/provisioning
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
-    # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
+      # prevents a Grafana startup error in case a newer plugin version (set in package.json) is used compared to the latest one published in the catalog
       GF_PLUGINS_PREINSTALL_DISABLED: true
       GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -9,6 +9,7 @@ import { useToggleSidePanel } from '@shared/domain/useToggleSidePanel';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
+import { InlineBanner } from '@shared/ui/InlineBanner';
 import { Panel } from '@shared/ui/Panel/Panel';
 import { PyroscopeLogo } from '@shared/ui/PyroscopeLogo';
 import React, { useEffect, useMemo } from 'react';
@@ -113,7 +114,14 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     }, [maxNodes]);
 
     const $dataState = $data.useState();
-    const isFetchingProfileData = $dataState?.data?.state === LoadingState.Loading;
+    const loadingState = $dataState?.data?.state;
+
+    const fetchProfileError =
+      loadingState === LoadingState.Error
+        ? ($dataState?.data?.errors?.[0] as Error) || new Error('Unknown error!')
+        : null;
+
+    const isFetchingProfileData = loadingState === LoadingState.Loading;
     const profileData = $dataState?.data?.series?.[0];
     const hasProfileData = Number(profileData?.length) > 1;
 
@@ -126,6 +134,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
         isFetchingProfileData,
         hasProfileData,
         profileData,
+        fetchProfileError,
         settings,
         export: {
           menu: exportMenu,
@@ -189,20 +198,26 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
             </AIButton>
           }
         >
-          <FlameGraph
-            data={data.profileData as any}
-            disableCollapsing={!data.settings?.collapsedFlamegraphs}
-            getTheme={actions.getTheme as any}
-            getExtraContextMenuButtons={gitHubIntegration.actions.getExtraFlameGraphMenuItems}
-            extraHeaderElements={
-              <data.export.menu.Component
-                model={data.export.menu}
-                query={data.export.query}
-                timeRange={data.export.timeRange}
-              />
-            }
-            keepFocusOnDataChange
-          />
+          {data.fetchProfileError && (
+            <InlineBanner severity="error" title="Error while loading profile data!" error={data.fetchProfileError} />
+          )}
+
+          {!data.fetchProfileError && (
+            <FlameGraph
+              data={data.profileData as any}
+              disableCollapsing={!data.settings?.collapsedFlamegraphs}
+              getTheme={actions.getTheme as any}
+              getExtraContextMenuButtons={gitHubIntegration.actions.getExtraFlameGraphMenuItems}
+              extraHeaderElements={
+                <data.export.menu.Component
+                  model={data.export.menu}
+                  query={data.export.query}
+                  timeRange={data.export.timeRange}
+                />
+              }
+              keepFocusOnDataChange
+            />
+          )}
         </Panel>
 
         {sidePanel.isOpen('ai') && (


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

This PR ensure the UI always displays an error message when loading profile data fails, for instance:

| Before | After |
|  ---   |  ---  |
| <img width="1699" alt="Screenshot 2025-02-12 at 13 30 50" src="https://github.com/user-attachments/assets/9b92a420-8099-468e-a374-e733727a6289" />  |  <img width="1694" alt="Screenshot 2025-02-12 at 13 32 25" src="https://github.com/user-attachments/assets/a58f5fb4-42e3-472c-b00f-96bf8538fd13" />|

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- When loading profile data fails, the UI always displays an error message
