### PR TITLE
docs: Fix label name for service_git_ref

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/ui/GitHubIntegrationBanner.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/ui/GitHubIntegrationBanner.tsx
@@ -13,7 +13,7 @@ export const GitHubIntegrationBanner = ({ onDismiss }: GitHubIntegrationBannerPr
       </p>
       <p>
         To activate this feature, you will need to add two new labels when sending profiles{' '}
-        <code>service_repository</code> and <code>service_ref</code>.{' '}
+        <code>service_repository</code> and <code>service_git_ref</code>.{' '}
       </p>
       <p>
         They should respectively be set to the full repository GitHub URL and the current{' '}


### PR DESCRIPTION
The only valid label name is `service_git_ref`.

Was highlighted by @Alex3k in [slack](https://raintank-corp.slack.com/archives/C03NCLB4GG7/p1741684699066899)

