### PR TITLE
ci: Fix GitHub release creation of a major version

### DIFF
--- a/.github/workflows/cut-new-release.yml
+++ b/.github/workflows/cut-new-release.yml
@@ -115,7 +115,7 @@ jobs:
           name: build-upload
           path: build
       - name: Get last changelog entry
-        run: awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
+        run: awk '/^(#+ \[)/ {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
       - name: Create Github release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** `-`

The creation of the GitHub release for our first major version (`v1.0.0`) worked, but the release notes were incorrect. This PR fixes it.

### 📖 Summary of the changes

This PR updates the regular expression used by `awk` to extract the most recent changes from the changelog file.

### 🧪 How to test?

- Manually, by executing `awk '/^(#+ \[)/ {s++} s == 1 {print}' CHANGELOG.md` in a terminal for various changelogs
