### PR TITLE
fix: use local pyroscope at port 4040 when server:local

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -40,7 +40,7 @@ services:
       context: ./samples/rideshare
       dockerfile: Dockerfile.load-generator
     environment:
-      - HOST_PREFIX=pyroscope-app-plugin-rideshare
+      - HOST_PREFIX=profiles-drilldown-rideshare
       # This should be the same as the rideshare replica count.
       - REPLICAS=5
       # Set this to 1 to turn on debug logging.

--- a/samples/provisioning-local/datasources/datasources.yaml
+++ b/samples/provisioning-local/datasources/datasources.yaml
@@ -4,7 +4,7 @@ datasources:
   - uid: grafanacloud-profiles-local
     type: grafana-pyroscope-datasource
     name: Local Pyroscope
-    url: http://pyroscope:4100
+    url: http://host.docker.internal:4040
     isDefault: true
     jsonData:
       keepCookies: [pyroscope_git_session]


### PR DESCRIPTION
### ✨ Description

I couldn't manage to connect with local pyroscope when running `yarn server:local`, I fixed it.

### 📖 Summary of the changes

Two changes:
* Fix provisioned local datasource to target the expected local pyroscope url.
* Fix load generator prefix so it sends requests to expected rideshare app

### 🧪 How to test?

1. Run pyroscope locally.
2. Then run `yarn dev` and `yarn server:local`, check how you can actually navigate to pyroscope data at localhost:3000

These steps don't work in main branch.
