### PR TITLE
ifrost/fix-cookie-sync

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
@@ -15,13 +15,17 @@ type Cookie = {
 };
 
 class InternalGitSessionCookieManager implements GitSessionCookieManager {
-  private rawCookie: Cookie | undefined;
   private sessionCookie: GitSessionCookie | undefined;
 
+  constructor() {
+    const cookie = InternalGitSessionCookieManager.getCookieFromJar(document.cookie, GITHUB_SESSION_COOKIE_NAME);
+
+    if (cookie) {
+      this.sessionCookie = GitSessionCookie.decode(cookie.value);
+    }
+  }
+
   getCookie(): GitSessionCookie | undefined {
-    // To make sure we're using a cookie that accurately reflects the browser
-    // state, let's be paranoid and make sure our cached cookie is accurate.
-    this.syncCookieWithBrowser();
     return this.sessionCookie;
   }
 
@@ -38,7 +42,6 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
     }
 
     this.deleteLegacyCookie();
-    this.rawCookie = rawCookie;
     this.sessionCookie = GitSessionCookie.decode(rawCookie.value);
     document.cookie = `${cookie}; path=/`;
   }
@@ -46,26 +49,11 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
   deleteCookie(): void {
     document.cookie = `${GITHUB_SESSION_COOKIE_NAME}=; Path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;`;
     this.deleteLegacyCookie();
-    this.rawCookie = undefined;
     this.sessionCookie = undefined;
   }
 
   private deleteLegacyCookie(): void {
     document.cookie = `${LEGACY_GITHUB_SESSION_COOKIE_NAME}=; Path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;`;
-  }
-
-  private syncCookieWithBrowser(): void {
-    const cookie = InternalGitSessionCookieManager.getCookieFromJar(document.cookie, GITHUB_SESSION_COOKIE_NAME);
-    if (cookie?.key === this.rawCookie?.key && cookie?.value === this.rawCookie?.value) {
-      return;
-    }
-
-    if (cookie) {
-      this.rawCookie = cookie;
-      this.sessionCookie = GitSessionCookie.decode(cookie.value);
-    } else {
-      this.deleteCookie();
-    }
   }
 
   private static getCookieFromJar(jar: string, name: string): Cookie | undefined {

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/GitSessionCookieManager.ts
@@ -60,7 +60,12 @@ class InternalGitSessionCookieManager implements GitSessionCookieManager {
       return;
     }
 
-    cookie !== undefined ? this.setCookie(`${cookie.key}=${cookie.value}`) : this.deleteCookie();
+    if (cookie) {
+      this.rawCookie = cookie;
+      this.sessionCookie = GitSessionCookie.decode(cookie.value);
+    } else {
+      this.deleteCookie();
+    }
   }
 
   private static getCookieFromJar(jar: string, name: string): Cookie | undefined {


### PR DESCRIPTION
Fixes #552

When Profiles Drilldown app is initially loaded, it reads the cookie from the browser to save its value in the memory. Inadvertently it also call again `document.cookie=` with the cookie already set in the browser. However when reading a cookie with `document.cookie` the expiration time is not readable so setting the cookie to based on value from `document.cookie` resets expiration.

We can probably simplify it a bit by reading the initial cookie from the browser only in the contractor and stop syncing it from the browser in the getter. The drawback is that after deleting the cookie the user needs to refresh the browser stop using it.

Alternatively we can still sync with the browser but add additional expiration based on decoded value.