### PR TITLE
docs: Update the readme for Drilldown with proper navigation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All Grafana instances come with Profiles Drilldown plugin preinstalled.
 
 ## Get started
 
-1. In the main navigation bar, click on Explore > Profiles.
+1. In the main navigation bar, click on **Drilldown** > **Profiles**.
 2. You’ll land in the **All services** overview that shows time series and CPU utilization visualizations for all the services in your selected Pyroscope instance.
 3. If needed, change your data source with the drop-down on the top left.
 4. Modify your time range in two ways:


### PR DESCRIPTION
Readme was mostly updated but it looks like we were still saying that this app was nested under "Explore" even though now its under "Drilldown".