### PR TITLE
ci: Update release workflow

### DIFF
--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -11,11 +11,6 @@ on:
           - patch
           - minor
           - major
-      generate-changelog:
-        description: 'Generate changelog'
-        required: false
-        type: boolean
-        default: true
 
 # No global permissions, each job defines own scope
 permissions: {}
@@ -32,11 +27,13 @@ jobs:
       - name: Version bump
         uses: grafana/plugin-ci-workflows/actions/plugins/version-bump-changelog@main
         with:
-          generate-changelog: ${{ inputs.generate-changelog }}
+          # We generate changelog in npm version command via `standard-changelog` library
+          generate-changelog: false
           version: ${{ inputs.version }}
 
   cd:
     name: CI / CD
+    needs: bump-version
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     # These are maximum permissions for the job and should match the permissions defined in the workflow
     permissions:
@@ -44,8 +41,6 @@ jobs:
       id-token: write
       attestations: write
     with:
-      # Checkout/build PR or main branch, depending on event
-      branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
 
       environment: prod
       attestation: true


### PR DESCRIPTION
Fixes a few things:

- disables shared changelog generation as we use different library to generate changelog (we can switch over to the shared one but we would need regenerate it to have consistent formatting
- remove not needed `branch` param
- add missing `needs: bump-version` to run jobs in sequence