### PR TITLE
ci: Use correct github.actor to prevent CI builds on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,9 @@ permissions:
   id-token: write
 
 jobs:
-  debug:
-    name: Debug
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Actor ${{ github.actor }}, triggering actor ${{ github.triggering_actor }}"
-
   build:
     name: Build and test
-    if: ${{ github.actor != 'Databases Frontend CI Bot' }}
+    if: github.actor != 'databases-frontend-ci-bot[bot]'
     uses: ./.github/workflows/build.yml
     with:
       e2e: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ permissions:
   id-token: write
 
 jobs:
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Actor ${{ github.actor }}, triggering actor ${{ github.triggering_actor }}"
+
   build:
     name: Build and test
     if: ${{ github.actor != 'Databases Frontend CI Bot' }}


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #295

Even after adding https://github.com/grafana/explore-profiles/commit/6bf120fb589e191affa1c45226eac77d98a5e0ae the commit created by the release workflow still triggers CI workflow - https://github.com/grafana/explore-profiles/actions/runs/13285546395. 

### 📖 Summary of the changes

This puts it in step with what other apps are doing (example: https://github.com/grafana/log-volume-explorer/blob/5acaf4dcedcec3af0710fc2eb744e5086aad234a/.github/workflows/ci.yml#L19)

<!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->

### 🧪 How to test?

The CI in the PR should work as expected. The actual change we can test only with the actual release workflow.
