### PR TITLE
PoC: Experiment with label presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "e2e:local:watch": "yarn e2e:local --ui",
     "format:fix": "prettier --write .",
     "generate:pyroscope-api": "npx @bufbuild/buf generate",
-    "postinstall": "husky install",
     "knip": "knip",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix && prettier --write --list-different .",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,6 +3,7 @@ import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { ErrorBoundary, useStyles2 } from '@grafana/ui';
 import { queryClient } from '@shared/infrastructure/react-query/queryClient';
+import { GroupByLabelsProvider } from '@shared/infrastructure/settings/GroupByLabelsContext';
 import { initFaro } from '@shared/infrastructure/tracking/faro/faro';
 import { QueryClientProvider } from '@tanstack/react-query';
 import React, { useState } from 'react';
@@ -25,15 +26,17 @@ export function App() {
     <ErrorBoundary onError={setError}>
       {() => (
         <QueryClientProvider client={queryClient}>
-          <Onboarding>
-            <div className={styles.pageContainer}>
-              <PluginPage layout={PageLayoutType.Custom}>
-                <div className="pyroscope-app">
-                  <Routes />
-                </div>
-              </PluginPage>
-            </div>
-          </Onboarding>
+          <GroupByLabelsProvider>
+            <Onboarding>
+              <div className={styles.pageContainer}>
+                <PluginPage layout={PageLayoutType.Custom}>
+                  <div className="pyroscope-app">
+                    <Routes />
+                  </div>
+                </PluginPage>
+              </div>
+            </Onboarding>
+          </GroupByLabelsProvider>
         </QueryClientProvider>
       )}
     </ErrorBoundary>

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/types/GridItemData.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/types/GridItemData.ts
@@ -1,5 +1,6 @@
 import { AdHocVariableFilter } from '@grafana/data';
 
+import { HierarchyFilter } from '../../../infrastructure/timeseries/TimeSeriesQueryRunnerParams';
 import { PanelType } from '../components/ScenePanelTypeSwitcher';
 
 export type GridItemData = {
@@ -14,6 +15,7 @@ export type GridItemData = {
       values: string[];
     };
     filters?: AdHocVariableFilter[];
+    hierarchyFilters?: HierarchyFilter[];
   };
   panelType: PanelType;
 };

--- a/src/pages/ProfilesExplorerView/components/SceneExploreAllServices/SceneExploreAllServices.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreAllServices/SceneExploreAllServices.tsx
@@ -4,27 +4,96 @@ import {
   sceneGraph,
   SceneObjectBase,
   SceneVariableSet,
+  VariableValueOption,
 } from '@grafana/scenes';
-import React from 'react';
+import { useLabelPreset } from '@shared/infrastructure/settings/GroupByLabelsContext';
+import React, { useEffect } from 'react';
 
 import { SceneByVariableRepeaterGrid } from '../../components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
+import { splitCompositeValue } from '../../infrastructure/series/http/formatSeriesResponse';
+import { HierarchyFilter } from '../../infrastructure/timeseries/TimeSeriesQueryRunnerParams';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
 import { PanelType } from '../SceneByVariableRepeaterGrid/components/ScenePanelTypeSwitcher';
 import { SceneQuickFilter } from '../SceneByVariableRepeaterGrid/components/SceneQuickFilter';
+import { GridItemData } from '../SceneByVariableRepeaterGrid/types/GridItemData';
 
-interface SceneExploreAllServicesState extends EmbeddedSceneState {}
+interface SceneExploreAllServicesState extends EmbeddedSceneState {
+  configuredPreset?: string;
+  presetLabels?: string[];
+}
+
+/**
+ * Splits a composite value into hierarchy filters based on the preset labels.
+ * The composite value is URL-encoded, so values like "my/cluster" are properly handled.
+ */
+function splitCompositeValueToHierarchyFilters(
+  compositeValue: string,
+  presetLabels: string[]
+): HierarchyFilter[] | undefined {
+  // If using default service_name preset, don't use hierarchy filters
+  if (presetLabels.length === 1 && presetLabels[0] === 'service_name') {
+    return undefined;
+  }
+
+  // Use the proper decoder that handles URL-encoded values
+  const values = splitCompositeValue(compositeValue);
+
+  // If the number of values doesn't match the preset labels, something is wrong
+  if (values.length !== presetLabels.length) {
+    return undefined;
+  }
+
+  return presetLabels.map((label, index) => ({
+    label,
+    value: values[index],
+  }));
+}
+
+/**
+ * Creates a mapOptionToItem function that properly handles preset labels
+ */
+function createMapOptionToItem(presetLabels: string[]) {
+  return (
+    option: VariableValueOption,
+    index: number,
+    { profileMetricId }: Record<string, string>
+  ): GridItemData | null => {
+    const compositeValue = option.value as string;
+    const hierarchyFilters = splitCompositeValueToHierarchyFilters(compositeValue, presetLabels);
+
+    // For default preset, use serviceName; for custom presets, use hierarchyFilters
+    const isDefaultPreset = presetLabels.length === 1 && presetLabels[0] === 'service_name';
+
+    return {
+      index,
+      value: compositeValue,
+      label: option.label,
+      queryRunnerParams: {
+        serviceName: isDefaultPreset ? compositeValue : undefined,
+        profileMetricId,
+        hierarchyFilters,
+      },
+      panelType: PanelType.TIMESERIES,
+    };
+  };
+}
 
 export class SceneExploreAllServices extends SceneObjectBase<SceneExploreAllServicesState> {
+  private static DEFAULT_PRESET_LABELS = ['service_name'];
+
   constructor() {
     super({
       key: 'explore-all-services',
+      configuredPreset: undefined,
+      presetLabels: SceneExploreAllServices.DEFAULT_PRESET_LABELS,
       $variables: new SceneVariableSet({
         variables: [
-          // we use a custom instance of ServiceNameVariable to display only the services associated to the selected profile metric
+          // Default: use ServiceNameVariable
+          // The preset will be applied dynamically when the component renders
           new ServiceNameVariable({
             query: ServiceNameVariable.QUERY_PROFILE_METRIC_DEPENDENT,
             skipUrlSync: true,
@@ -34,16 +103,7 @@ export class SceneExploreAllServices extends SceneObjectBase<SceneExploreAllServ
       body: new SceneByVariableRepeaterGrid({
         key: 'all-services-grid',
         variableName: 'serviceName',
-        mapOptionToItem: (option, index, { profileMetricId }) => ({
-          index,
-          value: option.value as string,
-          label: option.label,
-          queryRunnerParams: {
-            serviceName: option.value as string,
-            profileMetricId,
-          },
-          panelType: PanelType.TIMESERIES,
-        }),
+        mapOptionToItem: createMapOptionToItem(SceneExploreAllServices.DEFAULT_PRESET_LABELS),
         headerActions: (item) => [
           new SelectAction({ type: 'view-profiles', item }),
           new SelectAction({ type: 'view-labels', item }),
@@ -59,7 +119,37 @@ export class SceneExploreAllServices extends SceneObjectBase<SceneExploreAllServ
   onActivate() {
     sceneGraph
       .findByKeyAndType(this, 'quick-filter', SceneQuickFilter)
-      .setPlaceholder('Search services (comma-separated regexes are supported)');
+      .setPlaceholder('Search (comma-separated regexes are supported)');
+  }
+
+  /**
+   * Configures the variable and grid to use the specified preset.
+   * For the default ['service_name'] preset, uses standard service queries.
+   * For custom presets, fetches composite values joined with "/".
+   */
+  configureForPreset(presetLabels: string[], presetName: string) {
+    const presetKey = presetLabels.join(',');
+
+    // Skip if already configured for this preset
+    if (this.state.configuredPreset === presetKey) {
+      return;
+    }
+
+    this.setState({ configuredPreset: presetKey, presetLabels });
+
+    // Update the ServiceNameVariable with the new preset
+    const serviceNameVariable = sceneGraph.findByKeyAndType(this, 'serviceName', ServiceNameVariable);
+    serviceNameVariable.updatePreset(presetLabels, presetName);
+
+    // Update the grid's mapOptionToItem function to use the new preset labels
+    const grid = sceneGraph.findByKeyAndType(this, 'all-services-grid', SceneByVariableRepeaterGrid);
+    grid.setState({ mapOptionToItem: createMapOptionToItem(presetLabels) });
+
+    // Update quick filter placeholder
+    const itemLabel = presetName || presetLabels.join('/');
+    sceneGraph
+      .findByKeyAndType(this, 'quick-filter', SceneQuickFilter)
+      .setPlaceholder(`Search ${itemLabel} (comma-separated regexes are supported)`);
   }
 
   // see SceneProfilesExplorer
@@ -74,8 +164,19 @@ export class SceneExploreAllServices extends SceneObjectBase<SceneExploreAllServ
   }
 
   static Component({ model }: SceneComponentProps<SceneExploreAllServices>) {
-    const { body } = model.useState();
-
-    return <body.Component model={body} />;
+    return <SceneExploreAllServicesContent model={model} />;
   }
+}
+
+function SceneExploreAllServicesContent({ model }: { model: SceneExploreAllServices }) {
+  const { body } = model.useState();
+  const { activePreset, isLoading } = useLabelPreset();
+
+  useEffect(() => {
+    if (!isLoading && activePreset.labels.length > 0) {
+      model.configureForPreset(activePreset.labels, activePreset.name);
+    }
+  }, [model, activePreset, isLoading]);
+
+  return <body.Component model={body} />;
 }

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/infrastructure/buildCompareTimeSeriesQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneComparePanel/infrastructure/buildCompareTimeSeriesQueryRunner.ts
@@ -1,13 +1,25 @@
 import { SceneQueryRunner } from '@grafana/scenes';
 
 import { PYROSCOPE_DATA_SOURCE } from '../../../../../infrastructure/pyroscope-data-sources';
+import { HierarchyFilter } from '../../../../../infrastructure/timeseries/TimeSeriesQueryRunnerParams';
 import { withPreventInvalidQuery } from '../../../../../infrastructure/withPreventInvalidQuery';
 
 export function buildCompareTimeSeriesQueryRunner({
   filterKey,
+  hierarchyFilters,
 }: {
   filterKey: 'filtersBaseline' | 'filtersComparison';
+  hierarchyFilters?: HierarchyFilter[];
 }) {
+  // Build the label selector from hierarchy filters or fall back to serviceName
+  let labelSelector: string;
+  if (hierarchyFilters && hierarchyFilters.length > 0) {
+    const hierarchySelector = hierarchyFilters.map(({ label, value }) => `${label}="${value}"`).join(',');
+    labelSelector = `{${hierarchySelector},$${filterKey}}`;
+  } else {
+    labelSelector = `{service_name="$serviceName",$${filterKey}}`;
+  }
+
   const queryRunner = new SceneQueryRunner({
     datasource: PYROSCOPE_DATA_SOURCE,
     queries: [
@@ -15,7 +27,7 @@ export function buildCompareTimeSeriesQueryRunner({
         refId: `$profileMetricId-$serviceName-${filterKey}}`,
         queryType: 'metrics',
         profileTypeId: '$profileMetricId',
-        labelSelector: `{service_name="$serviceName",$${filterKey}}`,
+        labelSelector,
       },
     ],
   });

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/infrastructure/buildLabelValuesGridQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/components/SceneLabelValuesGrid/infrastructure/buildLabelValuesGridQueryRunner.ts
@@ -1,9 +1,22 @@
 import { SceneQueryRunner } from '@grafana/scenes';
 
 import { PYROSCOPE_DATA_SOURCE } from '../../../../../../../infrastructure/pyroscope-data-sources';
+import { HierarchyFilter } from '../../../../../../../infrastructure/timeseries/TimeSeriesQueryRunnerParams';
 
-export function buildLabelValuesGridQueryRunner({ label }: { label: string }) {
-  const selector = 'service_name="$serviceName"';
+export function buildLabelValuesGridQueryRunner({
+  label,
+  hierarchyFilters,
+}: {
+  label: string;
+  hierarchyFilters?: HierarchyFilter[];
+}) {
+  // Build selector from hierarchy filters or fall back to serviceName
+  let selector: string;
+  if (hierarchyFilters && hierarchyFilters.length > 0) {
+    selector = hierarchyFilters.map(({ label, value }) => `${label}="${value}"`).join(',');
+  } else {
+    selector = 'service_name="$serviceName"';
+  }
 
   return new SceneQueryRunner({
     datasource: PYROSCOPE_DATA_SOURCE,

--- a/src/pages/ProfilesExplorerView/components/SceneHierarchyNavigation/SceneHierarchyNavigation.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneHierarchyNavigation/SceneHierarchyNavigation.tsx
@@ -1,0 +1,106 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { Icon, Tag, useStyles2 } from '@grafana/ui';
+import { useGroupByLabels } from '@shared/infrastructure/settings/GroupByLabelsContext';
+import React from 'react';
+
+interface SceneHierarchyNavigationState extends SceneObjectState {
+  currentLevel: number;
+  selections: Record<string, string>;
+}
+
+export class SceneHierarchyNavigation extends SceneObjectBase<SceneHierarchyNavigationState> {
+  constructor() {
+    super({
+      key: 'hierarchy-navigation',
+      currentLevel: 0,
+      selections: {},
+    });
+  }
+
+  setSelection(label: string, value: string, level: number) {
+    const { selections } = this.state;
+    const newSelections = { ...selections, [label]: value };
+
+    // Clear selections for levels below the current one
+    // This is handled by the variable subscriptions
+
+    this.setState({
+      selections: newSelections,
+      currentLevel: level + 1,
+    });
+  }
+
+  goToLevel(level: number) {
+    this.setState({ currentLevel: level });
+  }
+
+  static Component({ model }: SceneComponentProps<SceneHierarchyNavigation>) {
+    return <HierarchyNavigationContent model={model} />;
+  }
+}
+
+function HierarchyNavigationContent({ model }: { model: SceneHierarchyNavigation }) {
+  const styles = useStyles2(getStyles);
+  const { groupByLabels, isUsingHierarchy } = useGroupByLabels();
+  const { selections, currentLevel } = model.useState();
+
+  // Don't show hierarchy navigation for default service_name only config
+  if (!isUsingHierarchy) {
+    return null;
+  }
+
+  const breadcrumbs = groupByLabels.slice(0, currentLevel).map((label, idx) => ({
+    label,
+    value: selections[label] || '',
+    level: idx,
+  }));
+
+  const currentLabel = groupByLabels[currentLevel];
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.breadcrumbs}>
+        {breadcrumbs.map(({ label, value, level }) => (
+          <React.Fragment key={label}>
+            <Tag
+              name={`${label}: ${value}`}
+              className={styles.breadcrumb}
+              onClick={() => model.goToLevel(level)}
+            />
+            <Icon name="angle-right" className={styles.separator} />
+          </React.Fragment>
+        ))}
+        {currentLabel && <span className={styles.currentLevel}>{currentLabel}</span>}
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(1)};
+    padding: ${theme.spacing(0.5)} 0;
+  `,
+  breadcrumbs: css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.5)};
+  `,
+  breadcrumb: css`
+    cursor: pointer;
+    &:hover {
+      background-color: ${theme.colors.action.hover};
+    }
+  `,
+  separator: css`
+    color: ${theme.colors.text.secondary};
+  `,
+  currentLevel: css`
+    color: ${theme.colors.text.primary};
+    font-weight: ${theme.typography.fontWeightMedium};
+  `,
+});

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -38,6 +38,7 @@ import { ProfilesDataSourceVariable } from '../../domain/variables/ProfilesDataS
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
 import { SpanSelectorVariable } from '../../domain/variables/SpanSelectorVariable';
 import { FavoritesDataSource } from '../../infrastructure/favorites/FavoritesDataSource';
+import { GroupByLabelDataSource } from '../../infrastructure/group-by-label/GroupByLabelDataSource';
 import { LabelsDataSource } from '../../infrastructure/labels/LabelsDataSource';
 import { SeriesDataSource } from '../../infrastructure/series/SeriesDataSource';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
@@ -212,6 +213,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
       sceneUtils.registerRuntimeDataSource({ dataSource: new SeriesDataSource() });
       sceneUtils.registerRuntimeDataSource({ dataSource: new FavoritesDataSource() });
       sceneUtils.registerRuntimeDataSource({ dataSource: new LabelsDataSource() });
+      sceneUtils.registerRuntimeDataSource({ dataSource: new GroupByLabelDataSource() });
     } catch (error) {
       const { message } = error as Error;
 

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/Header.tsx
@@ -11,6 +11,7 @@ import { GiveFeedbackButton } from '../../GiveFeedbackButton';
 import { SceneProfilesExplorer, SceneProfilesExplorerState } from '../SceneProfilesExplorer';
 import { useHeader } from './domain/useHeader';
 import { ExplorationTypeSelector } from './ui/ExplorationTypeSelector';
+import { LabelPresetSelector } from './ui/LabelPresetSelector';
 
 export type HeaderProps = {
   explorationType: SceneProfilesExplorerState['explorationType'];
@@ -70,6 +71,7 @@ export function Header(props: HeaderProps) {
             value={explorationType as string}
             onChange={actions.onChangeExplorationType}
           />
+          <LabelPresetSelector />
         </div>
 
         <div className={styles.appControlsRight}>

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/ui/LabelPresetSelector.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/components/ui/LabelPresetSelector.tsx
@@ -1,0 +1,65 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Select, useStyles2 } from '@grafana/ui';
+import { displayError, displaySuccess } from '@shared/domain/displayStatus';
+import { useLabelPreset } from '@shared/infrastructure/settings/GroupByLabelsContext';
+import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
+import React, { useMemo } from 'react';
+
+export function LabelPresetSelector() {
+  const styles = useStyles2(getStyles);
+  const { activePreset, allPresets, isLoading } = useLabelPreset();
+  const { settings, mutate } = useFetchPluginSettings();
+
+  const options: Array<SelectableValue<string>> = useMemo(
+    () =>
+      allPresets.map((preset) => ({
+        label: preset.name,
+        value: preset.name,
+        description: preset.labels.join(' / '),
+      })),
+    [allPresets]
+  );
+
+  const handleChange = async (selected: SelectableValue<string>) => {
+    if (!selected.value || selected.value === activePreset.name || !settings) {
+      return;
+    }
+
+    try {
+      await mutate({
+        ...settings,
+        activeLabelPreset: selected.value,
+      });
+      displaySuccess([`Switched to "${selected.value}" preset. Reloading...`]);
+      // Reload the page to apply the new preset
+      window.location.reload();
+    } catch (error) {
+      displayError(error as Error, ['Failed to switch preset']);
+    }
+  };
+
+  if (isLoading || allPresets.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <Select
+        options={options}
+        value={activePreset.name}
+        onChange={handleChange}
+        width={20}
+        prefix="Group by:"
+        aria-label="Label preset selector"
+      />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css`
+    display: flex;
+    align-items: center;
+  `,
+});

--- a/src/pages/ProfilesExplorerView/domain/useBuildPyroscopeQuery.ts
+++ b/src/pages/ProfilesExplorerView/domain/useBuildPyroscopeQuery.ts
@@ -1,6 +1,7 @@
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { useMemo } from 'react';
 
+import { useHierarchyFiltersSelector } from './useHierarchyFiltersSelector';
 import { FiltersVariable } from './variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from './variables/ProfileMetricVariable';
 import { ServiceNameVariable } from './variables/ServiceNameVariable/ServiceNameVariable';
@@ -16,8 +17,11 @@ export function useBuildPyroscopeQuery(sceneObject: SceneObject, filterKey: stri
 
   const { filterExpression } = sceneGraph.findByKeyAndType(sceneObject, filterKey, FiltersVariable).useState();
 
-  return useMemo(
-    () => `${profileMetricId}{service_name="${serviceName}",${filterExpression}}`,
-    [filterExpression, profileMetricId, serviceName]
-  );
+  const hierarchySelector = useHierarchyFiltersSelector(sceneObject);
+
+  return useMemo(() => {
+    // Use hierarchy selector if available, otherwise fall back to service_name
+    const labelSelector = hierarchySelector || `service_name="${serviceName}"`;
+    return `${profileMetricId}{${labelSelector},${filterExpression}}`;
+  }, [filterExpression, profileMetricId, serviceName, hierarchySelector]);
 }

--- a/src/pages/ProfilesExplorerView/domain/useHierarchyFiltersSelector.ts
+++ b/src/pages/ProfilesExplorerView/domain/useHierarchyFiltersSelector.ts
@@ -1,0 +1,59 @@
+import { sceneGraph, SceneObject } from '@grafana/scenes';
+import { useMemo } from 'react';
+
+import { HierarchyFilter } from '../infrastructure/timeseries/TimeSeriesQueryRunnerParams';
+import { GroupByLabelValueVariable } from './variables/GroupByVariable/GroupByLabelValueVariable';
+
+const MAX_HIERARCHY_LEVELS = 10;
+
+/**
+ * Gets hierarchy filters as an array of HierarchyFilter objects
+ * Can be used both in React components and outside of them
+ */
+export function getHierarchyFiltersFromScene(sceneObject: SceneObject): HierarchyFilter[] {
+  const filters: HierarchyFilter[] = [];
+
+  for (let i = 0; i < MAX_HIERARCHY_LEVELS; i++) {
+    try {
+      const hierarchyVar = sceneGraph.findByKeyAndType(
+        sceneObject,
+        `groupByLabelValue-${i}`,
+        GroupByLabelValueVariable
+      );
+      const value = hierarchyVar.state.value;
+      if (value && value !== '') {
+        filters.push({
+          label: hierarchyVar.getLabelName(),
+          value: value as string,
+        });
+      }
+    } catch {
+      // Variable not found, stop looking
+      break;
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Returns a selector string from the hierarchy variables (e.g., 'cluster="prod",namespace="api"')
+ * Returns null if no hierarchy variables are found, indicating to fall back to service_name
+ */
+export function useHierarchyFiltersSelector(sceneObject: SceneObject): string | null {
+  const hierarchyFilters = useHierarchyFilters(sceneObject);
+
+  return useMemo(() => {
+    if (hierarchyFilters.length === 0) {
+      return null;
+    }
+    return hierarchyFilters.map(({ label, value }) => `${label}="${value}"`).join(',');
+  }, [hierarchyFilters]);
+}
+
+/**
+ * React hook that returns an array of hierarchy filters from the scene's GroupByLabelValueVariable instances
+ */
+export function useHierarchyFilters(sceneObject: SceneObject): HierarchyFilter[] {
+  return getHierarchyFiltersFromScene(sceneObject);
+}

--- a/src/pages/ProfilesExplorerView/domain/variables/GroupByVariable/GroupByLabelValueVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/GroupByVariable/GroupByLabelValueVariable.tsx
@@ -1,0 +1,149 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2, VariableRefresh } from '@grafana/data';
+import { MultiValueVariable, QueryVariable, SceneComponentProps, VariableValueOption } from '@grafana/scenes';
+import { Cascader, Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import { prepareHistoryEntry } from '@shared/domain/prepareHistoryEntry';
+import { reportInteraction } from '@shared/domain/reportInteraction';
+import { userStorage } from '@shared/infrastructure/userStorage';
+import { nanoid } from 'nanoid';
+import React, { useMemo } from 'react';
+import { lastValueFrom } from 'rxjs';
+
+import { PYROSCOPE_GROUP_BY_LABEL_DATA_SOURCE } from '../../../infrastructure/pyroscope-data-sources';
+import { buildServiceNameCascaderOptions } from '../ServiceNameVariable/domain/useBuildServiceNameOptions';
+
+export type GroupByLabelValueVariableState = {
+  labelName: string;
+  hierarchyLevel: number;
+  query?: string;
+  skipUrlSync?: boolean;
+};
+
+export class GroupByLabelValueVariable extends QueryVariable {
+  private labelName: string;
+  private hierarchyLevel: number;
+
+  constructor(state: GroupByLabelValueVariableState) {
+    const { labelName, hierarchyLevel, skipUrlSync } = state;
+
+    super({
+      key: `groupByLabelValue-${hierarchyLevel}`,
+      name: `groupByLabelValue${hierarchyLevel}`,
+      label: labelName,
+      datasource: PYROSCOPE_GROUP_BY_LABEL_DATA_SOURCE,
+      query: `$dataSource labelValues ${labelName} level ${hierarchyLevel}`,
+      loading: true,
+      refresh: VariableRefresh.onTimeRangeChanged,
+      skipUrlSync,
+    });
+
+    this.labelName = labelName;
+    this.hierarchyLevel = hierarchyLevel;
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  onActivate() {
+    this.setInitialValue();
+
+    this.subscribeToState((newState, prevState) => {
+      if (newState.value && newState.value !== prevState.value) {
+        const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
+        if (!storage.groupByLabelValues) {
+          storage.groupByLabelValues = {};
+        }
+        storage.groupByLabelValues[this.labelName] = newState.value;
+        userStorage.set(userStorage.KEYS.PROFILES_EXPLORER, storage);
+      }
+    });
+  }
+
+  setInitialValue() {
+    const storage = userStorage.get(userStorage.KEYS.PROFILES_EXPLORER) || {};
+    const valueFromStorage = storage.groupByLabelValues?.[this.labelName];
+
+    if (valueFromStorage && !this.state.value) {
+      this.setState({ value: valueFromStorage });
+    }
+  }
+
+  async update() {
+    if (this.state.loading) {
+      return;
+    }
+
+    let options: VariableValueOption[] = [];
+    let error = null;
+
+    this.setState({ loading: true, options: [], error: null });
+
+    try {
+      options = await lastValueFrom(this.getValueOptions({}));
+    } catch (e) {
+      error = e;
+    } finally {
+      this.setState({ loading: false, options, error });
+    }
+  }
+
+  selectNewValue = (newValue: string) => {
+    reportInteraction('g_pyroscope_app_group_by_label_value_selected', {
+      labelName: this.labelName,
+      hierarchyLevel: this.hierarchyLevel,
+    });
+
+    if (!this.state.skipUrlSync) {
+      prepareHistoryEntry();
+    }
+
+    this.changeValueTo(newValue);
+  };
+
+  getLabelName() {
+    return this.labelName;
+  }
+
+  getHierarchyLevel() {
+    return this.hierarchyLevel;
+  }
+
+  static Component = ({ model }: SceneComponentProps<MultiValueVariable & { selectNewValue?: any }>) => {
+    const styles = useStyles2(getStyles);
+    const { loading, value, options, error, label } = model.useState();
+
+    const cascaderOptions = useMemo(
+      () => buildServiceNameCascaderOptions(options.map(({ label }) => label)),
+      [options]
+    );
+
+    if (error) {
+      return (
+        <Tooltip theme="error" content={error.toString()}>
+          <Icon className={styles.iconError} name="exclamation-triangle" size="xl" />
+        </Tooltip>
+      );
+    }
+
+    return (
+      <Cascader
+        key={nanoid(5)}
+        aria-label={`${label} list`}
+        width={32}
+        separator="/"
+        displayAllSelectedLevels
+        placeholder={loading ? `Loading ${label}...` : `Select ${label} (${options.length})`}
+        options={cascaderOptions}
+        initialValue={value as string}
+        changeOnSelect={false}
+        onSelect={model.selectNewValue}
+      />
+    );
+  };
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  iconError: css`
+    height: 32px;
+    align-self: center;
+    color: ${theme.colors.error.text};
+  `,
+});

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
@@ -16,6 +16,8 @@ type ServiceNameVariableState = {
   query?: string;
   skipUrlSync?: boolean;
   initialFilters?: AdHocVariableFilter[];
+  presetLabels?: string[];
+  presetName?: string;
 };
 
 export class ServiceNameVariable extends QueryVariable {
@@ -25,22 +27,80 @@ export class ServiceNameVariable extends QueryVariable {
   // hack: subscribe to changes of dataSource and profileMetricId
   static QUERY_PROFILE_METRIC_DEPENDENT = '$dataSource and only $profileMetricId services';
 
+  /**
+   * Builds a query string for fetching series with preset labels.
+   * Format: "$dataSource preset [label1,label2,label3] and only $profileMetricId services"
+   */
+  static buildPresetQuery(presetLabels: string[], profileMetricDependent = false): string {
+    const labelsStr = presetLabels.join(',');
+    if (profileMetricDependent) {
+      return `$dataSource preset [${labelsStr}] and only $profileMetricId services`;
+    }
+    return `$dataSource preset [${labelsStr}] and all services`;
+  }
+
   private initialFilters?: AdHocVariableFilter[];
+  private presetLabels?: string[];
+  private presetName?: string;
 
   constructor(state?: ServiceNameVariableState) {
+    const presetLabels = state?.presetLabels;
+    const isDefaultPreset = !presetLabels || (presetLabels.length === 1 && presetLabels[0] === 'service_name');
+
+    // Determine the query based on preset and whether it's profile metric dependent
+    let query = state?.query;
+    if (!query) {
+      query = isDefaultPreset
+        ? ServiceNameVariable.QUERY_DEFAULT
+        : ServiceNameVariable.buildPresetQuery(presetLabels!, false);
+    }
+
+    // Determine the label based on preset
+    const label = state?.presetName || (isDefaultPreset ? 'Service' : presetLabels!.join(' / '));
+
     super({
       key: 'serviceName',
       name: 'serviceName',
-      label: 'Service',
+      label,
       datasource: PYROSCOPE_SERIES_DATA_SOURCE,
-      query: ServiceNameVariable.QUERY_DEFAULT,
+      query,
       loading: true,
       refresh: VariableRefresh.onTimeRangeChanged,
       ...state,
     });
 
     this.initialFilters = state?.initialFilters;
+    this.presetLabels = presetLabels;
+    this.presetName = state?.presetName;
     this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  getPresetLabels(): string[] | undefined {
+    return this.presetLabels;
+  }
+
+  /**
+   * Updates the variable to use a new preset.
+   * This changes the query and label to match the new preset.
+   */
+  updatePreset(presetLabels: string[], presetName?: string) {
+    const isDefaultPreset = presetLabels.length === 1 && presetLabels[0] === 'service_name';
+    const isProfileMetricDependent = this.state.query?.includes('$profileMetricId');
+
+    const query = isDefaultPreset
+      ? isProfileMetricDependent
+        ? ServiceNameVariable.QUERY_PROFILE_METRIC_DEPENDENT
+        : ServiceNameVariable.QUERY_DEFAULT
+      : ServiceNameVariable.buildPresetQuery(presetLabels, isProfileMetricDependent);
+
+    const label = presetName || (isDefaultPreset ? 'Service' : presetLabels.join(' / '));
+
+    this.presetLabels = presetLabels;
+    this.presetName = presetName;
+    this.setState({ query, label });
+
+    // Trigger a refresh to fetch new data
+    this.update();
   }
 
   onActivate() {
@@ -98,14 +158,18 @@ export class ServiceNameVariable extends QueryVariable {
     this.changeValueTo(newValue);
   };
 
-  static Component = ({ model }: SceneComponentProps<MultiValueVariable & { selectNewValue?: any }>) => {
+  static Component = ({ model }: SceneComponentProps<MultiValueVariable & { selectNewValue?: any; getPresetLabels?: () => string[] | undefined }>) => {
     const styles = useStyles2(getStyles);
-    const { loading, value, options, error } = model.useState();
+    const { loading, value, options, error, label } = model.useState();
 
     const cascaderOptions = useMemo(
       () => buildServiceNameCascaderOptions(options.map(({ label }) => label)),
       [options]
     );
+
+    // Use the label from state for placeholder, or default to "service"
+    const itemName = label || 'service';
+    const placeholder = loading ? `Loading ${itemName}...` : `Select ${itemName} (${options.length})`;
 
     if (error) {
       return (
@@ -121,11 +185,11 @@ export class ServiceNameVariable extends QueryVariable {
         // and when switching exploration types, because the value might also be changed after the component has been rendered by SceneProfilesExplorer
         // (e.g. in SceneExploreServiceProfileTypes)
         key={nanoid(5)}
-        aria-label="Services list"
+        aria-label={`${itemName} list`}
         width={32}
         separator="/"
         displayAllSelectedLevels
-        placeholder={loading ? 'Loading services...' : `Select a service (${options.length})`}
+        placeholder={placeholder}
         options={cascaderOptions}
         initialValue={value as string}
         changeOnSelect={false}

--- a/src/pages/ProfilesExplorerView/infrastructure/flame-graph/buildFlameGraphQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/flame-graph/buildFlameGraphQueryRunner.ts
@@ -9,9 +9,22 @@ type FlameGraphQueryRunnerParams = TimeSeriesQueryRunnerParams & {
   spanSelector?: string;
 };
 
-export function buildFlameGraphQueryRunner({ filters, maxNodes, spanSelector }: FlameGraphQueryRunnerParams) {
+export function buildFlameGraphQueryRunner({
+  filters,
+  maxNodes,
+  spanSelector,
+  hierarchyFilters,
+}: FlameGraphQueryRunnerParams) {
   const completeFilters = filters ? [...filters] : [];
-  completeFilters.unshift({ key: 'service_name', operator: '=', value: '$serviceName' });
+
+  // Add hierarchy filters if provided, otherwise fall back to serviceName for backwards compatibility
+  if (hierarchyFilters && hierarchyFilters.length > 0) {
+    for (const { label, value } of hierarchyFilters) {
+      completeFilters.unshift({ key: label, operator: '=', value });
+    }
+  } else {
+    completeFilters.unshift({ key: 'service_name', operator: '=', value: '$serviceName' });
+  }
 
   const selector = completeFilters.map(({ key, operator, value }) => `${key}${operator}"${value}"`).join(',');
 

--- a/src/pages/ProfilesExplorerView/infrastructure/group-by-label/GroupByLabelDataSource.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/group-by-label/GroupByLabelDataSource.ts
@@ -1,0 +1,146 @@
+import {
+  DataQueryResponse,
+  FieldType,
+  LegacyMetricFindQueryOptions,
+  LoadingState,
+  MetricFindValue,
+  TestDataSourceResponse,
+  TimeRange,
+} from '@grafana/data';
+import { RuntimeDataSource, sceneGraph } from '@grafana/scenes';
+import { labelsRepository } from '@shared/infrastructure/labels/labelsRepository';
+import { logger } from '@shared/infrastructure/tracking/logger';
+
+import { GroupByLabelValueVariable } from '../../domain/variables/GroupByVariable/GroupByLabelValueVariable';
+import { computeRoundedTimeRange } from '../../helpers/computeRoundedTimeRange';
+import { LabelsApiClient } from '../labels/http/LabelsApiClient';
+import { PYROSCOPE_GROUP_BY_LABEL_DATA_SOURCE } from '../pyroscope-data-sources';
+import { safeInterpolate } from '../series/helpers/safeInterpolate';
+
+export class GroupByLabelDataSource extends RuntimeDataSource {
+  constructor() {
+    super(PYROSCOPE_GROUP_BY_LABEL_DATA_SOURCE.type, PYROSCOPE_GROUP_BY_LABEL_DATA_SOURCE.uid);
+  }
+
+  async query(): Promise<DataQueryResponse> {
+    return {
+      state: LoadingState.Done,
+      data: [
+        {
+          name: 'GroupByLabelValues',
+          fields: [
+            {
+              name: 'Label',
+              type: FieldType.other,
+              values: [],
+              config: {},
+            },
+          ],
+          length: 0,
+        },
+      ],
+    };
+  }
+
+  parseQuery(query: string): { labelName: string; hierarchyLevel: number } {
+    // Query format: "$dataSource labelValues <labelName> level <hierarchyLevel>"
+    const match = query.match(/labelValues (\S+) level (\d+)/);
+    if (!match) {
+      throw new Error(`Invalid query format: ${query}`);
+    }
+    return {
+      labelName: match[1],
+      hierarchyLevel: parseInt(match[2], 10),
+    };
+  }
+
+  buildHierarchyQuery(
+    sceneObject: GroupByLabelValueVariable,
+    profileMetricId: string,
+    hierarchyLevel: number
+  ): string {
+    const filters: string[] = [];
+
+    // Find all hierarchy variables with lower levels and include their values as filters
+    for (let i = 0; i < hierarchyLevel; i++) {
+      try {
+        const parentVar = sceneGraph.findByKeyAndType(
+          sceneObject,
+          `groupByLabelValue-${i}`,
+          GroupByLabelValueVariable
+        );
+        const parentValue = parentVar.state.value;
+        const parentLabelName = parentVar.getLabelName();
+        if (parentValue && parentValue !== '') {
+          filters.push(`${parentLabelName}="${parentValue}"`);
+        }
+      } catch {
+        // Parent variable not found, skip
+      }
+    }
+
+    if (filters.length > 0) {
+      return `${profileMetricId}{${filters.join(',')}}`;
+    }
+
+    return profileMetricId;
+  }
+
+  async metricFindQuery(query: string, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
+    const sceneObject = options.scopedVars?.__sceneObject?.valueOf() as GroupByLabelValueVariable;
+
+    // Don't fetch if variable is not active
+    if (!sceneObject.isActive) {
+      return [];
+    }
+
+    const { labelName, hierarchyLevel } = this.parseQuery(query);
+
+    const dataSourceUid = safeInterpolate(sceneObject, '$dataSource');
+    const profileMetricId = safeInterpolate(sceneObject, '$profileMetricId');
+
+    if (!profileMetricId) {
+      logger.warn(
+        'GroupByLabelDataSource: profileMetricId="%s" is empty! Discarding request.',
+        profileMetricId
+      );
+      return [];
+    }
+
+    const { from, to } = computeRoundedTimeRange(options.range as TimeRange);
+
+    // Build the query with hierarchy filters
+    const hierarchyQuery = this.buildHierarchyQuery(sceneObject, profileMetricId, hierarchyLevel);
+
+    labelsRepository.setApiClient(new LabelsApiClient({ dataSourceUid }));
+
+    try {
+      const labelValues = await labelsRepository.listLabelValues({
+        query: hierarchyQuery,
+        from,
+        to,
+        label: labelName,
+      });
+
+      return labelValues.map(({ value, label }) => ({
+        value,
+        text: label,
+      }));
+    } catch (error) {
+      logger.error(error as Error, {
+        info: 'Error while loading Pyroscope label values for group by hierarchy!',
+        labelName,
+        hierarchyLevel: String(hierarchyLevel),
+      });
+
+      throw error;
+    }
+  }
+
+  async testDatasource(): Promise<TestDataSourceResponse> {
+    return {
+      status: 'success',
+      message: 'OK',
+    };
+  }
+}

--- a/src/pages/ProfilesExplorerView/infrastructure/labels/LabelsDataSource.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/labels/LabelsDataSource.ts
@@ -7,12 +7,13 @@ import {
   TestDataSourceResponse,
   TimeRange,
 } from '@grafana/data';
-import { RuntimeDataSource } from '@grafana/scenes';
+import { RuntimeDataSource, sceneGraph } from '@grafana/scenes';
 import { isPrivateLabel } from '@shared/components/QueryBuilder/domain/helpers/isPrivateLabel';
 import { labelsRepository } from '@shared/infrastructure/labels/labelsRepository';
 import { logger } from '@shared/infrastructure/tracking/logger';
 import pLimit from 'p-limit';
 
+import { GroupByLabelValueVariable } from '../../domain/variables/GroupByVariable/GroupByLabelValueVariable';
 import { GroupByVariable } from '../../domain/variables/GroupByVariable/GroupByVariable';
 import { computeRoundedTimeRange } from '../../helpers/computeRoundedTimeRange';
 import { PYROSCOPE_LABELS_DATA_SOURCE } from '../pyroscope-data-sources';
@@ -49,6 +50,30 @@ export class LabelsDataSource extends RuntimeDataSource {
     };
   }
 
+  getHierarchyFiltersSelector(sceneObject: GroupByVariable): string | null {
+    const filters: string[] = [];
+
+    // Try to find hierarchy variables (up to 10 levels)
+    for (let i = 0; i < 10; i++) {
+      try {
+        const hierarchyVar = sceneGraph.findByKeyAndType(
+          sceneObject,
+          `groupByLabelValue-${i}`,
+          GroupByLabelValueVariable
+        );
+        const value = hierarchyVar.state.value;
+        if (value && value !== '') {
+          filters.push(`${hierarchyVar.getLabelName()}="${value}"`);
+        }
+      } catch {
+        // Variable not found, stop looking
+        break;
+      }
+    }
+
+    return filters.length > 0 ? filters.join(',') : null;
+  }
+
   getParams(options: LegacyMetricFindQueryOptions) {
     const { scopedVars, range } = options;
     const sceneObject = scopedVars?.__sceneObject?.valueOf() as GroupByVariable;
@@ -57,10 +82,14 @@ export class LabelsDataSource extends RuntimeDataSource {
     const serviceName = safeInterpolate(sceneObject, '$serviceName');
     const profileMetricId = safeInterpolate(sceneObject, '$profileMetricId');
 
+    // Try to use hierarchy filters, fall back to serviceName
+    const hierarchySelector = this.getHierarchyFiltersSelector(sceneObject);
+    const labelSelector = hierarchySelector || `service_name="${serviceName}"`;
+
     // we could interpolate ad hoc filters, but the Labels exploration type would reload all labels each time they are modified
     // const filters = sceneGraph.interpolate(sceneObject, '$filters');
-    // const pyroscopeQuery = `${profileMetricId}{service_name="${serviceName}",${filters}}`;
-    const query = `${profileMetricId}{service_name="${serviceName}"}`;
+    // const pyroscopeQuery = `${profileMetricId}{${labelSelector},${filters}}`;
+    const query = `${profileMetricId}{${labelSelector}}`;
 
     const { from, to } = computeRoundedTimeRange(range as TimeRange);
 

--- a/src/pages/ProfilesExplorerView/infrastructure/pyroscope-data-sources.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/pyroscope-data-sources.ts
@@ -24,3 +24,8 @@ export const PYROSCOPE_LABELS_DATA_SOURCE: DataSourceDef = Object.freeze({
   type: 'grafana-pyroscope-labels-datasource',
   uid: 'grafana-pyroscope-labels-datasource',
 });
+
+export const PYROSCOPE_GROUP_BY_LABEL_DATA_SOURCE: DataSourceDef = Object.freeze({
+  type: 'grafana-pyroscope-group-by-label-datasource',
+  uid: 'grafana-pyroscope-group-by-label-datasource',
+});

--- a/src/pages/ProfilesExplorerView/infrastructure/series/SeriesDataSource.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/SeriesDataSource.ts
@@ -41,6 +41,27 @@ export class SeriesDataSource extends RuntimeDataSource {
     }
   }
 
+  async fetchSeriesWithPreset(
+    dataSourceUid: string,
+    timeRange: TimeRange,
+    presetLabels: string[],
+    variableName?: string
+  ) {
+    seriesRepository.setApiClient(DataSourceProxyClientBuilder.build(dataSourceUid, SeriesApiClient));
+
+    try {
+      return await seriesRepository.listWithPreset({ timeRange, presetLabels });
+    } catch (error) {
+      logger.error(error as Error, {
+        info: 'Error while loading Pyroscope series with preset!',
+        variableName: variableName || '',
+        presetLabels: presetLabels.join(','),
+      });
+
+      throw error;
+    }
+  }
+
   async query(): Promise<DataQueryResponse> {
     return {
       state: LoadingState.Done,
@@ -61,6 +82,18 @@ export class SeriesDataSource extends RuntimeDataSource {
     };
   }
 
+  /**
+   * Parses a preset query string like "$dataSource preset [label1,label2] services"
+   * Returns the preset labels array or null if not a preset query
+   */
+  parsePresetQuery(query: string): string[] | null {
+    const match = query.match(/\$dataSource preset \[([^\]]+)\]/);
+    if (!match) {
+      return null;
+    }
+    return match[1].split(',').map((s) => s.trim());
+  }
+
   async metricFindQuery(query: string, options: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
     const sceneObject = options.scopedVars?.__sceneObject?.valueOf() as ServiceNameVariable | ProfileMetricVariable;
 
@@ -71,6 +104,22 @@ export class SeriesDataSource extends RuntimeDataSource {
     // Fallback to default datasource if interpolation not ready yet
     if (!dataSourceUid) {
       dataSourceUid = ApiClient.selectDefaultDataSource().uid as string;
+    }
+
+    // Check if this is a preset query
+    const presetLabels = this.parsePresetQuery(query);
+    if (presetLabels) {
+      const pyroscopeSeries = await this.fetchSeriesWithPreset(
+        dataSourceUid,
+        options.range as TimeRange,
+        presetLabels,
+        options.variable?.name
+      );
+
+      if (query.includes('$profileMetricId services')) {
+        return formatSeriesToServices(pyroscopeSeries, profileMetricId);
+      }
+      return formatSeriesToServices(pyroscopeSeries);
     }
 
     const pyroscopeSeries = await this.fetchSeries(dataSourceUid, options.range as TimeRange, options.variable?.name);

--- a/src/pages/ProfilesExplorerView/infrastructure/series/formatSeriesToServices.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/formatSeriesToServices.ts
@@ -1,7 +1,21 @@
 import { MetricFindValue } from '@grafana/data';
 import { localeCompare } from '@shared/domain/localeCompare';
 
+import { splitCompositeValue } from './http/formatSeriesResponse';
 import { PyroscopeSeries } from './http/SeriesApiClient';
+
+/**
+ * Decodes a composite value for display purposes.
+ * Splits the URL-encoded composite and joins with " / " for readability.
+ */
+function decodeForDisplay(compositeValue: string): string {
+  try {
+    return splitCompositeValue(compositeValue).join(' / ');
+  } catch {
+    // If decoding fails, return as-is
+    return compositeValue;
+  }
+}
 
 export function formatSeriesToServices(pyroscopeSeries: PyroscopeSeries, profileMetricId?: string): MetricFindValue[] {
   if (profileMetricId) {
@@ -9,16 +23,16 @@ export function formatSeriesToServices(pyroscopeSeries: PyroscopeSeries, profile
 
     return Array.from(servicesSet)
       .sort(localeCompare)
-      .map((serviceName) => ({
-        text: serviceName,
-        value: serviceName,
+      .map((compositeValue) => ({
+        text: decodeForDisplay(compositeValue),
+        value: compositeValue,
       }));
   }
 
   return Array.from(pyroscopeSeries.services.keys())
     .sort(localeCompare)
-    .map((serviceName) => ({
-      text: serviceName,
-      value: serviceName,
+    .map((compositeValue) => ({
+      text: decodeForDisplay(compositeValue),
+      value: compositeValue,
     }));
 }

--- a/src/pages/ProfilesExplorerView/infrastructure/series/http/SeriesApiClient.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/http/SeriesApiClient.ts
@@ -1,7 +1,7 @@
 import { ProfileMetric } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 
 import { DataSourceProxyClient } from './DataSourceProxyClient';
-import { formatSeriesResponse } from './formatSeriesResponse';
+import { formatSeriesResponse, formatSeriesResponseWithPreset } from './formatSeriesResponse';
 
 type ProfileMetricsMap = Map<ProfileMetric['id'], ProfileMetric>;
 type ServiceToProfileMetricsMap = Map<string, ProfileMetricsMap>;
@@ -30,5 +30,24 @@ export class SeriesApiClient extends DataSourceProxyClient {
     })
       .then((response) => response.json())
       .then(formatSeriesResponse);
+  }
+
+  async listWithPreset(options: { from: number; to: number; presetLabels: string[] }): Promise<PyroscopeSeries> {
+    const { from, to, presetLabels } = options;
+
+    // Always include __profile_type__ for profile metric mapping
+    const labelNames = [...presetLabels, '__profile_type__'];
+
+    return this.fetch('/querier.v1.QuerierService/Series', {
+      method: 'POST',
+      body: JSON.stringify({
+        start: from,
+        end: to,
+        labelNames,
+        matchers: [],
+      }),
+    })
+      .then((response) => response.json())
+      .then((data) => formatSeriesResponseWithPreset(data, presetLabels));
   }
 }

--- a/src/pages/ProfilesExplorerView/infrastructure/series/http/formatSeriesResponse.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/http/formatSeriesResponse.ts
@@ -26,6 +26,69 @@ function findServiceNameAndProfileMetricId(labels: Labels) {
   return [];
 }
 
+/**
+ * Encodes a value for use in a composite key.
+ * Uses URL encoding to handle any UTF-8 character including "/".
+ */
+export function encodeCompositeValue(value: string): string {
+  return encodeURIComponent(value);
+}
+
+/**
+ * Decodes a value from a composite key.
+ */
+export function decodeCompositeValue(encoded: string): string {
+  return decodeURIComponent(encoded);
+}
+
+/**
+ * Joins multiple label values into a composite value using "/" as delimiter.
+ * Each value is URL-encoded to handle special characters including "/".
+ */
+export function joinCompositeValues(values: string[]): string {
+  return values.map(encodeCompositeValue).join('/');
+}
+
+/**
+ * Splits a composite value back into individual label values.
+ * Each value is URL-decoded.
+ */
+export function splitCompositeValue(compositeValue: string): string[] {
+  return compositeValue.split('/').map(decodeCompositeValue);
+}
+
+/**
+ * Extracts values for the preset labels from a label set and joins them with "/"
+ * Returns [compositeValue, profileMetricId] or empty array if required labels are missing
+ */
+function findCompositeValueAndProfileMetricId(labels: Labels, presetLabels: string[]): [string, string] | [] {
+  const labelMap = new Map<string, string>();
+
+  for (const { name, value } of labels) {
+    labelMap.set(name, value);
+  }
+
+  const profileMetricId = labelMap.get('__profile_type__');
+  if (!profileMetricId) {
+    return [];
+  }
+
+  // Extract values for all preset labels in order
+  const values: string[] = [];
+  for (const labelName of presetLabels) {
+    const value = labelMap.get(labelName);
+    if (value === undefined) {
+      // If any preset label is missing, skip this label set
+      return [];
+    }
+    values.push(value);
+  }
+
+  // Join with "/" to create composite value (each value is URL-encoded)
+  const compositeValue = joinCompositeValues(values);
+  return [compositeValue, profileMetricId];
+}
+
 export function formatSeriesResponse(data: { labelsSet: Array<{ labels: Labels }> }): PyroscopeSeries {
   const services: PyroscopeSeries['services'] = new Map();
   const profileMetrics: PyroscopeSeries['profileMetrics'] = new Map();
@@ -53,6 +116,53 @@ export function formatSeriesResponse(data: { labelsSet: Array<{ labels: Labels }
     const profileMetricServices = profileMetrics.get(profileMetricId) || new Set();
     profileMetricServices.add(serviceName);
     profileMetrics.set(profileMetricId, profileMetricServices);
+  }
+
+  return { services, profileMetrics };
+}
+
+function addToSeriesMaps(
+  services: PyroscopeSeries['services'],
+  profileMetrics: PyroscopeSeries['profileMetrics'],
+  compositeValue: string,
+  profileMetricId: string
+) {
+  const serviceProfileMetrics = services.get(compositeValue) || new Map();
+  serviceProfileMetrics.set(profileMetricId, getProfileMetric(profileMetricId as ProfileMetricId));
+  services.set(compositeValue, serviceProfileMetrics);
+
+  const profileMetricServices = profileMetrics.get(profileMetricId) || new Set();
+  profileMetricServices.add(compositeValue);
+  profileMetrics.set(profileMetricId, profileMetricServices);
+}
+
+/**
+ * Formats series response using a label preset.
+ * Creates composite values by joining preset label values with "/".
+ * For example, with presetLabels=['cluster', 'namespace', 'container'],
+ * creates values like "prod-cluster/my-namespace/my-container".
+ */
+export function formatSeriesResponseWithPreset(
+  data: { labelsSet: Array<{ labels: Labels }> },
+  presetLabels: string[]
+): PyroscopeSeries {
+  const services: PyroscopeSeries['services'] = new Map();
+  const profileMetrics: PyroscopeSeries['profileMetrics'] = new Map();
+
+  if (!data.labelsSet) {
+    logger.warn('Pyroscope SeriesApiClient: no data received!');
+    return { services, profileMetrics };
+  }
+
+  for (const { labels } of data.labelsSet) {
+    const result = findCompositeValueAndProfileMetricId(labels, presetLabels);
+
+    if (result.length === 0) {
+      continue;
+    }
+
+    const [compositeValue, profileMetricId] = result;
+    addToSeriesMaps(services, profileMetrics, compositeValue, profileMetricId);
   }
 
   return { services, profileMetrics };

--- a/src/pages/ProfilesExplorerView/infrastructure/series/http/seriesRepository.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/http/seriesRepository.ts
@@ -37,6 +37,36 @@ class SeriesRepository extends AbstractRepository<SeriesApiClient, MemoryCacheCl
       throw error;
     }
   }
+
+  async listWithPreset(options: { timeRange: TimeRange; presetLabels: string[] }): Promise<PyroscopeSeries> {
+    const { from, to } = computeRoundedTimeRange(options.timeRange);
+    const { presetLabels } = options;
+
+    // Include preset labels in cache key
+    const cacheParams = [this.apiClient!.baseUrl, from, to, 'preset', ...presetLabels];
+
+    const responseFromCacheP = this.cacheClient!.get(cacheParams);
+    if (responseFromCacheP) {
+      const { services, profileMetrics } = await responseFromCacheP;
+
+      if (!services.size && !profileMetrics.size) {
+        this.cacheClient!.delete(cacheParams);
+      }
+
+      return { services, profileMetrics };
+    }
+
+    const fetchP = this.apiClient!.listWithPreset({ from, to, presetLabels });
+    this.cacheClient!.set(cacheParams, fetchP);
+
+    try {
+      const { services, profileMetrics } = await fetchP;
+      return { services, profileMetrics };
+    } catch (error) {
+      this.cacheClient!.delete(cacheParams);
+      throw error;
+    }
+  }
 }
 
 export const seriesRepository = new SeriesRepository({

--- a/src/pages/ProfilesExplorerView/infrastructure/timeseries/TimeSeriesQueryRunnerParams.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/timeseries/TimeSeriesQueryRunnerParams.ts
@@ -1,5 +1,10 @@
 import { AdHocVariableFilter } from '@grafana/data';
 
+export type HierarchyFilter = {
+  label: string;
+  value: string;
+};
+
 export type TimeSeriesQueryRunnerParams = {
   serviceName?: string;
   profileMetricId?: string;
@@ -7,4 +12,5 @@ export type TimeSeriesQueryRunnerParams = {
     label: string;
   };
   filters?: AdHocVariableFilter[];
+  hierarchyFilters?: HierarchyFilter[];
 };

--- a/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
@@ -1,8 +1,9 @@
+import { AdHocVariableFilter } from '@grafana/data';
 import { SceneQueryRunner } from '@grafana/scenes';
 
 import { PYROSCOPE_DATA_SOURCE } from '../pyroscope-data-sources';
 import { withPreventInvalidQuery } from '../withPreventInvalidQuery';
-import { TimeSeriesQueryRunnerParams } from './TimeSeriesQueryRunnerParams';
+import { HierarchyFilter, TimeSeriesQueryRunnerParams } from './TimeSeriesQueryRunnerParams';
 
 export type TimeSeriesQuery = {
   refId: string;
@@ -12,15 +13,32 @@ export type TimeSeriesQuery = {
   groupBy: string[];
 };
 
+function buildFiltersWithHierarchy(
+  filters: AdHocVariableFilter[] | undefined,
+  hierarchyFilters: HierarchyFilter[] | undefined,
+  serviceName: string | undefined
+): AdHocVariableFilter[] {
+  const completeFilters = filters ? [...filters] : [];
+
+  // Add hierarchy filters if provided, otherwise fall back to serviceName for backwards compatibility
+  if (hierarchyFilters && hierarchyFilters.length > 0) {
+    hierarchyFilters.forEach(({ label, value }) => {
+      completeFilters.unshift({ key: label, operator: '=', value });
+    });
+  } else {
+    completeFilters.unshift({ key: 'service_name', operator: '=', value: serviceName || '$serviceName' });
+  }
+
+  return completeFilters;
+}
+
 export function buildTimeSeriesQueryRunner(
-  { serviceName, profileMetricId, groupBy, filters }: TimeSeriesQueryRunnerParams,
+  { serviceName, profileMetricId, groupBy, filters, hierarchyFilters }: TimeSeriesQueryRunnerParams,
   limit?: number,
   annotations?: boolean,
   includeExemplars?: boolean
 ) {
-  const completeFilters = filters ? [...filters] : [];
-  completeFilters.unshift({ key: 'service_name', operator: '=', value: serviceName || '$serviceName' });
-
+  const completeFilters = buildFiltersWithHierarchy(filters, hierarchyFilters, serviceName);
   const selector = completeFilters.map(({ key, operator, value }) => `${key}${operator}"${value}"`).join(',');
 
   const queryRunner = new SceneQueryRunner({

--- a/src/pages/ProfilesExplorerView/infrastructure/withPreventInvalidQuery.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/withPreventInvalidQuery.ts
@@ -3,6 +3,31 @@ import { sceneGraph, SceneQueryRunner } from '@grafana/scenes';
 import { parseQuery } from '@shared/domain/url-params/parseQuery';
 import { logger } from '@shared/infrastructure/tracking/logger';
 
+/**
+ * Checks if the label selector has valid filters (either service_name or hierarchy filters)
+ * Returns true if the query has at least one meaningful filter
+ */
+function hasValidFilters(interpolatedSelector: string): boolean {
+  // Check for service_name
+  if (/service_name="[^"]+"/.test(interpolatedSelector)) {
+    return true;
+  }
+
+  // Check for any label filter (format: label_name="value")
+  // Exclude $filters variable placeholder and empty values
+  const labelFilterRegex = /([a-zA-Z_][a-zA-Z0-9_]*)="([^"]+)"/g;
+  let match;
+  while ((match = labelFilterRegex.exec(interpolatedSelector)) !== null) {
+    const [, labelName] = match;
+    // Skip internal labels and variable placeholders
+    if (!labelName.startsWith('__') && !labelName.startsWith('$')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function withPreventInvalidQuery(queryRunner: SceneQueryRunner) {
   queryRunner.addActivationHandler(() => {
     const { profileTypeId, labelSelector } = queryRunner.state.queries[0];
@@ -31,13 +56,19 @@ export function withPreventInvalidQuery(queryRunner: SceneQueryRunner) {
       return;
     }
 
-    const parsed = parseQuery(sceneGraph.interpolate(queryRunner, `$profileTypeId${labelSelector})`));
+    const interpolatedSelector = sceneGraph.interpolate(queryRunner, labelSelector);
 
-    if (!parsed.serviceId) {
-      queryRunner.setState({
-        queries: [{ refId: 'null' }],
-        data: buildErrorData(queryRunner, 'Missing service name!'),
-      });
+    // Check for valid filters (service_name or hierarchy filters)
+    if (!hasValidFilters(interpolatedSelector)) {
+      const parsed = parseQuery(sceneGraph.interpolate(queryRunner, `$profileTypeId${labelSelector})`));
+
+      // Only show error if there's truly no service identifier
+      if (!parsed.serviceId) {
+        queryRunner.setState({
+          queries: [{ refId: 'null' }],
+          data: buildErrorData(queryRunner, 'Missing service name!'),
+        });
+      }
     }
   });
 

--- a/src/pages/SettingsView/components/UISettingsView/UISettingsView.tsx
+++ b/src/pages/SettingsView/components/UISettingsView/UISettingsView.tsx
@@ -1,9 +1,22 @@
 import { css } from '@emotion/css';
-import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, FieldSet, InlineField, InlineFieldRow, InlineSwitch, Input, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import {
+  Alert,
+  Button,
+  FieldSet,
+  HorizontalGroup,
+  InlineField,
+  InlineFieldRow,
+  InlineSwitch,
+  Input,
+  Select,
+  TagsInput,
+  useStyles2,
+} from '@grafana/ui';
 import { displayError } from '@shared/domain/displayStatus';
 import { featureToggles } from '@shared/infrastructure/settings/featureToggles';
-import React from 'react';
+import { DEFAULT_LABEL_PRESETS, getActiveLabelPreset } from '@shared/infrastructure/settings/PluginSettings';
+import React, { useMemo, useState } from 'react';
 
 import { useUISettingsView } from './domain/useUISettingsView';
 
@@ -112,8 +125,127 @@ export function UISettingsView({ children }: { children: React.ReactNode }) {
         </FieldSet>
       )}
 
+      <LabelPresetsSettings data={data} actions={actions} styles={styles} />
+
       {children}
     </form>
+  );
+}
+
+function LabelPresetsSettings({
+  data,
+  actions,
+  styles,
+}: {
+  data: ReturnType<typeof useUISettingsView>['data'];
+  actions: ReturnType<typeof useUISettingsView>['actions'];
+  styles: Record<string, string>;
+}) {
+  const activePreset = getActiveLabelPreset(data);
+  const [isAddingPreset, setIsAddingPreset] = useState(false);
+  const [newPresetName, setNewPresetName] = useState('');
+
+  const presetOptions: Array<SelectableValue<string>> = useMemo(
+    () => data.labelPresets.map((p) => ({ label: p.name, value: p.name, description: p.labels.join(' / ') })),
+    [data.labelPresets]
+  );
+
+  const isDefaultPreset = DEFAULT_LABEL_PRESETS.some((p) => p.name === activePreset.name);
+
+  const handleAddPreset = () => {
+    if (newPresetName.trim() && !data.labelPresets.some((p) => p.name === newPresetName.trim())) {
+      actions.addLabelPreset({ name: newPresetName.trim(), labels: ['service_name'] });
+      actions.setActiveLabelPreset(newPresetName.trim());
+      setNewPresetName('');
+      setIsAddingPreset(false);
+    }
+  };
+
+  const handleDeletePreset = () => {
+    if (!isDefaultPreset && data.labelPresets.length > 1) {
+      actions.removeLabelPreset(activePreset.name);
+    }
+  };
+
+  return (
+    <FieldSet label="Label presets" data-testid="label-presets-settings">
+      <div className={styles.labelPresetsInfo}>
+        <p>
+          Label presets define how profiles are grouped and displayed. Each preset combines one or more labels into a
+          single identifier. For example, the <code>Kubernetes</code> preset combines <code>cluster</code>,{' '}
+          <code>namespace</code>, and <code>container</code> labels, displaying values like{' '}
+          <code>prod-cluster/my-namespace/my-container</code>.
+        </p>
+      </div>
+      <InlineFieldRow>
+        <InlineField
+          label="Active preset"
+          labelWidth={24}
+          tooltip="Select which label preset to use for grouping profiles"
+        >
+          <HorizontalGroup spacing="sm">
+            <Select
+              options={presetOptions}
+              value={data.activeLabelPreset}
+              onChange={(v) => v.value && actions.setActiveLabelPreset(v.value)}
+              width={30}
+            />
+            {!isDefaultPreset && data.labelPresets.length > 1 && (
+              <Button variant="destructive" size="sm" icon="trash-alt" onClick={handleDeletePreset} aria-label="Delete preset" />
+            )}
+          </HorizontalGroup>
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField
+          label="Labels"
+          labelWidth={24}
+          tooltip="The labels in this preset. Values will be joined with '/' to create a composite identifier."
+        >
+          <TagsInput
+            tags={activePreset.labels}
+            onChange={(labels) => actions.updateLabelPreset(activePreset.name, labels)}
+            placeholder="Add label"
+            width={40}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      {activePreset.labels.length > 0 && (
+        <div className={styles.presetPreview}>
+          Preview: <code>{activePreset.labels.join(' / ')}</code>
+        </div>
+      )}
+
+      {isAddingPreset ? (
+        <div className={styles.addPresetForm}>
+          <InlineFieldRow>
+            <InlineField label="New preset name" labelWidth={24}>
+              <HorizontalGroup spacing="sm">
+                <Input
+                  value={newPresetName}
+                  onChange={(e) => setNewPresetName(e.currentTarget.value)}
+                  placeholder="Enter preset name"
+                  width={30}
+                  onKeyDown={(e) => e.key === 'Enter' && handleAddPreset()}
+                />
+                <Button variant="primary" size="sm" onClick={handleAddPreset} disabled={!newPresetName.trim()}>
+                  Create
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => setIsAddingPreset(false)}>
+                  Cancel
+                </Button>
+              </HorizontalGroup>
+            </InlineField>
+          </InlineFieldRow>
+        </div>
+      ) : (
+        <div className={styles.addPresetButton}>
+          <Button variant="secondary" size="sm" icon="plus" onClick={() => setIsAddingPreset(true)}>
+            Add new preset
+          </Button>
+        </div>
+      )}
+    </FieldSet>
   );
 }
 
@@ -147,5 +279,38 @@ const getStyles = (theme: GrafanaTheme2) => ({
       font-style: normal;
       font-weight: ${theme.typography.fontWeightBold};
     }
+  `,
+  labelPresetsInfo: css`
+    max-width: 700px;
+    margin-bottom: ${theme.spacing(2)};
+
+    p {
+      margin-bottom: ${theme.spacing(1)};
+    }
+
+    code {
+      background-color: ${theme.colors.background.secondary};
+      padding: ${theme.spacing(0.25)} ${theme.spacing(0.5)};
+      border-radius: ${theme.shape.radius.default};
+    }
+  `,
+  presetPreview: css`
+    margin-top: ${theme.spacing(1)};
+    margin-left: ${theme.spacing(24)};
+    color: ${theme.colors.text.secondary};
+
+    code {
+      background-color: ${theme.colors.background.secondary};
+      padding: ${theme.spacing(0.25)} ${theme.spacing(0.5)};
+      border-radius: ${theme.shape.radius.default};
+      font-weight: ${theme.typography.fontWeightMedium};
+    }
+  `,
+  addPresetForm: css`
+    margin-top: ${theme.spacing(2)};
+  `,
+  addPresetButton: css`
+    margin-top: ${theme.spacing(2)};
+    margin-left: ${theme.spacing(24)};
   `,
 });

--- a/src/pages/SettingsView/components/UISettingsView/domain/useUISettingsView.ts
+++ b/src/pages/SettingsView/components/UISettingsView/domain/useUISettingsView.ts
@@ -1,6 +1,6 @@
 import { displayError, displaySuccess } from '@shared/domain/displayStatus';
 import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
-import { DEFAULT_SETTINGS, PluginSettings } from '@shared/infrastructure/settings/PluginSettings';
+import { DEFAULT_SETTINGS, LabelPreset, PluginSettings } from '@shared/infrastructure/settings/PluginSettings';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { useEffect, useState } from 'react';
 
@@ -50,6 +50,35 @@ export function useUISettingsView() {
           ...s,
           enableMetricsFromProfiles: !s.enableMetricsFromProfiles,
         }));
+      },
+      setActiveLabelPreset(presetName: string) {
+        setCurrentSettings((s) => ({
+          ...s,
+          activeLabelPreset: presetName,
+        }));
+      },
+      addLabelPreset(preset: LabelPreset) {
+        setCurrentSettings((s) => ({
+          ...s,
+          labelPresets: [...s.labelPresets, preset],
+        }));
+      },
+      updateLabelPreset(presetName: string, labels: string[]) {
+        setCurrentSettings((s) => ({
+          ...s,
+          labelPresets: s.labelPresets.map((p) => (p.name === presetName ? { ...p, labels } : p)),
+        }));
+      },
+      removeLabelPreset(presetName: string) {
+        setCurrentSettings((s) => {
+          const newPresets = s.labelPresets.filter((p) => p.name !== presetName);
+          return {
+            ...s,
+            labelPresets: newPresets,
+            // If removing the active preset, switch to the first available
+            activeLabelPreset: s.activeLabelPreset === presetName ? newPresets[0]?.name || 'Services' : s.activeLabelPreset,
+          };
+        });
       },
       async saveSettings() {
         setMaxNodes(currentSettings.maxNodes);

--- a/src/shared/domain/reportInteraction.ts
+++ b/src/shared/domain/reportInteraction.ts
@@ -69,6 +69,10 @@ export type Interactions = {
     type: ActionType;
   };
   g_pyroscope_app_service_name_selected: {};
+  g_pyroscope_app_group_by_label_value_selected: {
+    labelName: string;
+    hierarchyLevel: number;
+  };
   g_pyroscope_app_share_link_clicked: {};
   g_pyroscope_app_timeseries_scale_changed: {
     scale: ScaleDistribution;

--- a/src/shared/domain/url-params/parseQuery.ts
+++ b/src/shared/domain/url-params/parseQuery.ts
@@ -20,6 +20,30 @@ export function parseQuery(query: string): ParsedQuery {
   return { serviceId, profileMetricId, labelsSelector, labels };
 }
 
+type HierarchyFilter = {
+  label: string;
+  value: string;
+};
+
+type ParsedQueryWithHierarchy = ParsedQuery & {
+  hierarchyFilters: HierarchyFilter[];
+};
+
+export function parseQueryWithHierarchy(query: string, groupByLabels: string[]): ParsedQueryWithHierarchy {
+  const base = parseQuery(query);
+  const hierarchyFilters: HierarchyFilter[] = [];
+
+  for (const label of groupByLabels) {
+    const regex = new RegExp(`${label}="([^"]+)"`);
+    const match = query.match(regex);
+    if (match && match[1]) {
+      hierarchyFilters.push({ label, value: match[1] });
+    }
+  }
+
+  return { ...base, hierarchyFilters };
+}
+
 type BuildQueryParams = {
   serviceId: string;
   profileMetricId: string;
@@ -30,3 +54,23 @@ export const buildQuery = ({ serviceId, profileMetricId, labels }: BuildQueryPar
   labels?.length
     ? `${profileMetricId}{service_name="${serviceId}",${labels.join()}}`
     : `${profileMetricId}{service_name="${serviceId}"}`;
+
+type BuildQueryWithHierarchyParams = {
+  hierarchyFilters: HierarchyFilter[];
+  profileMetricId: string;
+  labels?: string[];
+};
+
+export const buildQueryWithHierarchy = ({
+  hierarchyFilters,
+  profileMetricId,
+  labels,
+}: BuildQueryWithHierarchyParams): string => {
+  const hierarchySelector = hierarchyFilters.map(({ label, value }) => `${label}="${value}"`).join(',');
+
+  if (labels?.length) {
+    return `${profileMetricId}{${hierarchySelector},${labels.join()}}`;
+  }
+
+  return `${profileMetricId}{${hierarchySelector}}`
+};

--- a/src/shared/infrastructure/labels/labelsRepository.ts
+++ b/src/shared/infrastructure/labels/labelsRepository.ts
@@ -9,6 +9,7 @@ type ListLabelsOptions = {
   query: string;
   from: number;
   to: number;
+  excludeLabels?: string[];
 };
 
 type ListLabelValuesOptions = ListLabelsOptions & {
@@ -18,14 +19,25 @@ type ListLabelValuesOptions = ListLabelsOptions & {
 class LabelsRepository extends AbstractRepository<LabelsApiClient, MemoryCacheClient> {
   cacheClient: MemoryCacheClient;
 
+  static isNotMetaLabel = (label: string) => !/^__.+__$/.test(label);
+
   static isNotMetaLabelOrServiceName = (label: string) => !/^(__.+__|service_name)$/.test(label);
 
-  static parseLabelsResponse(json: Record<string, any>): Suggestions {
+  static createLabelFilter = (excludeLabels: string[]) => {
+    const excludeSet = new Set(excludeLabels);
+    return (label: string) => LabelsRepository.isNotMetaLabel(label) && !excludeSet.has(label);
+  };
+
+  static parseLabelsResponse(json: Record<string, any>, excludeLabels?: string[]): Suggestions {
     if (!Array.isArray(json.names)) {
       return [];
     }
 
-    const uniqueLabels: string[] = Array.from(new Set(json.names.filter(LabelsRepository.isNotMetaLabelOrServiceName)));
+    const filterFn = excludeLabels?.length
+      ? LabelsRepository.createLabelFilter(excludeLabels)
+      : LabelsRepository.isNotMetaLabelOrServiceName;
+
+    const uniqueLabels: string[] = Array.from(new Set(json.names.filter(filterFn)));
 
     return uniqueLabels.map((label) => ({ value: label, label }));
   }
@@ -51,15 +63,15 @@ class LabelsRepository extends AbstractRepository<LabelsApiClient, MemoryCacheCl
     invariant(from > 0 && to > 0 && to > from, 'Invalid timerange!');
   }
 
-  async listLabels({ query, from, to }: ListLabelsOptions): Promise<Suggestions> {
+  async listLabels({ query, from, to, excludeLabels }: ListLabelsOptions): Promise<Suggestions> {
     LabelsRepository.assertParams(query, from, to);
 
-    const cacheParams = [this.apiClient!.baseUrl, query, from, to];
+    const cacheParams = [this.apiClient!.baseUrl, query, from, to, excludeLabels?.join(',') || ''];
 
     const labelsFromCacheP = this.cacheClient.get(cacheParams);
     if (labelsFromCacheP) {
       const json = await labelsFromCacheP;
-      const labels = LabelsRepository.parseLabelsResponse(json);
+      const labels = LabelsRepository.parseLabelsResponse(json, excludeLabels);
 
       if (!labels.length) {
         this.cacheClient.delete(cacheParams);
@@ -73,7 +85,7 @@ class LabelsRepository extends AbstractRepository<LabelsApiClient, MemoryCacheCl
 
     try {
       const json = await fetchP;
-      return LabelsRepository.parseLabelsResponse(json);
+      return LabelsRepository.parseLabelsResponse(json, excludeLabels);
     } catch (error) {
       this.cacheClient.delete(cacheParams);
       throw error;

--- a/src/shared/infrastructure/settings/GroupByLabelsContext.tsx
+++ b/src/shared/infrastructure/settings/GroupByLabelsContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useMemo } from 'react';
+
+import {
+  DEFAULT_LABEL_PRESETS,
+  DEFAULT_SETTINGS,
+  getActiveLabelPreset,
+  isDefaultServiceNamePreset,
+  LabelPreset,
+} from './PluginSettings';
+import { useFetchPluginSettings } from './useFetchPluginSettings';
+
+type LabelPresetContextValue = {
+  activePreset: LabelPreset;
+  allPresets: LabelPreset[];
+  isLoading: boolean;
+  isDefaultPreset: boolean;
+};
+
+const LabelPresetContext = createContext<LabelPresetContextValue>({
+  activePreset: DEFAULT_LABEL_PRESETS[0],
+  allPresets: DEFAULT_LABEL_PRESETS,
+  isLoading: true,
+  isDefaultPreset: true,
+});
+
+export function LabelPresetProvider({ children }: { children: React.ReactNode }) {
+  const { settings, isFetching } = useFetchPluginSettings();
+
+  const value = useMemo(() => {
+    const effectiveSettings = settings ?? DEFAULT_SETTINGS;
+    return {
+      activePreset: getActiveLabelPreset(effectiveSettings),
+      allPresets: effectiveSettings.labelPresets ?? DEFAULT_LABEL_PRESETS,
+      isLoading: isFetching,
+      isDefaultPreset: isDefaultServiceNamePreset(effectiveSettings),
+    };
+  }, [settings, isFetching]);
+
+  return <LabelPresetContext.Provider value={value}>{children}</LabelPresetContext.Provider>;
+}
+
+export function useLabelPreset(): LabelPresetContextValue {
+  return useContext(LabelPresetContext);
+}
+
+// Backwards compatibility aliases
+export const GroupByLabelsProvider = LabelPresetProvider;
+export function useGroupByLabels() {
+  const { activePreset, isLoading, isDefaultPreset } = useLabelPreset();
+  return {
+    groupByLabels: activePreset.labels,
+    isLoading,
+    isUsingHierarchy: !isDefaultPreset,
+  };
+}

--- a/src/shared/infrastructure/settings/PluginSettings.ts
+++ b/src/shared/infrastructure/settings/PluginSettings.ts
@@ -1,9 +1,21 @@
+export type LabelPreset = {
+  name: string;
+  labels: string[];
+};
+
+export const DEFAULT_LABEL_PRESETS: LabelPreset[] = [
+  { name: 'Services', labels: ['service_name'] },
+  { name: 'Kubernetes', labels: ['cluster', 'namespace', 'container'] },
+];
+
 export type PluginSettings = {
   collapsedFlamegraphs: boolean;
   maxNodes: number;
   enableFlameGraphDotComExport: boolean;
   enableFunctionDetails: boolean;
   enableMetricsFromProfiles?: boolean;
+  labelPresets: LabelPreset[];
+  activeLabelPreset: string;
 };
 
 export const DEFAULT_SETTINGS: PluginSettings = Object.freeze({
@@ -12,4 +24,22 @@ export const DEFAULT_SETTINGS: PluginSettings = Object.freeze({
   enableFlameGraphDotComExport: true,
   enableFunctionDetails: true,
   enableMetricsFromProfiles: false,
+  labelPresets: DEFAULT_LABEL_PRESETS,
+  activeLabelPreset: 'Services',
 });
+
+/**
+ * Gets the active label preset from settings
+ */
+export function getActiveLabelPreset(settings: PluginSettings): LabelPreset {
+  const preset = settings.labelPresets.find((p) => p.name === settings.activeLabelPreset);
+  return preset || DEFAULT_LABEL_PRESETS[0];
+}
+
+/**
+ * Checks if the active preset is the default service_name preset
+ */
+export function isDefaultServiceNamePreset(settings: PluginSettings): boolean {
+  const preset = getActiveLabelPreset(settings);
+  return preset.labels.length === 1 && preset.labels[0] === 'service_name';
+}


### PR DESCRIPTION
This is an experiment the drilldown group by could be changed by label presets:

Currently we hard code a service_name, but for other Personas a breakdown by:

- cluster + node: To see what Kubernetes nodes are using 
- cluster + namespace: To see what namespaces are busy


