### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @grafana/observability-traces-and-profiling
+


### PR DESCRIPTION
This is to make sure the protection rule is applied. The protection rule is applied but without CODEOWNERS file is not enforced (e.g. #447)
