### PR TITLE
chore(ci): Push PR branches to ops catalog

### DIFF
--- a/.github/workflows/plugins-pr.yml
+++ b/.github/workflows/plugins-pr.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: Branch to publish from. Can be used to deploy PRs to dev
+        description: Branch to publish from. Can be used to deploy PRs to dev and ops
         required: true
       docs-only:
         description: Only publish docs, do not publish the plugin


### PR DESCRIPTION
https://github.com/grafana/profiles-drilldown/pull/579 was tested in dev which has new endpoint available but to check what's gonna happen in cases where the version is used without the new endpoint we also need to push the branch to ops catalog