### PR TITLE
fix(FlameGraph): Use entire file as context in "Optimize Code" prompt

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -9,16 +9,15 @@ plugins:
     out: src/shared/pyroscope-api
     opt: target=ts
 inputs:
-    # Build a subset of the Pyroscope protobuf API
+  # Build a subset of the Pyroscope protobuf API
   - git_repo: https://github.com/grafana/pyroscope.git
     # Update this to any commit, which is merged in Pyroscope main
     ref: weekly-f105-886b418af
     subdir: api
     paths:
-    - adhocprofiles/
-    - querier/
-    - settings/
-    - types/
-    - vcs/
-    - google/
-
+      - adhocprofiles/
+      - querier/
+      - settings/
+      - types/
+      - vcs/
+      - google/

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/CodeContainer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/CodeContainer.tsx
@@ -22,7 +22,7 @@ export function CodeContainer({ dataSourceUid, functionDetails }: CodeContainerP
   return (
     <>
       <Code
-        lines={data.lines}
+        lines={data.snippetLines}
         unit={data.unit}
         githubUrl={data.githubUrl}
         isLoadingCode={data.isLoadingCode}
@@ -39,7 +39,7 @@ export function CodeContainer({ dataSourceUid, functionDetails }: CodeContainerP
         <AiSuggestionsPanel
           suggestionPromptInputs={{
             functionDetails: functionDetails,
-            lines: data.lines,
+            lines: data.allLines,
           }}
         />
       ) : null}

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/__tests__/annotateLines.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/__tests__/annotateLines.spec.ts
@@ -1,16 +1,16 @@
-import { annotateLines, annotatePlaceholderLineProfiles } from '../buildLineProfiles';
+import { annotateLines, annotatePlaceholderLines } from '../annotateLines';
 
 describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
   describe('if callSitesMap is empty', () => {
     it('returns an empty snippet and empty allLines array', () => {
-      const result = annotatePlaceholderLineProfiles(new Map());
+      const result = annotatePlaceholderLines(new Map());
       expect(result).toEqual([[], []]);
     });
   });
 
   describe('if callSitesMap is not empty', () => {
     it('returns a snippet of annotated code lines', () => {
-      const [snippet, allLines] = annotatePlaceholderLineProfiles(
+      const { snippetLines, allLines } = annotatePlaceholderLines(
         new Map([
           [12, { line: 12, flat: 0, cum: 40000000 }],
           [15, { line: 15, flat: 0, cum: 710000000 }],
@@ -18,7 +18,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
         ])
       );
 
-      expect(snippet).toEqual([
+      expect(snippetLines).toEqual([
         {
           cum: 0,
           flat: 0,
@@ -116,7 +116,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
 
     describe('when the lines contained in callSitesMap are smaller than the number of padded lines', () => {
       it('returns an array cropped properly', () => {
-        const [snippet, allLines] = annotatePlaceholderLineProfiles(
+        const { snippetLines, allLines } = annotatePlaceholderLines(
           new Map([
             [2, { line: 2, flat: 0, cum: 40000000 }],
             [4, { line: 4, flat: 0, cum: 710000000 }],
@@ -124,7 +124,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
           ])
         );
 
-        expect(snippet).toEqual([
+        expect(snippetLines).toEqual([
           {
             cum: 30000000,
             flat: 0,
@@ -190,8 +190,8 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
 describe('buildLineProfiles(fileContent, callSitesMap', () => {
   describe('if callSitesMap is empty', () => {
     it('returns an empty snippet array', () => {
-      const [snippet, allLines] = annotateLines('// this file is empty', new Map());
-      expect(snippet).toEqual([]);
+      const { snippetLines, allLines } = annotateLines('// this file is empty', new Map());
+      expect(snippetLines).toEqual([]);
       expect(allLines).toEqual([
         {
           cum: 0,
@@ -230,7 +230,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
 });`;
 
     it('returns an array containing samples/line info, sorted by line number and padded with extra lines', () => {
-      const [snippet, allLines] = annotateLines(
+      const { snippetLines, allLines } = annotateLines(
         fileContent,
         new Map([
           [12, { line: 12, flat: 0, cum: 40000000 }],
@@ -239,7 +239,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
         ])
       );
 
-      expect(snippet).toEqual([
+      expect(snippetLines).toEqual([
         {
           cum: 0,
           flat: 0,
@@ -482,7 +482,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
 
     describe('when the lines contained in callSitesMap are smaller than the number of padded lines', () => {
       it('returns an array cropped properly', () => {
-        const [snippet, allLines] = annotateLines(
+        const { snippetLines, allLines } = annotateLines(
           fileContent,
           new Map([
             [2, { line: 2, flat: 0, cum: 40000000 }],
@@ -491,7 +491,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
           ])
         );
 
-        expect(snippet).toEqual([
+        expect(snippetLines).toEqual([
           {
             cum: 30000000,
             flat: 0,

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/__tests__/annotateLines.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/__tests__/annotateLines.spec.ts
@@ -4,7 +4,10 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
   describe('if callSitesMap is empty', () => {
     it('returns an empty snippet and empty allLines array', () => {
       const result = annotatePlaceholderLines(new Map());
-      expect(result).toEqual([[], []]);
+      expect(result).toEqual({
+        snippetLines: [],
+        allLines: [],
+      });
     });
   });
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/__tests__/buildLineProfiles.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/__tests__/buildLineProfiles.spec.ts
@@ -1,16 +1,16 @@
-import { buildLineProfiles, buildPlaceholderLineProfiles } from '../buildLineProfiles';
+import { annotateLines, annotatePlaceholderLineProfiles } from '../buildLineProfiles';
 
 describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
   describe('if callSitesMap is empty', () => {
-    it('returns an empty array', () => {
-      const result = buildPlaceholderLineProfiles(new Map());
-      expect(result).toEqual([]);
+    it('returns an empty snippet and empty allLines array', () => {
+      const result = annotatePlaceholderLineProfiles(new Map());
+      expect(result).toEqual([[], []]);
     });
   });
 
   describe('if callSitesMap is not empty', () => {
-    it('returns an array containing samples/line info, sorted by line number and padded with extra lines', () => {
-      const result = buildPlaceholderLineProfiles(
+    it('returns a snippet of annotated code lines', () => {
+      const [snippet, allLines] = annotatePlaceholderLineProfiles(
         new Map([
           [12, { line: 12, flat: 0, cum: 40000000 }],
           [15, { line: 15, flat: 0, cum: 710000000 }],
@@ -18,105 +18,105 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
         ])
       );
 
-      expect(result).toMatchInlineSnapshot(`
-        [
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 6,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 7,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 8,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 9,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 10,
-          },
-          {
-            "cum": 30000000,
-            "flat": 0,
-            "line": undefined,
-            "number": 11,
-          },
-          {
-            "cum": 40000000,
-            "flat": 0,
-            "line": undefined,
-            "number": 12,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 13,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 14,
-          },
-          {
-            "cum": 710000000,
-            "flat": 0,
-            "line": undefined,
-            "number": 15,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 16,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 17,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 18,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 19,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": undefined,
-            "number": 20,
-          },
-        ]
-      `);
+      expect(snippet).toEqual([
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 6,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 7,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 8,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 9,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 10,
+        },
+        {
+          cum: 30000000,
+          flat: 0,
+          line: undefined,
+          number: 11,
+        },
+        {
+          cum: 40000000,
+          flat: 0,
+          line: undefined,
+          number: 12,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 13,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 14,
+        },
+        {
+          cum: 710000000,
+          flat: 0,
+          line: undefined,
+          number: 15,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 16,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 17,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 18,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 19,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: undefined,
+          number: 20,
+        },
+      ]);
+
+      expect(allLines).toEqual([]);
     });
 
     describe('when the lines contained in callSitesMap are smaller than the number of padded lines', () => {
       it('returns an array cropped properly', () => {
-        const result = buildPlaceholderLineProfiles(
+        const [snippet, allLines] = annotatePlaceholderLineProfiles(
           new Map([
             [2, { line: 2, flat: 0, cum: 40000000 }],
             [4, { line: 4, flat: 0, cum: 710000000 }],
@@ -124,64 +124,64 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
           ])
         );
 
-        expect(result).toMatchInlineSnapshot(`
-          [
-            {
-              "cum": 30000000,
-              "flat": 0,
-              "line": undefined,
-              "number": 1,
-            },
-            {
-              "cum": 40000000,
-              "flat": 0,
-              "line": undefined,
-              "number": 2,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": undefined,
-              "number": 3,
-            },
-            {
-              "cum": 710000000,
-              "flat": 0,
-              "line": undefined,
-              "number": 4,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": undefined,
-              "number": 5,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": undefined,
-              "number": 6,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": undefined,
-              "number": 7,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": undefined,
-              "number": 8,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": undefined,
-              "number": 9,
-            },
-          ]
-        `);
+        expect(snippet).toEqual([
+          {
+            cum: 30000000,
+            flat: 0,
+            line: undefined,
+            number: 1,
+          },
+          {
+            cum: 40000000,
+            flat: 0,
+            line: undefined,
+            number: 2,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: undefined,
+            number: 3,
+          },
+          {
+            cum: 710000000,
+            flat: 0,
+            line: undefined,
+            number: 4,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: undefined,
+            number: 5,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: undefined,
+            number: 6,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: undefined,
+            number: 7,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: undefined,
+            number: 8,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: undefined,
+            number: 9,
+          },
+        ]);
+
+        expect(allLines).toEqual([]);
       });
     });
   });
@@ -189,9 +189,17 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
 
 describe('buildLineProfiles(fileContent, callSitesMap', () => {
   describe('if callSitesMap is empty', () => {
-    it('returns an empty array', () => {
-      const result = buildLineProfiles('// this file is empty', new Map());
-      expect(result).toEqual([]);
+    it('returns an empty snippet array', () => {
+      const [snippet, allLines] = annotateLines('// this file is empty', new Map());
+      expect(snippet).toEqual([]);
+      expect(allLines).toEqual([
+        {
+          cum: 0,
+          flat: 0,
+          line: '// this file is empty',
+          number: 1,
+        },
+      ]);
     });
   });
 
@@ -222,7 +230,7 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
 });`;
 
     it('returns an array containing samples/line info, sorted by line number and padded with extra lines', () => {
-      const result = buildLineProfiles(
+      const [snippet, allLines] = annotateLines(
         fileContent,
         new Map([
           [12, { line: 12, flat: 0, cum: 40000000 }],
@@ -231,105 +239,250 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
         ])
       );
 
-      expect(result).toMatchInlineSnapshot(`
-        [
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "            const result = buildPlaceholderLineProfiles(new Map());",
-            "number": 6,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "            expect(result).toEqual([]);",
-            "number": 7,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "        });",
-            "number": 8,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "    });",
-            "number": 9,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "",
-            "number": 10,
-          },
-          {
-            "cum": 30000000,
-            "flat": 0,
-            "line": "    describe('if callSitesMap is not empty', () => {",
-            "number": 11,
-          },
-          {
-            "cum": 40000000,
-            "flat": 0,
-            "line": "        it('returns an array containing samples/line info, sorted by line number and padded with extra lines', () => {",
-            "number": 12,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "            const result = buildPlaceholderLineProfiles(",
-            "number": 13,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "                new Map([",
-            "number": 14,
-          },
-          {
-            "cum": 710000000,
-            "flat": 0,
-            "line": "                [12, { line: 12, flat: 0, cum: 40000000 }],",
-            "number": 15,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "                [15, { line: 15, flat: 0, cum: 710000000 }],",
-            "number": 16,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "                [11, { line: 11, flat: 0, cum: 30000000 }],",
-            "number": 17,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "                ])",
-            "number": 18,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "            );",
-            "number": 19,
-          },
-          {
-            "cum": 0,
-            "flat": 0,
-            "line": "",
-            "number": 20,
-          },
-        ]
-      `);
+      expect(snippet).toEqual([
+        {
+          cum: 0,
+          flat: 0,
+          line: '            const result = buildPlaceholderLineProfiles(new Map());',
+          number: 6,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            expect(result).toEqual([]);',
+          number: 7,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '        });',
+          number: 8,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '    });',
+          number: 9,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '',
+          number: 10,
+        },
+        {
+          cum: 30000000,
+          flat: 0,
+          line: "    describe('if callSitesMap is not empty', () => {",
+          number: 11,
+        },
+        {
+          cum: 40000000,
+          flat: 0,
+          line: "        it('returns an array containing samples/line info, sorted by line number and padded with extra lines', () => {",
+          number: 12,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            const result = buildPlaceholderLineProfiles(',
+          number: 13,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                new Map([',
+          number: 14,
+        },
+        {
+          cum: 710000000,
+          flat: 0,
+          line: '                [12, { line: 12, flat: 0, cum: 40000000 }],',
+          number: 15,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                [15, { line: 15, flat: 0, cum: 710000000 }],',
+          number: 16,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                [11, { line: 11, flat: 0, cum: 30000000 }],',
+          number: 17,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                ])',
+          number: 18,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            );',
+          number: 19,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '',
+          number: 20,
+        },
+      ]);
+
+      expect(allLines).toEqual([
+        {
+          cum: 0,
+          flat: 0,
+          line: "import { buildLineProfiles, buildPlaceholderLineProfiles } from '../buildLineProfiles';",
+          number: 1,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '',
+          number: 2,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: "describe('buildPlaceholderLineProfiles(callSitesMap)', () => {",
+          number: 3,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: "    describe('if callSitesMap is empty', () => {",
+          number: 4,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: "        it('returns an empty array', () => {",
+          number: 5,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            const result = buildPlaceholderLineProfiles(new Map());',
+          number: 6,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            expect(result).toEqual([]);',
+          number: 7,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '        });',
+          number: 8,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '    });',
+          number: 9,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '',
+          number: 10,
+        },
+        {
+          cum: 30000000,
+          flat: 0,
+          line: "    describe('if callSitesMap is not empty', () => {",
+          number: 11,
+        },
+        {
+          cum: 40000000,
+          flat: 0,
+          line: "        it('returns an array containing samples/line info, sorted by line number and padded with extra lines', () => {",
+          number: 12,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            const result = buildPlaceholderLineProfiles(',
+          number: 13,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                new Map([',
+          number: 14,
+        },
+        {
+          cum: 710000000,
+          flat: 0,
+          line: '                [12, { line: 12, flat: 0, cum: 40000000 }],',
+          number: 15,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                [15, { line: 15, flat: 0, cum: 710000000 }],',
+          number: 16,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                [11, { line: 11, flat: 0, cum: 30000000 }],',
+          number: 17,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '                ])',
+          number: 18,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            );',
+          number: 19,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '',
+          number: 20,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '            expect(result).toMatchInlineSnapshot();',
+          number: 21,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '        });',
+          number: 22,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '    });',
+          number: 23,
+        },
+        {
+          cum: 0,
+          flat: 0,
+          line: '});',
+          number: 24,
+        },
+      ]);
     });
 
     describe('when the lines contained in callSitesMap are smaller than the number of padded lines', () => {
       it('returns an array cropped properly', () => {
-        const result = buildLineProfiles(
+        const [snippet, allLines] = annotateLines(
           fileContent,
           new Map([
             [2, { line: 2, flat: 0, cum: 40000000 }],
@@ -338,64 +491,209 @@ describe('buildPlaceholderLineProfiles(callSitesMap)', () => {
           ])
         );
 
-        expect(result).toMatchInlineSnapshot(`
-          [
-            {
-              "cum": 30000000,
-              "flat": 0,
-              "line": "import { buildLineProfiles, buildPlaceholderLineProfiles } from '../buildLineProfiles';",
-              "number": 1,
-            },
-            {
-              "cum": 40000000,
-              "flat": 0,
-              "line": "",
-              "number": 2,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": "describe('buildPlaceholderLineProfiles(callSitesMap)', () => {",
-              "number": 3,
-            },
-            {
-              "cum": 710000000,
-              "flat": 0,
-              "line": "    describe('if callSitesMap is empty', () => {",
-              "number": 4,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": "        it('returns an empty array', () => {",
-              "number": 5,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": "            const result = buildPlaceholderLineProfiles(new Map());",
-              "number": 6,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": "            expect(result).toEqual([]);",
-              "number": 7,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": "        });",
-              "number": 8,
-            },
-            {
-              "cum": 0,
-              "flat": 0,
-              "line": "    });",
-              "number": 9,
-            },
-          ]
-        `);
+        expect(snippet).toEqual([
+          {
+            cum: 30000000,
+            flat: 0,
+            line: "import { buildLineProfiles, buildPlaceholderLineProfiles } from '../buildLineProfiles';",
+            number: 1,
+          },
+          {
+            cum: 40000000,
+            flat: 0,
+            line: '',
+            number: 2,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: "describe('buildPlaceholderLineProfiles(callSitesMap)', () => {",
+            number: 3,
+          },
+          {
+            cum: 710000000,
+            flat: 0,
+            line: "    describe('if callSitesMap is empty', () => {",
+            number: 4,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: "        it('returns an empty array', () => {",
+            number: 5,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '            const result = buildPlaceholderLineProfiles(new Map());',
+            number: 6,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '            expect(result).toEqual([]);',
+            number: 7,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '        });',
+            number: 8,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '    });',
+            number: 9,
+          },
+        ]);
+
+        expect(allLines).toEqual([
+          {
+            cum: 30000000,
+            flat: 0,
+            line: "import { buildLineProfiles, buildPlaceholderLineProfiles } from '../buildLineProfiles';",
+            number: 1,
+          },
+          {
+            cum: 40000000,
+            flat: 0,
+            line: '',
+            number: 2,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: "describe('buildPlaceholderLineProfiles(callSitesMap)', () => {",
+            number: 3,
+          },
+          {
+            cum: 710000000,
+            flat: 0,
+            line: "    describe('if callSitesMap is empty', () => {",
+            number: 4,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: "        it('returns an empty array', () => {",
+            number: 5,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '            const result = buildPlaceholderLineProfiles(new Map());',
+            number: 6,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '            expect(result).toEqual([]);',
+            number: 7,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '        });',
+            number: 8,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '    });',
+            number: 9,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '',
+            number: 10,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: "    describe('if callSitesMap is not empty', () => {",
+            number: 11,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: "        it('returns an array containing samples/line info, sorted by line number and padded with extra lines', () => {",
+            number: 12,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '            const result = buildPlaceholderLineProfiles(',
+            number: 13,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '                new Map([',
+            number: 14,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '                [12, { line: 12, flat: 0, cum: 40000000 }],',
+            number: 15,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '                [15, { line: 15, flat: 0, cum: 710000000 }],',
+            number: 16,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '                [11, { line: 11, flat: 0, cum: 30000000 }],',
+            number: 17,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '                ])',
+            number: 18,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '            );',
+            number: 19,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '',
+            number: 20,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '            expect(result).toMatchInlineSnapshot();',
+            number: 21,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '        });',
+            number: 22,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '    });',
+            number: 23,
+          },
+          {
+            cum: 0,
+            flat: 0,
+            line: '});',
+            number: 24,
+          },
+        ]);
       });
     });
   });

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/annotateLines.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/annotateLines.ts
@@ -4,9 +4,17 @@ const VERTICAL_LINES_PADDING = 5;
 
 type CallSitesMap = Map<number, CallSiteProps>;
 
-export function annotatePlaceholderLineProfiles(callSitesMap: CallSitesMap): LineProfile[][] {
+interface AnnotatedLines {
+  snippetLines: LineProfile[];
+  allLines: LineProfile[];
+}
+
+export function annotatePlaceholderLines(callSitesMap: CallSitesMap): AnnotatedLines {
   if (!callSitesMap.size) {
-    return [[], []];
+    return {
+      snippetLines: [],
+      allLines: [],
+    };
   }
 
   const callSites = Array.from(callSitesMap.values()).sort((a, b) => a.line - b.line);
@@ -28,10 +36,13 @@ export function annotatePlaceholderLineProfiles(callSitesMap: CallSitesMap): Lin
 
   // With no file contents, we return only a dummy annotated snippet which shows
   // the appropriate line numbers, but no content.
-  return [annotatedSnippet, []];
+  return {
+    snippetLines: annotatedSnippet,
+    allLines: [],
+  };
 }
 
-export function annotateLines(fileContent: string, callSitesMap: CallSitesMap): LineProfile[][] {
+export function annotateLines(fileContent: string, callSitesMap: CallSitesMap): AnnotatedLines {
   const callSites = Array.from(callSitesMap.values()).sort((a, b) => a.line - b.line);
   const lines = fileContent.split('\n');
 
@@ -49,12 +60,18 @@ export function annotateLines(fileContent: string, callSitesMap: CallSitesMap): 
 
   if (callSitesMap.size === 0) {
     // If the call site map is empty, there's no snippet to render.
-    return [[], annotatedLines];
+    return {
+      snippetLines: [],
+      allLines: annotatedLines,
+    };
   }
 
   const firstLineIndex = Math.max(0, callSites[0].line - VERTICAL_LINES_PADDING - 1);
   const lastLineIndex = Math.min(lines.length, callSites[callSites.length - 1].line + VERTICAL_LINES_PADDING);
   const annotatedSnippet = annotatedLines.slice(firstLineIndex, lastLineIndex);
 
-  return [annotatedSnippet, annotatedLines];
+  return {
+    snippetLines: annotatedSnippet,
+    allLines: annotatedLines,
+  };
 }

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
@@ -4,8 +4,8 @@ import { useMemo, useState } from 'react';
 import { FunctionDetails, LineProfile } from '../../../domain/types/FunctionDetails';
 import { useGitHubContext } from '../../GitHubContextProvider/useGitHubContext';
 import { useFetchVCSFile } from '../infrastructure/useFetchVCSFile';
+import { annotateLines, annotatePlaceholderLines } from './annotateLines';
 import { buildGithubUrlForFunction } from './buildGithubUrlForFunction';
-import { annotateLines, annotatePlaceholderLineProfiles } from './buildLineProfiles';
 
 /**
  * View model for Code component
@@ -35,16 +35,13 @@ export function useCodeContainer(dataSourceUid: string, functionDetails: Functio
   });
 
   // might be a bit costly so we memoize it
-  const { snippetLines, lines } = useMemo(() => {
-    const [snippetLines, lines] = fileInfo?.content
-      ? annotateLines(fileInfo.content, functionDetails.callSites)
-      : annotatePlaceholderLineProfiles(functionDetails.callSites);
-
-    return {
-      snippetLines,
-      lines,
-    };
-  }, [fileInfo?.content, functionDetails.callSites]);
+  const { snippetLines, allLines } = useMemo(
+    () =>
+      fileInfo?.content
+        ? annotateLines(fileInfo.content, functionDetails.callSites)
+        : annotatePlaceholderLines(functionDetails.callSites),
+    [fileInfo?.content, functionDetails.callSites]
+  );
 
   return {
     data: {
@@ -54,8 +51,8 @@ export function useCodeContainer(dataSourceUid: string, functionDetails: Functio
       unit: functionDetails.unit,
       githubUrl: fileInfo?.URL ? buildGithubUrlForFunction(fileInfo.URL, functionDetails.startLine) : undefined,
       snippetLines: snippetLines.map((annotatedLine) => ({ ...annotatedLine, line: annotatedLine.line ?? '???' })),
-      allLines: lines.map((annotateLine) => ({ ...annotateLine, line: annotateLine.line ?? '???' })),
-      noCodeAvailable: Boolean(fetchError) || !lines.some((line) => line.line),
+      allLines: allLines.map((annotateLine) => ({ ...annotateLine, line: annotateLine.line ?? '???' })),
+      noCodeAvailable: Boolean(fetchError) || !allLines.some((line) => line.line),
     },
     actions: {
       setOpenAiSuggestions,


### PR DESCRIPTION
### ✨ Description

Currently, we only use the snippet of code displayed to the user as context for the LLM prompt. This has the downside of making the LLM reason with less information. If we pass the entire file (if we have it) to the LLM prompt, this should improve its reasoning ability and give users the chance to ask follow up questions about portions of the code which might be in the same file, but not in the profiling snippet.

Here's an example of a short code snippet in a large file:

![image-1](https://github.com/user-attachments/assets/30c38045-b535-4521-b401-51665058d2d0)

When asked about code in a different part of the same file, the LLM reports it can only reason about the current snippet:

![image](https://github.com/user-attachments/assets/0e7b4171-0c91-4648-b53f-698666973673)

With the changes in this PR, the LLM can now reason about the the entire file. Here's a snippet that's part of a larger file:

<img width="1096" alt="Screenshot 2025-03-11 at 5 17 43 PM" src="https://github.com/user-attachments/assets/e817cc96-c2ff-4ff3-abb2-2c9d35c96345" />

And here is the LLM's response to asking about a specific part of the file not found in the snippet:

<img width="1074" alt="Screenshot 2025-03-11 at 5 07 43 PM" src="https://github.com/user-attachments/assets/9eacfe46-661b-4a06-b642-d25ff08fd913" />


### 🧪 How to test?

The unit tests should pass
