### PR TITLE
feat: Support source code integration for languages without file paths

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
@@ -14,6 +14,7 @@ import { ProfilesDataSourceVariable } from '../../../../domain/variables/Profile
 import { getSceneVariableValue } from '../../../../helpers/getSceneVariableValue';
 import { CodeContainer } from './components/CodeContainer/CodeContainer';
 import { GitHubRepository } from './components/GitHubRepository';
+import { calculateIsGitHubSupported } from './domain/calculateIsGitHubSupported';
 import { formatFileName } from './domain/formatFileName';
 import { useFunctionVersion } from './domain/FunctionVersionContext';
 import { CommitWithSamples, getCommitsWithSamples } from './domain/getCommitsWithSamples';
@@ -69,7 +70,7 @@ export class SceneFunctionDetailsPanel extends SceneObjectBase<SceneFunctionDeta
     }
 
     const isGitHubRepo = isGitHubRepository(functionVersion?.repository || '');
-    const isGitHubSupported = currentFunctionDetails?.fileName?.endsWith('.go');
+    const isGitHubSupported = calculateIsGitHubSupported(currentFunctionDetails);
     const shouldDisplayGitHubBanner = !isGitHubBannerDismissed && !isGitHubRepo && isGitHubSupported;
 
     // TODO: massage in useFetchFunctionsDetails?

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/__tests__/isGitHubSupported.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/__tests__/isGitHubSupported.spec.ts
@@ -1,0 +1,170 @@
+import { calculateIsGitHubSupported } from '../domain/calculateIsGitHubSupported';
+import { FunctionDetails } from '../domain/types/FunctionDetails';
+import { PLACEHOLDER_COMMIT_DATA } from '../components/GitHubContextProvider/infrastructure/PrivateVcsClient';
+
+/**
+ * Tests for the calculateIsGitHubSupported function
+ *
+ * The function determines if GitHub integration is supported based on:
+ * 1. At least one of name or fileName must be non-empty
+ * 2. At least one callSite must have a line number > 0
+ */
+describe('calculateIsGitHubSupported', () => {
+  const createMockFunctionDetails = (overrides?: Partial<FunctionDetails>): FunctionDetails => ({
+    name: 'testFunction',
+    fileName: '/path/to/file.go',
+    startLine: 10,
+    callSites: new Map([
+      [15, { line: 15, flat: 100, cum: 200 }],
+      [20, { line: 20, flat: 50, cum: 150 }],
+    ]),
+    unit: 'nanoseconds',
+    commit: PLACEHOLDER_COMMIT_DATA,
+    version: {
+      repository: 'https://github.com/test/repo',
+      git_ref: 'main',
+      root_path: '/',
+    },
+    ...overrides,
+  });
+
+  describe('when both name and valid line numbers exist', () => {
+    it('should return true', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: 'testFunction',
+        fileName: '',
+        callSites: new Map([[15, { line: 15, flat: 100, cum: 200 }]]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when both fileName and valid line numbers exist', () => {
+    it('should return true', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: '',
+        fileName: '/path/to/file.go',
+        callSites: new Map([[15, { line: 15, flat: 100, cum: 200 }]]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when name and fileName are both empty', () => {
+    it('should return false even with valid line numbers', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: '',
+        fileName: '',
+        callSites: new Map([[15, { line: 15, flat: 100, cum: 200 }]]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when callSites is empty', () => {
+    it('should return false even with name/fileName', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: 'testFunction',
+        fileName: '/path/to/file.go',
+        callSites: new Map(),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when all callSites have line number 0', () => {
+    it('should return false', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: 'testFunction',
+        fileName: '/path/to/file.go',
+        callSites: new Map([
+          [0, { line: 0, flat: 100, cum: 200 }],
+        ]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when at least one callSite has line number > 0', () => {
+    it('should return true when mixed with line 0', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: 'testFunction',
+        fileName: '/path/to/file.go',
+        callSites: new Map([
+          [0, { line: 0, flat: 50, cum: 100 }],
+          [15, { line: 15, flat: 100, cum: 200 }],
+        ]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true with multiple valid line numbers', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: 'testFunction',
+        fileName: '/path/to/file.go',
+        callSites: new Map([
+          [15, { line: 15, flat: 100, cum: 200 }],
+          [20, { line: 20, flat: 50, cum: 150 }],
+        ]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when name and fileName exist but no valid line numbers', () => {
+    it('should return false', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: 'testFunction',
+        fileName: '/path/to/file.go',
+        callSites: new Map([[0, { line: 0, flat: 100, cum: 200 }]]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when both name and fileName exist with valid line numbers', () => {
+    it('should return true', () => {
+      const functionDetails = createMockFunctionDetails({
+        name: 'testFunction',
+        fileName: '/path/to/file.go',
+        callSites: new Map([[15, { line: 15, flat: 100, cum: 200 }]]),
+      });
+
+      const result = calculateIsGitHubSupported(functionDetails);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when functionDetails is undefined', () => {
+    it('should return false', () => {
+      const result = calculateIsGitHubSupported(undefined);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/domain/useCodeContainer.ts
@@ -32,6 +32,7 @@ export function useCodeContainer(dataSourceUid: string, functionDetails: Functio
     repository: version?.repository ?? '',
     gitRef: version?.git_ref ?? '',
     rootPath: version?.root_path ?? '',
+    functionName: functionDetails.name ?? '',
   });
 
   // might be a bit costly so we memoize it

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/infrastructure/useFetchVCSFile.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/CodeContainer/infrastructure/useFetchVCSFile.ts
@@ -10,6 +10,7 @@ type FetchParams = {
   gitRef: string;
   localPath: string;
   rootPath: string;
+  functionName: string;
 };
 
 type FetchResponse = {
@@ -28,14 +29,15 @@ export function useFetchVCSFile({
   gitRef,
   localPath,
   rootPath,
+  functionName,
 }: FetchParams): FetchResponse {
   const privateVcsClient = DataSourceProxyClientBuilder.build(dataSourceUid, PrivateVcsClient);
   const { isFetching, error, data } = useQuery({
-    enabled: Boolean(enabled && localPath),
-    queryKey: ['vcs-file', repository, gitRef, localPath, rootPath],
+    enabled: Boolean(enabled && repository && (localPath || functionName)),
+    queryKey: ['vcs-file', repository, gitRef, localPath, rootPath, functionName],
     queryFn: () =>
       privateVcsClient
-        .getFile(repository, gitRef, localPath, rootPath)
+        .getFile(repository, gitRef, localPath, rootPath, functionName)
         .then((code) => ({
           content: code.content,
           URL: code.URL,

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/PrivateVcsClient.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/components/GitHubContextProvider/infrastructure/PrivateVcsClient.ts
@@ -71,7 +71,13 @@ export class PrivateVcsClient extends DataSourceProxyClient {
    * @param localPath A file path relative to the repository root
    * @returns Base64 encoded file contents.
    */
-  async getFile(repositoryUrl: string, gitRef: string, localPath: string, rootPath: string): Promise<GetFileResponse> {
+  async getFile(
+    repositoryUrl: string,
+    gitRef: string,
+    localPath: string,
+    rootPath: string,
+    functionName: string
+  ): Promise<GetFileResponse> {
     const response = await this.postWithRefresh(
       '/vcs.v1.VCSService/GetFile',
       JSON.stringify({
@@ -79,6 +85,7 @@ export class PrivateVcsClient extends DataSourceProxyClient {
         ref: gitRef,
         localPath,
         rootPath,
+        functionName,
       })
     );
 

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/calculateIsGitHubSupported.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/calculateIsGitHubSupported.ts
@@ -1,0 +1,20 @@
+import { FunctionDetails } from './types/FunctionDetails';
+
+/**
+ * Determines if GitHub integration is supported for the given function details.
+ *
+ * GitHub integration is supported when:
+ * 1. At least one of name or fileName is non-empty
+ * 2. At least one callSite has a line number > 0
+ *
+ * @param functionDetails - The function details to check
+ * @returns true if GitHub integration is supported, false otherwise
+ */
+export function calculateIsGitHubSupported(functionDetails: FunctionDetails | undefined): boolean {
+  const hasNameOrFileName = Boolean(functionDetails?.name || functionDetails?.fileName);
+  const hasLineNumber = Boolean(
+    functionDetails?.callSites &&
+      Array.from(functionDetails.callSites.values()).some((callSite) => callSite.line > 0)
+  );
+  return hasNameOrFileName && hasLineNumber;
+}


### PR DESCRIPTION
Extends GitHub integration to support Java and other languages where the function name is available but the file path may not be. This enables source code viewing for a broader range of profiling scenarios.

Changes:
- Extract GitHub support logic into calculateIsGitHubSupported function
- Add comprehensive test coverage for GitHub support detection
- Pass function name to VCS client for file resolution
- Enable file fetching when either localPath or functionName is available

The new logic supports GitHub integration when there's a function name or file path AND at least one call site with a valid line number.