### PR TITLE
chore: Use a specific version of Pyroscope for e2e tests

### DIFF
--- a/Dockerfile.pyroscope.e2e
+++ b/Dockerfile.pyroscope.e2e
@@ -6,7 +6,7 @@ RUN unzip grafana-pyroscope-sample-blocks-public.zip \
  && mv grafana-pyroscope-sample-blocks-public data-shared \
  && rm grafana-pyroscope-sample-blocks-public.zip
 
-FROM docker.io/grafana/pyroscope:latest
+FROM docker.io/grafana/pyroscope:weekly-f129-6d0f4264a
 
 COPY samples/static/pyroscope/config.yaml /etc/pyroscope/config.yaml
 COPY --from=blocks --chown=pyroscope:pyroscope data-shared /data-shared

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
 
   pyroscope:
     container_name: 'pyroscope'
-    image: grafana/pyroscope:latest
+    image: grafana/pyroscope:weekly-f129-6d0f4264a
     ports:
       - 4100:4100/tcp
     volumes:


### PR DESCRIPTION
Ci started to failing out of the blue because tests are using pyroscope:latest which is having issues. While investigating this is a temporary measure to unblock plugin development.

Ideally we will have both - test against a fixed (close to latest and automatically updated) version and a smoke test on latest.