### PR TITLE
fix: prevent API queries with zero time ranges

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/__test__/useFetchDotProfiles.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/__test__/useFetchDotProfiles.spec.ts
@@ -1,0 +1,221 @@
+import { dateTime } from '@grafana/data';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { useFetchDotProfiles } from '../useFetchDotProfiles';
+
+// Mock the dependencies
+jest.mock('../../../../infrastructure/profiles/ProfileApiClient');
+jest.mock('../../../../infrastructure/series/http/DataSourceProxyClientBuilder');
+jest.mock('../cleanupDotResponse', () => ({
+  cleanupDotResponse: jest.fn((response) => response),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  Wrapper.displayName = 'TestQueryClientWrapper';
+  return Wrapper;
+};
+
+describe('useFetchDotProfiles', () => {
+  const dataSourceUid = 'test-datasource-uid';
+  const profileMetricId = 'process_cpu:cpu:nanoseconds:cpu:nanoseconds';
+
+  describe('time range validation', () => {
+    it('should not fetch when time ranges have zero from value', () => {
+      const fetchParams = [
+        {
+          query: '{service_name="test"}',
+          timeRange: {
+            from: dateTime(0), // Zero value
+            to: dateTime(Date.now()),
+            raw: { from: 'now-1h', to: 'now' },
+          },
+        },
+      ];
+
+      const { result } = renderHook(() => useFetchDotProfiles(false, fetchParams, dataSourceUid, profileMetricId), {
+        wrapper: createWrapper(),
+      });
+
+      // Should not be fetching because time range is invalid
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.profiles).toEqual([]);
+      expect(result.current.validationError).toBeDefined();
+      expect(result.current.validationError?.message).toContain('Invalid time range');
+    });
+
+    it('should not fetch when time ranges have zero to value', () => {
+      const fetchParams = [
+        {
+          query: '{service_name="test"}',
+          timeRange: {
+            from: dateTime(Date.now() - 3600000),
+            to: dateTime(0), // Zero value
+            raw: { from: 'now-1h', to: 'now' },
+          },
+        },
+      ];
+
+      const { result } = renderHook(() => useFetchDotProfiles(false, fetchParams, dataSourceUid, profileMetricId), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.profiles).toEqual([]);
+      expect(result.current.validationError).toBeDefined();
+      expect(result.current.validationError?.message).toContain('Invalid time range');
+    });
+
+    it('should not fetch when diff mode has one time range with zero values', () => {
+      const fetchParams = [
+        {
+          query: '{service_name="baseline"}',
+          timeRange: {
+            from: dateTime(Date.now() - 7200000),
+            to: dateTime(Date.now() - 3600000),
+            raw: { from: 'now-2h', to: 'now-1h' },
+          },
+        },
+        {
+          query: '{service_name="comparison"}',
+          timeRange: {
+            from: dateTime(0), // Zero value
+            to: dateTime(0), // Zero value
+            raw: { from: 'now-1h', to: 'now' },
+          },
+        },
+      ];
+
+      const { result } = renderHook(() => useFetchDotProfiles(true, fetchParams, dataSourceUid, profileMetricId), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.profiles).toEqual([]);
+      expect(result.current.validationError).toBeDefined();
+      expect(result.current.validationError?.message).toContain('Invalid time range');
+    });
+
+    it('should fetch when time ranges have valid non-zero values', async () => {
+      const fetchParams = [
+        {
+          query: '{service_name="test"}',
+          timeRange: {
+            from: dateTime(Date.now() - 3600000), // Valid non-zero value
+            to: dateTime(Date.now()), // Valid non-zero value
+            raw: { from: 'now-1h', to: 'now' },
+          },
+        },
+      ];
+
+      const { result } = renderHook(() => useFetchDotProfiles(false, fetchParams, dataSourceUid, profileMetricId), {
+        wrapper: createWrapper(),
+      });
+
+      // No validation error for valid time ranges
+      expect(result.current.validationError).toBeUndefined();
+
+      // Initially should be fetching (or will start fetching)
+      await waitFor(() => {
+        // The query should have been enabled and attempted
+        // We expect either isFetching to be true or an error to occur due to mocked dependencies
+        expect(result.current.isFetching || result.current.fetchError).toBeTruthy();
+      });
+    });
+
+    it('should fetch when diff mode has both valid time ranges', async () => {
+      const fetchParams = [
+        {
+          query: '{service_name="baseline"}',
+          timeRange: {
+            from: dateTime(Date.now() - 7200000), // Valid non-zero value
+            to: dateTime(Date.now() - 3600000), // Valid non-zero value
+            raw: { from: 'now-2h', to: 'now-1h' },
+          },
+        },
+        {
+          query: '{service_name="comparison"}',
+          timeRange: {
+            from: dateTime(Date.now() - 3600000), // Valid non-zero value
+            to: dateTime(Date.now()), // Valid non-zero value
+            raw: { from: 'now-1h', to: 'now' },
+          },
+        },
+      ];
+
+      const { result } = renderHook(() => useFetchDotProfiles(true, fetchParams, dataSourceUid, profileMetricId), {
+        wrapper: createWrapper(),
+      });
+
+      // No validation error for valid time ranges
+      expect(result.current.validationError).toBeUndefined();
+
+      // The query should have been enabled and attempted
+      await waitFor(() => {
+        expect(result.current.isFetching || result.current.fetchError).toBeTruthy();
+      });
+    });
+  });
+
+  describe('fetch params validation', () => {
+    it('should return validation error when diff mode receives wrong number of params', () => {
+      const fetchParams = [
+        {
+          query: '{service_name="test"}',
+          timeRange: {
+            from: dateTime(Date.now() - 3600000),
+            to: dateTime(Date.now()),
+            raw: { from: 'now-1h', to: 'now' },
+          },
+        },
+      ];
+
+      const { result } = renderHook(
+        () => useFetchDotProfiles(true, fetchParams, dataSourceUid, profileMetricId), // isDiff=true but only 1 param
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.validationError).toBeDefined();
+      expect(result.current.validationError?.message).toContain('Invalid number of fetch parameters');
+    });
+
+    it('should return validation error when non-diff mode receives wrong number of params', () => {
+      const fetchParams = [
+        {
+          query: '{service_name="baseline"}',
+          timeRange: {
+            from: dateTime(Date.now() - 7200000),
+            to: dateTime(Date.now() - 3600000),
+            raw: { from: 'now-2h', to: 'now-1h' },
+          },
+        },
+        {
+          query: '{service_name="comparison"}',
+          timeRange: {
+            from: dateTime(Date.now() - 3600000),
+            to: dateTime(Date.now()),
+            raw: { from: 'now-1h', to: 'now' },
+          },
+        },
+      ];
+
+      const { result } = renderHook(
+        () => useFetchDotProfiles(false, fetchParams, dataSourceUid, profileMetricId), // isDiff=false but 2 params
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.validationError).toBeDefined();
+      expect(result.current.validationError?.message).toContain('Invalid number of fetch parameters');
+    });
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/useFetchDotProfiles.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/infrastructure/useFetchDotProfiles.ts
@@ -42,6 +42,17 @@ function validateFetchParams(isDiff: boolean, fetchParams: FetchParams) {
     params = [];
   }
 
+  // Validate time ranges - ensure all have non-zero from and to values
+  // Sending zero parameter values to the API can cause issues
+  const hasInvalidTimeRanges = params.some(({ timeRange }) => {
+    return timeRange.from.unix() === 0 || timeRange.to.unix() === 0;
+  });
+
+  if (hasInvalidTimeRanges) {
+    error = new Error('Invalid time range: from and to values must be non-zero');
+    params = [];
+  }
+
   return { params, error };
 }
 
@@ -55,6 +66,7 @@ function usePerformFetchDotProfiles(dataSourceUid: string, fetchParams: FetchPar
       ...fetchParams.flatMap(({ query, timeRange }) => [query, timeRange.from.unix(), timeRange.to.unix()]),
       MAX_NODES,
     ],
+    enabled: fetchParams.length > 0,
     queryFn: () => {
       // TODO: pass a signal options to properly abort all in-flight requests
       return Promise.all(


### PR DESCRIPTION
## Summary

Fixes an issue introduced in commit e18b2639 where the `AnalyzeDiffFlameGraph` component was causing API queries with `from=0` and `to=0` time ranges, which are invalid up till recently the backend handled with 500s.