### PR TITLE
fix: Correct the menu for explore-profiles

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ export const PYROSCOPE_APP_ID = plugin.id;
 export const PLUGIN_BASE_URL = `/a/${PYROSCOPE_APP_ID}`;
 
 export enum ROUTES {
-  EXPLORE = '/explore',
+  EXPLORE = '/',
   ADHOC = '/ad-hoc',
   SETTINGS = '/settings',
   RECORDING_RULES = '/recording-rules',

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -42,8 +42,8 @@
   "includes": [
     {
       "type": "page",
-      "name": "Profiles",
-      "path": "/a/%PLUGIN_ID%/explore",
+      "name": "Explore",
+      "path": "/a/%PLUGIN_ID%",
       "action": "datasources:explore",
       "addToNav": true,
       "defaultNav": true


### PR DESCRIPTION
This is my first attempt to fix #486, but it might have some backwards compatibility problems, as `/explore` goes away.
