### PR TITLE
chore(e2e): update tests

### DIFF
--- a/e2e/tests/flame-graph-view/github-integration.spec.ts
+++ b/e2e/tests/flame-graph-view/github-integration.spec.ts
@@ -15,7 +15,7 @@ test.describe('Flame graph view', () => {
   });
 
   test.describe('GitHub Integration', () => {
-    const nodePosition = { x: 30, y: 30 };
+    const nodePosition = { x: 30, y: 60 };
     const functionName = 'github.com/grafana/dskit/services.(*BasicService).main';
     const startLine = '153';
     // see ellipsis hack in SceneFunctionDetailsPanel.tsx


### PR DESCRIPTION
### ✨ Description

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

In GitHub Integration tests we use profiles generated by Pyroscope backend. In the latest version the profile changed a bit and additional function block is showing up before `main()` function we use for testing. 

This causes our e2e tests fail in main.

The fix is to move the user interaction coordinates to click on the right block.

Check the flame graph below - look at StartAsync and main functions in the top left corner

| before | after |
|---|---|
| <img width="1708" alt="Screenshot 2025-03-25 at 14 14 12" src="https://github.com/user-attachments/assets/f71069b1-731a-44ca-9a2f-0328528a9f6c" /> | <img width="1710" alt="Screenshot 2025-03-25 at 14 11 44" src="https://github.com/user-attachments/assets/892ac215-25da-46e7-8cfc-c42db9511b27" /> |



### 🧪 How to test?

e2e tests should pass
