### PR TITLE
ci: Trigger unique Argo workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,5 +26,5 @@ jobs:
           workflow_template: 'deploy-plugin-${{ inputs.environment }}'
           parameters: |
             plugintag=${{ inputs.version }}
-          extra_args: '--name deploy-plugin-${{ inputs.environment }}-${{ inputs.version }}'
+          extra_args: '--name deploy-plugin-${{ inputs.environment }}-${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}'
           log_level: 'debug'


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #295

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

Argo workflow ids need to be unique. If we want to roll back a version that had been deployed with Argo workflow before by using a new Argo workflow run we need to make sure the name is unique.

Otherwise this happens: https://github.com/grafana/explore-profiles/actions/runs/13290554925/job/37110024616

Failed to submit workflow: rpc error: code = AlreadyExists desc = workflows.argoproj.io ...  already exists, the server was not able to generate a unique name for the object

### 🧪 How to test?

Can be tested after merging to main - dev flow will be triggered
