### PR TITLE
ci: Group workflows in queues to avoid race conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ permissions:
   id-token: write
 
 # This ensures builds in main are queued instead of running in parallel to ensure there's no race condition to
-# deploy dev environment from main with Argo. At the same time we don't cancel in progress workflows to ensure they finish
-# to give feedback about the build for each commit. See also https://github.com/grafana/explore-profiles/issues/440
+# deploy dev environment from main with Argo. At the same time we cancel in progress workflows to not lock the queue
+# as some steps require approval an may not be run. See also https://github.com/grafana/explore-profiles/issues/440
 # for more information.
 concurrency:
   group: ${{ github.ref }} # ensures workflows in the same branch are grouped together
-  cancel-in-progress: false # ensures workflows do not cancel each other, they will queue instead
+  cancel-in-progress: true # ensures workflows do not cancel each other, they will queue instead
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ permissions:
   pull-requests: write
   id-token: write
 
+# This ensures builds in main are queued instead of running in parallel to ensure there's no race condition to
+# deploy dev environment from main with Argo. At the same time we don't cancel in progress workflows to ensure they finish
+# to give feedback about the build for each commit. See also https://github.com/grafana/explore-profiles/issues/440
+# for more information.
+concurrency:
+  group: ${{ github.ref }} # ensures workflows in the same branch are grouped together
+  cancel-in-progress: false # ensures workflows do not cancel each other, they will queue instead
+
 jobs:
   build:
     name: Build and test


### PR DESCRIPTION
### ✨ Description

Fixes: #440
<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

This should group workflows in queues to avoid running two jobs in parallel that would end up with Argo deployments (it may cause issues described in #440)

The drawback is that job won't cancel each other automatically so in PRs CI will run for all commits even if they are submitted while CI is still running for the previous commit.

### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
