### PR TITLE
ci: Use shorter sha for Argo workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,13 @@ jobs:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+      # Argo workflow names can be max 63 characters long so we truncate sha/version to max 10 characters
+      - name: Truncate version/sha
+        id: truncate
+        env:
+          VERSION: ${{ inputs.version }}
+        run: echo "short_version=${VERSION::10}" >> "$GITHUB_OUTPUT"
+
       - name: Deploying ${{ inputs.version }} to ${{ inputs.environment }}
         uses: grafana/shared-workflows/actions/trigger-argo-workflow@trigger-argo-workflow-v1.1.0
         with:
@@ -26,5 +33,5 @@ jobs:
           workflow_template: 'deploy-plugin-${{ inputs.environment }}'
           parameters: |
             plugintag=${{ inputs.version }}
-          extra_args: '--name deploy-plugin-${{ inputs.environment }}-${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}'
+          extra_args: '--name deploy-plugin-${{ inputs.environment }}-${{ steps.truncate.outputs.short_version }}-${{ github.run_id }}-${{ github.run_attempt }}'
           log_level: 'debug'


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** #295
 
This didn't work https://github.com/grafana/explore-profiles/pull/414 because of  https://github.com/grafana/explore-profiles/actions/runs/13291594115/job/37113913511

```
Failed to submit workflow: rpc error: code = InvalidArgument desc = workflow name \"deploy-plugin-dev-cfcbb7e1e5e84f224323fd6af619f06e7d0f97ac-13291594115-1\" must not be more than 63 characters long (currently 72)
```

### 📖 Summary of the changes

Truncating to 10 characters. 7 is a short sha but also v0.0.10 is 7 characters long so giving a bit more to take longer version numbers into account. We may need something more robust though but I don't want to complicate things at the same time :/ 

### 🧪 How to test?

Same as #414 - we can test with dev flow from main
