### PR TITLE
feat: visualize profile annotations

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries/SceneLabelValuesTimeseries.tsx
@@ -226,6 +226,10 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     });
   }
 
+  getPanel() {
+    return this.state.body;
+  }
+
   updateItem(partialItem: Partial<GridItemData>) {
     const { item, headerActions, body } = this.state;
     const updatedItem = merge({}, item, partialItem);

--- a/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
@@ -17,7 +17,7 @@ import { FiltersVariable } from '../domain/variables/FiltersVariable/FiltersVari
 import { GroupByVariable } from '../domain/variables/GroupByVariable/GroupByVariable';
 import { ProfileMetricVariable } from '../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../domain/variables/ServiceNameVariable/ServiceNameVariable';
-import { createAnnotationFrame } from '../helpers/annotationCollector';
+import { createThrottlingAnnotationFrame } from '../helpers/createThrottlingAnnotationFrame';
 import { getSceneVariableValue } from '../helpers/getSceneVariableValue';
 import { PYROSCOPE_DATA_SOURCE } from '../infrastructure/pyroscope-data-sources';
 import { getProfileMetricLabel } from '../infrastructure/series/helpers/getProfileMetricLabel';
@@ -158,7 +158,7 @@ export class SceneMainServiceTimeseries extends SceneObjectBase<SceneMainService
         // add annotation for the first time
         if (!newState.data.annotations?.length && !prevState.data?.annotations?.length) {
           const { $data } = this.getTimeseries()!.state;
-          const annotationFrame = createAnnotationFrame(newState.data);
+          const annotationFrame = createThrottlingAnnotationFrame(newState.data);
 
           $data?.setState({
             data: {

--- a/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
@@ -156,7 +156,7 @@ export class SceneMainServiceTimeseries extends SceneObjectBase<SceneMainService
         }
 
         // add annotation for the first time
-        if (!newState.data.annotations?.length && !prevState.data?.annotations?.length) {
+        if (!prevState.data?.annotations?.length) {
           const { $data } = this.getTimeseries()!.state;
           const annotationFrame = createThrottlingAnnotationFrame(newState.data);
 

--- a/src/pages/ProfilesExplorerView/helpers/__tests__/createThrottlingAnnotationFrame.spec.ts
+++ b/src/pages/ProfilesExplorerView/helpers/__tests__/createThrottlingAnnotationFrame.spec.ts
@@ -1,0 +1,284 @@
+import { DataFrame, DataTopic, DateTime, Field, FieldType, LoadingState, PanelData } from '@grafana/data';
+
+import { createThrottlingAnnotationFrame } from '../createThrottlingAnnotationFrame';
+
+describe('createThrottlingAnnotationFrame', () => {
+  const mockTime = 1234567890000;
+  const mockLimitResetTime = Math.floor(mockTime / 1000) + 3600; // 1 hour later
+
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => mockTime);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should create annotation frame from throttling annotations', () => {
+    const mockPanelData: PanelData = {
+      series: [
+        {
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: [mockTime],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'value',
+              type: FieldType.number,
+              values: [100],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'annotations',
+              type: FieldType.other,
+              values: [
+                [
+                  {
+                    key: 'pyroscope.ingest.throttled',
+                    value: JSON.stringify({
+                      body: {
+                        periodType: 'day',
+                        periodLimitMb: 1024,
+                        limitResetTime: mockLimitResetTime,
+                        samplingPeriodSec: 60,
+                        samplingRequests: 1,
+                        usageGroup: '',
+                      },
+                    }),
+                  },
+                ],
+              ],
+              config: {},
+            } as Field,
+          ],
+          length: 1,
+        } as DataFrame,
+      ],
+      state: LoadingState.Done,
+      timeRange: {
+        from: mockTime as unknown as DateTime,
+        to: mockTime as unknown as DateTime,
+        raw: {
+          from: mockTime as unknown as DateTime,
+          to: mockTime as unknown as DateTime,
+        },
+      },
+    };
+
+    const result = createThrottlingAnnotationFrame(mockPanelData);
+
+    expect(result.fields).toHaveLength(5);
+    expect(result.fields[0].name).toBe('time');
+    expect(result.fields[0].values[0]).toBe(mockTime);
+    expect(result.fields[1].name).toBe('timeEnd');
+    expect(result.fields[1].values[0]).toBe(mockLimitResetTime * 1000);
+    expect(result.fields[3].name).toBe('text');
+    expect(result.fields[3].values[0]).toBe('Ingestion limit of 1 GiB/day reached');
+    expect(result.fields[4].name).toBe('isRegion');
+    expect(result.fields[4].values[0]).toBe(false);
+    expect(result.meta?.dataTopic).toBe(DataTopic.Annotations);
+  });
+
+  it('should handle empty annotations array', () => {
+    const mockPanelData: PanelData = {
+      series: [
+        {
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: [mockTime],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'value',
+              type: FieldType.number,
+              values: [100],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'annotations',
+              type: FieldType.other,
+              values: [[]],
+              config: {},
+            } as Field,
+          ],
+          length: 1,
+        } as DataFrame,
+      ],
+      state: LoadingState.Done,
+      timeRange: {
+        from: mockTime as unknown as DateTime,
+        to: mockTime as unknown as DateTime,
+        raw: {
+          from: mockTime as unknown as DateTime,
+          to: mockTime as unknown as DateTime,
+        },
+      },
+    };
+
+    const result = createThrottlingAnnotationFrame(mockPanelData);
+    expect(result.fields[0].values.length).toBe(0);
+  });
+
+  it('should ignore unsupported annotation types', () => {
+    const mockPanelData: PanelData = {
+      series: [
+        {
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: [mockTime],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'value',
+              type: FieldType.number,
+              values: [100],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'annotations',
+              type: FieldType.other,
+              values: [
+                [
+                  {
+                    key: 'unsupported.annotation.type',
+                    value: JSON.stringify({ some: 'data' }),
+                  },
+                ],
+              ],
+              config: {},
+            } as Field,
+          ],
+          length: 1,
+        } as DataFrame,
+      ],
+      state: LoadingState.Done,
+      timeRange: {
+        from: mockTime as unknown as DateTime,
+        to: mockTime as unknown as DateTime,
+        raw: {
+          from: mockTime as unknown as DateTime,
+          to: mockTime as unknown as DateTime,
+        },
+      },
+    };
+
+    const result = createThrottlingAnnotationFrame(mockPanelData);
+    expect(result.fields[0].values.length).toBe(0);
+  });
+
+  it('should handle series without annotations field', () => {
+    const mockPanelData: PanelData = {
+      series: [
+        {
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: [mockTime],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'value',
+              type: FieldType.number,
+              values: [100],
+              config: {},
+            } as Field<number>,
+          ],
+          length: 1,
+        } as DataFrame,
+      ],
+      state: LoadingState.Done,
+      timeRange: {
+        from: mockTime as unknown as DateTime,
+        to: mockTime as unknown as DateTime,
+        raw: {
+          from: mockTime as unknown as DateTime,
+          to: mockTime as unknown as DateTime,
+        },
+      },
+    };
+
+    const result = createThrottlingAnnotationFrame(mockPanelData);
+    expect(result.fields[0].values.length).toBe(0);
+  });
+
+  it('should deduplicate annotations with same reset time', () => {
+    const mockPanelData: PanelData = {
+      series: [
+        {
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: [mockTime, mockTime + 1000],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'value',
+              type: FieldType.number,
+              values: [100, 200],
+              config: {},
+            } as Field<number>,
+            {
+              name: 'annotations',
+              type: FieldType.other,
+              values: [
+                [
+                  {
+                    key: 'pyroscope.ingest.throttled',
+                    value: JSON.stringify({
+                      body: {
+                        periodType: 'day',
+                        periodLimitMb: 1024,
+                        limitResetTime: mockLimitResetTime,
+                        samplingPeriodSec: 60,
+                        samplingRequests: 1,
+                        usageGroup: '',
+                      },
+                    }),
+                  },
+                ],
+                [
+                  {
+                    key: 'pyroscope.ingest.throttled',
+                    value: JSON.stringify({
+                      body: {
+                        periodType: 'day',
+                        periodLimitMb: 1024,
+                        limitResetTime: mockLimitResetTime,
+                        samplingPeriodSec: 60,
+                        samplingRequests: 1,
+                        usageGroup: '',
+                      },
+                    }),
+                  },
+                ],
+              ],
+              config: {},
+            } as Field,
+          ],
+          length: 2,
+        } as DataFrame,
+      ],
+      state: LoadingState.Done,
+      timeRange: {
+        from: mockTime as unknown as DateTime,
+        to: mockTime as unknown as DateTime,
+        raw: {
+          from: mockTime as unknown as DateTime,
+          to: mockTime as unknown as DateTime,
+        },
+      },
+    };
+
+    const result = createThrottlingAnnotationFrame(mockPanelData);
+    expect(result.fields[0].values.length).toBe(1);
+  });
+});

--- a/src/pages/ProfilesExplorerView/helpers/__tests__/createThrottlingAnnotationFrame.spec.ts
+++ b/src/pages/ProfilesExplorerView/helpers/__tests__/createThrottlingAnnotationFrame.spec.ts
@@ -31,30 +31,39 @@ describe('createThrottlingAnnotationFrame', () => {
               values: [100],
               config: {},
             } as Field<number>,
+          ],
+          length: 1,
+        } as DataFrame,
+      ],
+      annotations: [
+        {
+          fields: [
             {
               name: 'annotations',
               type: FieldType.other,
               values: [
                 [
                   {
-                    key: 'pyroscope.ingest.throttled',
-                    value: JSON.stringify({
-                      body: {
-                        periodType: 'day',
-                        periodLimitMb: 1024,
-                        limitResetTime: mockLimitResetTime,
-                        samplingPeriodSec: 60,
-                        samplingRequests: 1,
-                        usageGroup: '',
-                      },
-                    }),
+                    timestamp: mockTime,
+                    annotation: {
+                      key: 'pyroscope.ingest.throttled',
+                      value: JSON.stringify({
+                        body: {
+                          periodType: 'day',
+                          periodLimitMb: 1024,
+                          limitResetTime: mockLimitResetTime,
+                          samplingPeriodSec: 60,
+                          samplingRequests: 1,
+                          usageGroup: '',
+                        },
+                      }),
+                    },
                   },
                 ],
               ],
               config: {},
             } as Field,
           ],
-          length: 1,
         } as DataFrame,
       ],
       state: LoadingState.Done,
@@ -76,7 +85,7 @@ describe('createThrottlingAnnotationFrame', () => {
     expect(result.fields[1].name).toBe('timeEnd');
     expect(result.fields[1].values[0]).toBe(mockLimitResetTime * 1000);
     expect(result.fields[3].name).toBe('text');
-    expect(result.fields[3].values[0]).toBe('Ingestion limit of 1 GiB/day reached');
+    expect(result.fields[3].values[0]).toBe('Ingestion limit (1 GiB/day) reached');
     expect(result.fields[4].name).toBe('isRegion');
     expect(result.fields[4].values[0]).toBe(false);
     expect(result.meta?.dataTopic).toBe(DataTopic.Annotations);
@@ -99,6 +108,13 @@ describe('createThrottlingAnnotationFrame', () => {
               values: [100],
               config: {},
             } as Field<number>,
+          ],
+          length: 1,
+        } as DataFrame,
+      ],
+      annotations: [
+        {
+          fields: [
             {
               name: 'annotations',
               type: FieldType.other,
@@ -106,7 +122,6 @@ describe('createThrottlingAnnotationFrame', () => {
               config: {},
             } as Field,
           ],
-          length: 1,
         } as DataFrame,
       ],
       state: LoadingState.Done,
@@ -141,21 +156,30 @@ describe('createThrottlingAnnotationFrame', () => {
               values: [100],
               config: {},
             } as Field<number>,
+          ],
+          length: 1,
+        } as DataFrame,
+      ],
+      annotations: [
+        {
+          fields: [
             {
               name: 'annotations',
               type: FieldType.other,
               values: [
                 [
                   {
-                    key: 'unsupported.annotation.type',
-                    value: JSON.stringify({ some: 'data' }),
+                    timestamp: mockTime,
+                    annotation: {
+                      key: 'unsupported.annotation.type',
+                      value: JSON.stringify({ some: 'data' }),
+                    },
                   },
                 ],
               ],
               config: {},
             } as Field,
           ],
-          length: 1,
         } as DataFrame,
       ],
       state: LoadingState.Done,
@@ -226,45 +250,57 @@ describe('createThrottlingAnnotationFrame', () => {
               values: [100, 200],
               config: {},
             } as Field<number>,
+          ],
+          length: 2,
+        } as DataFrame,
+      ],
+      annotations: [
+        {
+          fields: [
             {
               name: 'annotations',
               type: FieldType.other,
               values: [
                 [
                   {
-                    key: 'pyroscope.ingest.throttled',
-                    value: JSON.stringify({
-                      body: {
-                        periodType: 'day',
-                        periodLimitMb: 1024,
-                        limitResetTime: mockLimitResetTime,
-                        samplingPeriodSec: 60,
-                        samplingRequests: 1,
-                        usageGroup: '',
-                      },
-                    }),
+                    timestamp: mockTime,
+                    annotation: {
+                      key: 'pyroscope.ingest.throttled',
+                      value: JSON.stringify({
+                        body: {
+                          periodType: 'day',
+                          periodLimitMb: 1024,
+                          limitResetTime: mockLimitResetTime,
+                          samplingPeriodSec: 60,
+                          samplingRequests: 1,
+                          usageGroup: '',
+                        },
+                      }),
+                    },
                   },
                 ],
                 [
                   {
-                    key: 'pyroscope.ingest.throttled',
-                    value: JSON.stringify({
-                      body: {
-                        periodType: 'day',
-                        periodLimitMb: 1024,
-                        limitResetTime: mockLimitResetTime,
-                        samplingPeriodSec: 60,
-                        samplingRequests: 1,
-                        usageGroup: '',
-                      },
-                    }),
+                    timestamp: mockTime + 1000,
+                    annotation: {
+                      key: 'pyroscope.ingest.throttled',
+                      value: JSON.stringify({
+                        body: {
+                          periodType: 'day',
+                          periodLimitMb: 1024,
+                          limitResetTime: mockLimitResetTime,
+                          samplingPeriodSec: 60,
+                          samplingRequests: 1,
+                          usageGroup: '',
+                        },
+                      }),
+                    },
                   },
                 ],
               ],
               config: {},
             } as Field,
           ],
-          length: 2,
         } as DataFrame,
       ],
       state: LoadingState.Done,

--- a/src/pages/ProfilesExplorerView/helpers/annotationCollector.ts
+++ b/src/pages/ProfilesExplorerView/helpers/annotationCollector.ts
@@ -1,0 +1,122 @@
+import {
+  createDataFrame,
+  DataFrameDTO,
+  DataTopic,
+  FieldType,
+  formattedValueToString,
+  getValueFormat,
+  PanelData,
+} from '@grafana/data';
+
+const formatSize = (size: number) => formattedValueToString(getValueFormat('bytes')(size));
+
+interface ProfileAnnotation {
+  type: ProfileAnnotationType;
+  body: ProfileThrottledAnnotation;
+}
+
+interface ProfileThrottledAnnotation {
+  periodType: string;
+  periodLimitMb: number;
+  limitResetTime: number;
+  samplingPeriodSec: number;
+  samplingRequests: number;
+  usageGroup: string;
+}
+
+enum ProfileAnnotationType {
+  Throttled = 'throttled',
+}
+
+interface ProfileAnnotationContainer {
+  bodies: string[];
+}
+
+interface AnnotationData {
+  times: number[];
+  timeEnds: number[];
+  texts: string[];
+  isRegion: boolean[];
+}
+
+function processThrottledAnnotation(
+  annotation: ProfileAnnotation,
+  currentKey: number | undefined
+): { text: string; timeEnd: number; isRegion: boolean; key: number } | null {
+  if (annotation.type !== ProfileAnnotationType.Throttled) {
+    return null;
+  }
+
+  if (currentKey === annotation.body.limitResetTime) {
+    return null;
+  }
+
+  const limit = formatSize(annotation.body.periodLimitMb * 1024 * 1024);
+  return {
+    text: `Ingestion limit of ${limit}/${annotation.body.periodType} reached`,
+    timeEnd: annotation.body.limitResetTime * 1000,
+    isRegion: annotation.body.limitResetTime < Math.floor(Date.now() / 1000),
+    key: annotation.body.limitResetTime,
+  };
+}
+
+function collectAnnotationData(data: PanelData): AnnotationData {
+  const result: AnnotationData = {
+    times: [],
+    timeEnds: [],
+    texts: [],
+    isRegion: [],
+  };
+
+  data.series.forEach((s) => {
+    if (s.fields.length <= 2 || s.fields[2].name !== 'annotations') {
+      return;
+    }
+
+    let key: number | undefined;
+    s.fields[2].values.forEach((annotationContainer: ProfileAnnotationContainer, i) => {
+      if (!annotationContainer) {
+        return;
+      }
+
+      annotationContainer.bodies.forEach((body) => {
+        const annotation = JSON.parse(body) as ProfileAnnotation;
+        const processed = processThrottledAnnotation(annotation, key);
+
+        if (processed) {
+          result.times.push(s.fields[0].values[i]);
+          result.timeEnds.push(processed.timeEnd);
+          result.isRegion.push(processed.isRegion);
+          result.texts.push(processed.text);
+          key = processed.key;
+        }
+      });
+    });
+  });
+
+  return result;
+}
+
+export function createAnnotationFrame(data: PanelData) {
+  const { times, timeEnds, texts, isRegion } = collectAnnotationData(data);
+
+  const fields = [
+    { name: 'time', type: FieldType.time, values: times },
+    { name: 'timeEnd', type: FieldType.time, values: timeEnds },
+    { name: 'color', type: FieldType.other, values: [] },
+    { name: 'text', type: FieldType.string, values: texts },
+    { name: 'isRegion', type: FieldType.boolean, values: isRegion },
+  ];
+
+  const frame: DataFrameDTO = {
+    name: 'annotations',
+    fields,
+  };
+
+  const annotationFrame = createDataFrame(frame);
+  annotationFrame.meta = {
+    dataTopic: DataTopic.Annotations,
+  };
+
+  return annotationFrame;
+}

--- a/src/shared/types/ProfileAnnotation.ts
+++ b/src/shared/types/ProfileAnnotation.ts
@@ -1,0 +1,26 @@
+export interface TimedAnnotation {
+  timestamp: number;
+  annotation: RawProfileAnnotation;
+}
+
+export interface RawProfileAnnotation {
+  key: string;
+  value: string;
+}
+
+export enum ProfileAnnotationKey {
+  Throttled = 'pyroscope.ingest.throttled',
+}
+
+export interface ProfileAnnotation {
+  body: ProfileThrottledAnnotation;
+}
+
+export interface ProfileThrottledAnnotation {
+  periodType: string;
+  periodLimitMb: number;
+  limitResetTime: number;
+  samplingPeriodSec: number;
+  samplingRequests: number;
+  usageGroup: string;
+}


### PR DESCRIPTION
### ✨ Description

Time series from profiling data can experience drops/increases when ingest throttling is enabled/disabled. To provide more context to users on when and why this happens, the Pyroscope API [now provides annotations as part of the series data](https://github.com/grafana/pyroscope/pull/3956).

This change visualizes annotations present in series responses, within time series panels.

<img width="1077" alt="Screenshot 2025-04-16 at 14 18 19" src="https://github.com/user-attachments/assets/4d95488a-5e00-4cd9-83f5-af280805a4fa" />

Ideally I would like to make it possible for users to disable these annotations if they find them distracting. This information would get stored in local storage (like Favorites). I will look into ways we can do this in the UI.

### 📖 Summary of the changes

We subscribe to the time series panel data to extract and process annotations optionally present in the data. Annotations come as a separate data frame (see https://github.com/grafana/grafana/pull/104130 for more info).

The displayed annotations are range-based when the start and end of the "event" is within the range of the time series panel. When the "end" time of the event is in the future, we render non-ranged (regular) annotations.

### 🧪 How to test?

I've added tests for the annotation processing part. For a full end-to-end test we need:

- Grafana with https://github.com/grafana/grafana/pull/104130
- A recent version of Pyroscope (including https://github.com/grafana/pyroscope/pull/3956)
- A way to apply ingestion limits (throttling) to profiles, e.g., by providing tenant overrides for Pyroscope
  ```
    overrides:
      anonymous:
        ingestion_rate_mb: 200
        ingestion_limit:
          period_type: hour
          period_limit_mb: 128
          limit_reached: true
          limit_reset_time: 1744829133
          sampling:
            num_requests: 1
            period: 10s
        max_profile_stacktrace_samples: 32000
  ```

I will try to make testing easier once the Grafana change gets merged.