### PR TITLE
chore(annotations): Show annotations only on main timeline panels

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries/SceneLabelValuesTimeseries.tsx
@@ -45,6 +45,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     legendPlacement,
     data,
     overrides,
+    annotations,
   }: {
     item: SceneLabelValuesTimeseriesState['item'];
     headerActions: SceneLabelValuesTimeseriesState['headerActions'];
@@ -52,6 +53,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     legendPlacement?: SceneLabelValuesTimeseriesState['legendPlacement'];
     data?: SceneDataTransformer;
     overrides?: SceneLabelValuesTimeseriesState['overrides'];
+    annotations?: boolean;
   }) {
     super({
       key: 'timeseries-label-values',
@@ -68,7 +70,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
               $data: buildTimeSeriesQueryRunner(
                 item.queryRunnerParams,
                 displayAllValues ? undefined : LabelsDataSource.MAX_TIMESERIES_LABEL_VALUES,
-                true
+                annotations
               ),
               transformations: [addRefId, addStats],
             })

--- a/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
@@ -106,6 +106,7 @@ export class SceneMainServiceTimeseries extends SceneObjectBase<SceneMainService
     return new SceneLabelValuesTimeseries({
       item: timeseriesItem,
       headerActions,
+      annotations: true,
       // we pass data for the scenarios where we land on the page from a shared link
       // we do this to prevent rendering a timeseries without groupBy for a second then with groupBy
       // and also to directly render something when there's no groupBy in the URL


### PR DESCRIPTION
In #522 we enabled annotations globally, for all timeline panels. We've since learned that this can be noisy in grid views, when all services get annotated. With this change, annotations will be visible in the main timelines only - in the Labels and Flame Graph explorations.