### PR TITLE
chore: bring back renamed grafana-o11yinsights-app extension

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { useChromeHeaderHeight } from '@grafana/runtime';
+import { useChromeHeaderHeight, usePluginComponent } from '@grafana/runtime';
 import { Field, Icon, IconButton, useStyles2 } from '@grafana/ui';
 import { featureToggles } from '@shared/infrastructure/settings/featureToggles';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
@@ -28,13 +28,31 @@ export function Header(props: HeaderProps) {
 
   const { settings } = useFetchPluginSettings();
 
-  const { explorationType, dataSourceVariable, timePickerControl, refreshPickerControl, sceneVariables, gridControls } =
-    data;
+  const {
+    explorationType,
+    dataSourceVariable,
+    timePickerControl,
+    refreshPickerControl,
+    sceneVariables,
+    gridControls,
+    serviceName,
+  } = data;
+
+  type O11yInsightsLauncherV1Props = {
+    dataSourceUid: string;
+    serviceName?: string;
+  };
+
+  const { component: InsightsLauncher } = usePluginComponent<O11yInsightsLauncherV1Props>(
+    'grafana-o11yinsights-app/insights-launcher/v1'
+  );
 
   return (
     <div className={styles.header} data-testid="allControls">
       <GiveFeedbackButton />
-
+      {InsightsLauncher && (
+        <InsightsLauncher dataSourceUid={dataSourceVariable.getValueText()} serviceName={serviceName} />
+      )}
       <div className={styles.appControls} data-testid="appControls">
         <div className={styles.appControlsLeft}>
           <ExplorationTypeSelector

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/domain/useHeader.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/domain/useHeader.ts
@@ -5,6 +5,7 @@ import { logger } from '@shared/infrastructure/tracking/logger';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PLUGIN_BASE_URL, ROUTES } from 'src/constants';
+import { getSceneVariableValue } from 'src/pages/ProfilesExplorerView/helpers/getSceneVariableValue';
 
 import { ProfilesDataSourceVariable } from '../../../../domain/variables/ProfilesDataSourceVariable';
 import { ExplorationType } from '../../SceneProfilesExplorer';
@@ -46,6 +47,11 @@ export function useHeader({ explorationType, controls, body, $variables, onChang
 
   const navigate = useNavigate();
 
+  const explorationTypeHasServiceName =
+    explorationType !== ExplorationType.ALL_SERVICES && explorationType !== ExplorationType.FAVORITES;
+
+  const serviceName = explorationTypeHasServiceName ? getSceneVariableValue($variables, 'serviceName') : undefined;
+
   return {
     data: {
       explorationType,
@@ -56,6 +62,7 @@ export function useHeader({ explorationType, controls, body, $variables, onChang
       gridControls,
       body,
       dataSourceUid,
+      serviceName,
     },
     actions: {
       onChangeExplorationType,

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -8,7 +8,10 @@
   "preload": true,
   "dependencies": {
     "grafanaDependency": ">=11.5.0",
-    "plugins": []
+    "plugins": [],
+    "extensions": {
+      "exposedComponents": ["grafana-o11yinsights-app/insights-launcher/v1"]
+    }
   },
   "info": {
     "keywords": ["app", "pyroscope", "profiling", "explore", "profiles", "performance", "drilldown"],


### PR DESCRIPTION
### ✨ Description

Brings back the `o11yinsights` extension with its new name.
Pending suppression of the pop-up error.

Related issue(s): 
- #477 


<!-- General summary of what the PR aims to do -->

### 📖 Summary of the changes

<!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->

### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
