### PR TITLE
fix(*): Remove lazy loading of page components

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -2,17 +2,16 @@ import React from 'react';
 import { Routes as ReactRouterRoutes, Route } from 'react-router-dom';
 
 import { ROUTES } from '../constants';
-
-const ProfilesExplorerView = React.lazy(() => import('../pages/ProfilesExplorerView/ProfilesExplorerView'));
-const AdHocView = React.lazy(() => import('../pages/AdHocView/AdHocView'));
-const SettingsView = React.lazy(() => import('../pages/SettingsView/SettingsView'));
+import AdHocView from '../pages/AdHocView/AdHocView';
+import ProfilesExplorerView from '../pages/ProfilesExplorerView/ProfilesExplorerView';
+import SettingsView from '../pages/SettingsView/SettingsView';
 
 export function Routes() {
   return (
     <ReactRouterRoutes>
-      <Route path={`${ROUTES.EXPLORE}/*`} element={<ProfilesExplorerView />} />
-      <Route path={`${ROUTES.ADHOC}/*`} element={<AdHocView />} />
-      <Route path={`${ROUTES.SETTINGS}/*`} element={<SettingsView />} />
+      <Route path={ROUTES.EXPLORE} element={<ProfilesExplorerView />} />
+      <Route path={ROUTES.ADHOC} element={<AdHocView />} />
+      <Route path={ROUTES.SETTINGS} element={<SettingsView />} />
       {/* Default Route */}
       <Route path="/*" element={<ProfilesExplorerView />} />
     </ReactRouterRoutes>


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** relates to https://github.com/grafana/explore-profiles/pull/324

After trying to rollback to a previous version of the plugin, we've noticed many "Loading chunk 75 failed" errors in the browser (~25 for a single user!). 

To prevent this situation to happen, this PR removes the lazy loading of the page components introduced in https://github.com/grafana/explore-profiles/pull/324.

### 📖 Summary of the changes

See diff tab

### 🧪 How to test?

- The build should pass
- After merging and deploying, rolling back to a previous version should not cause any error in the user browser
