### PR TITLE
fix(Settings): Reload settings when data source changes

### DIFF
--- a/src/shared/infrastructure/settings/settingsApiClient.ts
+++ b/src/shared/infrastructure/settings/settingsApiClient.ts
@@ -38,4 +38,6 @@ class SettingsApiClient extends ApiClient {
   }
 }
 
-export const settingsApiClient = new SettingsApiClient();
+export const useSettingsApiClient = () => {
+  return new SettingsApiClient();
+};

--- a/src/shared/infrastructure/settings/useFetchPluginSettings.ts
+++ b/src/shared/infrastructure/settings/useFetchPluginSettings.ts
@@ -1,7 +1,8 @@
+import { ApiClient } from '@shared/infrastructure/http/ApiClient';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_SETTINGS, PluginSettings } from './PluginSettings';
-import { settingsApiClient } from './settingsApiClient';
+import { useSettingsApiClient } from './settingsApiClient';
 
 type FetchParams = {
   enabled?: boolean;
@@ -18,9 +19,11 @@ type FetchResponse = {
  * Fetches the plugin settings and, if none/only some have been stored previously, returns adequate default values for the rest of the application
  */
 export function useFetchPluginSettings({ enabled }: FetchParams = {}): FetchResponse {
+  const settingsApiClient = useSettingsApiClient();
+
   const { isFetching, error, data } = useQuery({
     enabled,
-    queryKey: ['settings'],
+    queryKey: ['settings', 'ds-uid-' + ApiClient.selectDefaultDataSource().uid],
     queryFn: () =>
       settingsApiClient.get().then(
         (json) =>


### PR DESCRIPTION
### ✨ Description

Fixes: #467

<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

Ensure base URL is recreated for settings when fetching + when data source changes the query is retriggered.

### 🧪 How to test?

Looks for `/api/datasources/proxy/uid/[DATASOURCE_UID]/settings.v1.SettingsService/Get` calls in network tab. The `[DATASOURCE_UID]` should be updated after changing the data source.


Before:

https://github.com/user-attachments/assets/c3ee7581-56cf-409c-afdf-be5d1061dcbb

After:

https://github.com/user-attachments/assets/0ec49778-20f8-4462-8cba-4fd54429ac83
