### PR TITLE
fix: Cascader options break when services have multiple levels with matching prefix

### DIFF
--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/__tests__/useBuildServiceNameOptions.spec.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/__tests__/useBuildServiceNameOptions.spec.ts
@@ -26,7 +26,7 @@ describe('buildServiceNameCascaderOptions', () => {
 
     const expected: CascaderOption[] = [
       {
-        value: 'service1',
+        value: 'service1/',
         label: 'service1',
         items: [
           { value: 'service1/subservice1', label: 'subservice1' },
@@ -44,11 +44,11 @@ describe('buildServiceNameCascaderOptions', () => {
 
     const expected: CascaderOption[] = [
       {
-        value: 'service1',
+        value: 'service1/',
         label: 'service1',
         items: [
           {
-            value: 'service1/subservice1',
+            value: 'service1/subservice1/',
             label: 'subservice1',
             items: [
               { value: 'service1/subservice1/endpoint1', label: 'endpoint1' },
@@ -73,16 +73,16 @@ describe('buildServiceNameCascaderOptions', () => {
         items: undefined,
       },
       {
-        value: 'service2',
+        value: 'service2/',
         label: 'service2',
         items: [{ value: 'service2/subservice1', label: 'subservice1' }],
       },
       {
-        value: 'service3',
+        value: 'service3/',
         label: 'service3',
         items: [
           {
-            value: 'service3/subservice1',
+            value: 'service3/subservice1/',
             label: 'subservice1',
             items: [{ value: 'service3/subservice1/endpoint1', label: 'endpoint1' }],
           },
@@ -104,7 +104,7 @@ describe('buildServiceNameCascaderOptions', () => {
         items: undefined,
       },
       {
-        value: 'top-service',
+        value: 'top-service/',
         label: 'top-service',
         items: [
           {

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/__tests__/useBuildServiceNameOptions.spec.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/__tests__/useBuildServiceNameOptions.spec.ts
@@ -1,0 +1,126 @@
+import { CascaderOption } from '@grafana/ui';
+
+import { buildServiceNameCascaderOptions } from '../useBuildServiceNameOptions';
+
+describe('buildServiceNameCascaderOptions', () => {
+  it('should return empty array for empty input', () => {
+    const result = buildServiceNameCascaderOptions([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should build cascader options for single level service names', () => {
+    const serviceNames = ['service1', 'service2'];
+    const result = buildServiceNameCascaderOptions(serviceNames);
+
+    const expected: CascaderOption[] = [
+      { value: 'service1', label: 'service1' },
+      { value: 'service2', label: 'service2' },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should build cascader options for nested service names', () => {
+    const serviceNames = ['service1/subservice1', 'service1/subservice2'];
+    const result = buildServiceNameCascaderOptions(serviceNames);
+
+    const expected: CascaderOption[] = [
+      {
+        value: 'service1',
+        label: 'service1',
+        items: [
+          { value: 'service1/subservice1', label: 'subservice1' },
+          { value: 'service1/subservice2', label: 'subservice2' },
+        ],
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should build cascader options for deeply nested service names', () => {
+    const serviceNames = ['service1/subservice1/endpoint1', 'service1/subservice1/endpoint2'];
+    const result = buildServiceNameCascaderOptions(serviceNames);
+
+    const expected: CascaderOption[] = [
+      {
+        value: 'service1',
+        label: 'service1',
+        items: [
+          {
+            value: 'service1/subservice1',
+            label: 'subservice1',
+            items: [
+              { value: 'service1/subservice1/endpoint1', label: 'endpoint1' },
+              { value: 'service1/subservice1/endpoint2', label: 'endpoint2' },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle mixed depth with no overlaps', () => {
+    const serviceNames = ['service1', 'service2/subservice1', 'service3/subservice1/endpoint1'];
+    const result = buildServiceNameCascaderOptions(serviceNames);
+
+    const expected: CascaderOption[] = [
+      {
+        value: 'service1',
+        label: 'service1',
+        items: undefined,
+      },
+      {
+        value: 'service2',
+        label: 'service2',
+        items: [{ value: 'service2/subservice1', label: 'subservice1' }],
+      },
+      {
+        value: 'service3',
+        label: 'service3',
+        items: [
+          {
+            value: 'service3/subservice1',
+            label: 'subservice1',
+            items: [{ value: 'service3/subservice1/endpoint1', label: 'endpoint1' }],
+          },
+        ],
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle mixed depth with overlap of service names', () => {
+    const serviceNames = ['top-service', 'top-service/sub-service1', 'top-service/sub-service2'];
+    const result = buildServiceNameCascaderOptions(serviceNames);
+
+    const expected: CascaderOption[] = [
+      {
+        value: 'service1',
+        label: 'service1',
+        items: undefined,
+      },
+      {
+        value: 'service2',
+        label: 'service2',
+        items: [{ value: 'service2/subservice1', label: 'subservice1' }],
+      },
+      {
+        value: 'service3',
+        label: 'service3',
+        items: [
+          {
+            value: 'service3/subservice1',
+            label: 'subservice1',
+            items: [{ value: 'service3/subservice1/endpoint1', label: 'endpoint1' }],
+          },
+        ],
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/__tests__/useBuildServiceNameOptions.spec.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/__tests__/useBuildServiceNameOptions.spec.ts
@@ -99,23 +99,23 @@ describe('buildServiceNameCascaderOptions', () => {
 
     const expected: CascaderOption[] = [
       {
-        value: 'service1',
-        label: 'service1',
+        value: 'top-service',
+        label: 'top-service',
         items: undefined,
       },
       {
-        value: 'service2',
-        label: 'service2',
-        items: [{ value: 'service2/subservice1', label: 'subservice1' }],
-      },
-      {
-        value: 'service3',
-        label: 'service3',
+        value: 'top-service',
+        label: 'top-service',
         items: [
           {
-            value: 'service3/subservice1',
-            label: 'subservice1',
-            items: [{ value: 'service3/subservice1/endpoint1', label: 'endpoint1' }],
+            label: 'sub-service1',
+            value: 'top-service/sub-service1',
+            items: undefined,
+          },
+          {
+            label: 'sub-service2',
+            value: 'top-service/sub-service2',
+            items: undefined,
           },
         ],
       },

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/useBuildServiceNameOptions.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/useBuildServiceNameOptions.ts
@@ -24,7 +24,8 @@ export function buildServiceNameCascaderOptions(serviceNames: string[]) {
 
       if (!hierarchy.has(currentPath) || isComplete) {
         const option: CascaderOption = {
-          value: currentPath,
+          // the value needs to be different for a complete one vs the one that goes deeper otherwise it will not be selected.
+          value: isComplete ? currentPath : currentPath + '/',
           label: part,
           items: isComplete ? undefined : [],
         };

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/useBuildServiceNameOptions.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/useBuildServiceNameOptions.ts
@@ -1,4 +1,4 @@
-import { Cascader, CascaderOption } from '@grafana/ui';
+import { CascaderOption } from '@grafana/ui';
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export function buildServiceNameCascaderOptions(serviceNames: string[]) {
@@ -20,7 +20,7 @@ export function buildServiceNameCascaderOptions(serviceNames: string[]) {
       const previousPath = currentPath;
       currentPath = currentPath ? `${currentPath}/${part}` : part;
 
-      const isComplete = i == parts.length - 1;
+      const isComplete = i === parts.length - 1;
 
       if (!hierarchy.has(currentPath) || isComplete) {
         const option: CascaderOption = {
@@ -29,26 +29,22 @@ export function buildServiceNameCascaderOptions(serviceNames: string[]) {
           items: isComplete ? undefined : [],
         };
 
-        // if the option is complete, we don't need to show the placeholder
+        // if the option is not complete it should be part of the hierachy
         if (!isComplete) {
           hierarchy.set(currentPath, option);
         }
 
-        if (!previousPath) {
-          rootElements.push(option);
-        }
-
-        // Add to parent's items if not root level
+        // Add to parent's items if not root level, other wise it will be added to the rootElements
         if (previousPath) {
           const parent = hierarchy.get(previousPath);
           if (parent && parent.items) {
             parent.items.push(option);
           }
+        } else {
+          rootElements.push(option);
         }
       }
     }
   }
-
-  // Return only root level options
   return rootElements;
 }

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/useBuildServiceNameOptions.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/domain/useBuildServiceNameOptions.ts
@@ -1,40 +1,54 @@
-import { CascaderOption } from '@grafana/ui';
+import { Cascader, CascaderOption } from '@grafana/ui';
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export function buildServiceNameCascaderOptions(serviceNames: string[]) {
-  const options: CascaderOption[] = [];
+  // Sort the service names to ensure consistent ordering
+  const sortedServiceNames = [...serviceNames].sort();
 
-  for (const serviceId of serviceNames) {
-    // serviceId = ebpf/agent-logs/agent ; parts = [ebpf,agent-logs,agent]
+  // Keep track of the root elements
+  const rootElements: CascaderOption[] = [];
+
+  // Create a map to store the hierarchy
+  const hierarchy = new Map<string, CascaderOption>();
+
+  for (const serviceId of sortedServiceNames) {
     const parts = serviceId.split('/');
+    let currentPath = '';
 
-    let currentPart: string;
-    const currentValues = [];
-    let currentOptions = options;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const previousPath = currentPath;
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
 
-    for (let level = 0; level < parts.length; level += 1) {
-      currentPart = parts[level];
-      currentValues.push(currentPart);
-      const value = currentValues.join('/');
+      const isComplete = i == parts.length - 1;
 
-      const existingOption = currentOptions.find((o) => o.value === value);
-
-      if (existingOption) {
-        currentOptions = existingOption.items as CascaderOption[];
-      } else {
-        const newOption = {
-          value,
-          label: currentPart,
-          // setting items only for non-terminal nodes is required by the Cascader component
-          // without it, the initial value would not be properly set in the UI
-          items: level < parts.length - 1 ? [] : undefined,
+      if (!hierarchy.has(currentPath) || isComplete) {
+        const option: CascaderOption = {
+          value: currentPath,
+          label: part,
+          items: isComplete ? undefined : [],
         };
 
-        currentOptions.push(newOption);
-        currentOptions = newOption.items || [];
+        // if the option is complete, we don't need to show the placeholder
+        if (!isComplete) {
+          hierarchy.set(currentPath, option);
+        }
+
+        if (!previousPath) {
+          rootElements.push(option);
+        }
+
+        // Add to parent's items if not root level
+        if (previousPath) {
+          const parent = hierarchy.get(previousPath);
+          if (parent && parent.items) {
+            parent.items.push(option);
+          }
+        }
       }
     }
   }
 
-  return options;
+  // Return only root level options
+  return rootElements;
 }


### PR DESCRIPTION
Assuming there is an overlap of services on different levels in the service_name hierachie, the app crashses.

![image](https://github.com/user-attachments/assets/ba65b9f1-0182-4709-8f7b-b9cf2f9fcdca)

I created that example by having two profiles series:

- `my-service`
- `my-service/my-subservice`

I have reimplemented the function sorting the services names first and then building up a hierarchic map, which should also be faster.

What is not ideal yet, is that it is not clear which one of the two is the one with children vs. the main one:

![image](https://github.com/user-attachments/assets/1f4e8cac-bbf7-4271-949b-1744d77dba6c)
![image](https://github.com/user-attachments/assets/678aa79f-c87c-4ff6-9ecc-fae911417b30)

