### PR TITLE
fix: recording rules list to use rule id as row id

### DIFF
--- a/src/pages/RecordingRulesView/RecordingRulesView.tsx
+++ b/src/pages/RecordingRulesView/RecordingRulesView.tsx
@@ -128,7 +128,7 @@ export default function RecordingRulesView() {
           columns={columns}
           pageSize={10}
           data={formattedRules || []}
-          getRowId={(rule) => rule.metricName}
+          getRowId={(rule) => rule.id}
         ></InteractiveTable>
         <BackButton />
       </div>


### PR DESCRIPTION
### ✨ Description

Fixes: #583 

### 📖 Summary of the changes

We need to use rule.id as the row identifier, as metric name can be repeated while creating compounded rules.


### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->
