### PR TITLE
WIP: feat: Add label filters to the all services view

### DIFF
--- a/e2e/tests/all-services-view/filters.spec.ts
+++ b/e2e/tests/all-services-view/filters.spec.ts
@@ -1,0 +1,45 @@
+import { ExplorationType } from '../../config/constants';
+import { expect, test } from '../../fixtures';
+
+test.describe('All services view - Filters', () => {
+  test('var-filters is cleared when switching from Labels to All services', async ({ exploreProfilesPage }) => {
+    await exploreProfilesPage.goto(ExplorationType.Labels);
+
+    const filter = ['vehicle', '=', 'car'];
+    await exploreProfilesPage.addFilter(filter);
+    await exploreProfilesPage.assertFilters([filter]);
+
+    await exploreProfilesPage.selectExplorationType('All services');
+    await exploreProfilesPage.selectExplorationType('Labels');
+
+    await exploreProfilesPage.assertFilters([]);
+  });
+
+  test('var-filters-all persists when switching away from All services and back', async ({ exploreProfilesPage }) => {
+    await exploreProfilesPage.goto(ExplorationType.AllServices);
+
+    const filter = ['vehicle', '=', 'car'];
+    await exploreProfilesPage.addFilter(filter, 'filters-all');
+    await exploreProfilesPage.assertFilters([filter], 'filters-all');
+
+    await exploreProfilesPage.selectExplorationType('Labels');
+    await exploreProfilesPage.selectExplorationType('All services');
+
+    await exploreProfilesPage.assertFilters([filter], 'filters-all');
+  });
+
+  test('var-filters and var-filters-all are independent', async ({ exploreProfilesPage }) => {
+    await exploreProfilesPage.goto(ExplorationType.AllServices);
+
+    await exploreProfilesPage.addFilter(['region', '=', 'us-east'], 'filters-all');
+
+    await exploreProfilesPage.selectExplorationType('Labels');
+    await exploreProfilesPage.addFilter(['vehicle', '=', 'bike']);
+
+    await exploreProfilesPage.selectExplorationType('All services');
+    await exploreProfilesPage.assertFilters([['region', '=', 'us-east']], 'filters-all');
+
+    await exploreProfilesPage.selectExplorationType('Labels');
+    await exploreProfilesPage.assertFilters([]);
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid.tsx
@@ -35,12 +35,13 @@ import { GridItemData } from './types/GridItemData';
 
 interface SceneByVariableRepeaterGridState extends EmbeddedSceneState {
   variableName: string;
+  filtersKey: string;
   items: GridItemData[];
   headerActions: (item: GridItemData, items: GridItemData[]) => VizPanelState['headerActions'];
   mapOptionToItem: (
     option: VariableValueOption,
     index: number,
-    variablesValues: Record<string, string>
+    variablesValues: Record<string, any>
   ) => GridItemData | null;
   sortItemsFn: (a: GridItemData, b: GridItemData) => number;
   hideNoData: boolean;
@@ -62,12 +63,14 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
   constructor({
     key,
     variableName,
+    filtersKey = 'filters',
     headerActions,
     mapOptionToItem,
     sortItemsFn,
   }: {
     key: string;
     variableName: SceneByVariableRepeaterGridState['variableName'];
+    filtersKey?: string;
     headerActions: SceneByVariableRepeaterGridState['headerActions'];
     mapOptionToItem: SceneByVariableRepeaterGridState['mapOptionToItem'];
     sortItemsFn?: SceneByVariableRepeaterGridState['sortItemsFn'];
@@ -75,6 +78,7 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
     super({
       key,
       variableName,
+      filtersKey,
       items: [],
       headerActions,
       mapOptionToItem,
@@ -188,14 +192,23 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
   }
 
   subscribeToFiltersChange() {
-    const filtersVariable = sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable);
+    const filtersVariable = sceneGraph.findByKeyAndType(this, this.state.filtersKey, FiltersVariable);
     const noDataSwitcher = sceneGraph.findByKeyAndType(this, 'no-data-switcher', SceneNoDataSwitcher);
 
     // the handler will be called each time a filter is added/removed/modified
-    return filtersVariable.subscribeToState(() => {
-      if (noDataSwitcher.state.hideNoData === 'on') {
-        // to be sure the list is updated we force render because the filters only influence the query made in each panel
-        this.renderGridItems(true);
+    return filtersVariable.subscribeToState((newState, prevState) => {
+      // Check if filters actually changed (not just other state properties)
+      if (JSON.stringify(newState.filters) !== JSON.stringify(prevState.filters)) {
+        // Re-query the variable to get filtered services/profile types from the Series API
+        const variable = sceneGraph.lookupVariable(this.state.variableName, this) as QueryVariable & {
+          update: () => void;
+        };
+        variable.update();
+
+        // Also force re-render if hideNoData is enabled
+        if (noDataSwitcher.state.hideNoData === 'on') {
+          this.renderGridItems(true);
+        }
       }
     });
   }
@@ -203,10 +216,15 @@ export class SceneByVariableRepeaterGrid extends SceneObjectBase<SceneByVariable
   buildItemsData(variable: QueryVariable) {
     const { mapOptionToItem } = this.state;
 
+    // Get current filters from FiltersVariable to include in queryRunnerParams
+    const filtersVariable = sceneGraph.findByKeyAndType(this, this.state.filtersKey, FiltersVariable);
+    const filters = filtersVariable.state.filters;
+
     const variableValues = {
       serviceName: getSceneVariableValue(this, 'serviceName'),
       profileMetricId: getSceneVariableValue(this, 'profileMetricId'),
       panelType: sceneGraph.findByKeyAndType(this, 'panel-type-switcher', ScenePanelTypeSwitcher).state.panelType,
+      filters: filters.length > 0 ? filters : undefined,
     };
 
     const items = variable.state.options

--- a/src/pages/ProfilesExplorerView/components/SceneExploreAllServices/SceneExploreAllServices.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreAllServices/SceneExploreAllServices.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { SceneByVariableRepeaterGrid } from '../../components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
+import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
@@ -34,13 +35,15 @@ export class SceneExploreAllServices extends SceneObjectBase<SceneExploreAllServ
       body: new SceneByVariableRepeaterGrid({
         key: 'all-services-grid',
         variableName: 'serviceName',
-        mapOptionToItem: (option, index, { profileMetricId }) => ({
+        filtersKey: 'filters-all',
+        mapOptionToItem: (option, index, { profileMetricId, filters }) => ({
           index,
           value: option.value as string,
           label: option.label,
           queryRunnerParams: {
             serviceName: option.value as string,
             profileMetricId,
+            filters,
           },
           panelType: PanelType.TIMESERIES,
         }),
@@ -65,7 +68,10 @@ export class SceneExploreAllServices extends SceneObjectBase<SceneExploreAllServ
   // see SceneProfilesExplorer
   getVariablesAndGridControls() {
     return {
-      variables: [sceneGraph.findByKeyAndType(this, 'profileMetricId', ProfileMetricVariable)],
+      variables: [
+        sceneGraph.findByKeyAndType(this, 'profileMetricId', ProfileMetricVariable),
+        sceneGraph.findByKeyAndType(this, 'filters-all', FiltersVariable),
+      ],
       gridControls: [
         sceneGraph.findByKeyAndType(this, 'quick-filter', SceneQuickFilter),
         sceneGraph.findByKeyAndType(this, 'layout-switcher', SceneLayoutSwitcher),

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceProfileTypes/SceneExploreServiceProfileTypes.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceProfileTypes/SceneExploreServiceProfileTypes.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { SceneByVariableRepeaterGrid } from '../../components/SceneByVariableRepeaterGrid/SceneByVariableRepeaterGrid';
 import { FavAction } from '../../domain/actions/FavAction';
 import { SelectAction } from '../../domain/actions/SelectAction';
+import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
 import { SceneLayoutSwitcher } from '../SceneByVariableRepeaterGrid/components/SceneLayoutSwitcher';
@@ -35,13 +36,14 @@ export class SceneExploreServiceProfileTypes extends SceneObjectBase<SceneExplor
       body: new SceneByVariableRepeaterGrid({
         key: 'profile-metrics-grid',
         variableName: 'profileMetricId',
-        mapOptionToItem: (option, index, { serviceName }) => ({
+        mapOptionToItem: (option, index, { serviceName, filters }) => ({
           index,
           value: option.value as string,
           label: option.label,
           queryRunnerParams: {
             serviceName,
             profileMetricId: option.value as string,
+            filters,
           },
           panelType: PanelType.TIMESERIES,
         }),
@@ -76,7 +78,10 @@ export class SceneExploreServiceProfileTypes extends SceneObjectBase<SceneExplor
   // see SceneProfilesExplorer
   getVariablesAndGridControls() {
     return {
-      variables: [sceneGraph.findByKeyAndType(this, 'serviceName', ServiceNameVariable)],
+      variables: [
+        sceneGraph.findByKeyAndType(this, 'serviceName', ServiceNameVariable),
+        sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable),
+      ],
       gridControls: [
         sceneGraph.findByKeyAndType(this, 'quick-filter', SceneQuickFilter),
         sceneGraph.findByKeyAndType(this, 'layout-switcher', SceneLayoutSwitcher),

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -148,6 +148,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
                 return filtered.length > 0 ? filtered : undefined;
               })(),
             }),
+            new FiltersVariable({ key: 'filters-all' }),
             new FiltersVariable({ key: 'filtersBaseline' }),
             new FiltersVariable({ key: 'filtersComparison' }),
             new GroupByVariable(),
@@ -236,6 +237,7 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
       .subscribeToState((newState, prevState) => {
         if (newState.value && newState.value !== prevState.value) {
           FiltersVariable.resetAll(this);
+          sceneGraph.findByKeyAndType(this, 'filters-all', FiltersVariable).reset();
           this.resetSpanSelector();
         }
       });
@@ -377,14 +379,15 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
     sceneGraph.findByKeyAndType(this, 'profileIdSelector', ProfileIdSelectorVariable).reset();
     this.resetSpanSelector();
 
-    // preserve existing filters only when switching to "Labels", "Flame graph" or "Diff flame graph"
-    // if not, they will be added to the queries without any notice on the UI
-    if (
-      ![ExplorationType.LABELS, ExplorationType.FLAME_GRAPH, ExplorationType.DIFF_FLAME_GRAPH].includes(
-        nextExplorationType as ExplorationType
-      )
-    ) {
+    // Reset service-specific filters when switching to ALL_SERVICES (no selected service context)
+    if (nextExplorationType === ExplorationType.ALL_SERVICES) {
       sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable).reset();
+    }
+
+    // Reset all filters when switching to Favorites (which displays/uses neither)
+    if (nextExplorationType === ExplorationType.FAVORITES) {
+      sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable).reset();
+      sceneGraph.findByKeyAndType(this, 'filters-all', FiltersVariable).reset();
     }
   }
 

--- a/src/pages/ProfilesExplorerView/domain/useBuildPyroscopeQuery.ts
+++ b/src/pages/ProfilesExplorerView/domain/useBuildPyroscopeQuery.ts
@@ -1,6 +1,7 @@
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { useMemo } from 'react';
 
+import { SceneProfilesExplorer, ExplorationType } from '../components/SceneProfilesExplorer/SceneProfilesExplorer';
 import { FiltersVariable } from './variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from './variables/ProfileMetricVariable';
 import { ServiceNameVariable } from './variables/ServiceNameVariable/ServiceNameVariable';
@@ -16,8 +17,27 @@ export function useBuildPyroscopeQuery(sceneObject: SceneObject, filterKey: stri
 
   const { filterExpression } = sceneGraph.findByKeyAndType(sceneObject, filterKey, FiltersVariable).useState();
 
+  // Get the current exploration type to determine if we should include service_name
+  const { explorationType } = sceneGraph
+    .findByKeyAndType(sceneObject, 'profiles-explorer', SceneProfilesExplorer)
+    .useState();
+
+  // Only include service_name filter for views that have a single service selected
+  // For "all", "profiles", and "favorites" views, we want to query across all services
+  const shouldIncludeServiceName =
+    explorationType === ExplorationType.LABELS ||
+    explorationType === ExplorationType.FLAME_GRAPH ||
+    explorationType === ExplorationType.DIFF_FLAME_GRAPH;
+
   return useMemo(() => {
-    const labels = `{service_name="${serviceName}",${filterExpression}}`;
-    return profileMetricId != null && profileMetricId !== '' ? `${profileMetricId}${labels}` : labels;
-  }, [filterExpression, profileMetricId, serviceName]);
+    if (shouldIncludeServiceName && serviceName) {
+      const labels = `{service_name="${serviceName}",${filterExpression}}`;
+      return profileMetricId != null && profileMetricId !== '' ? `${profileMetricId}${labels}` : labels;
+    }
+    // For "all" and "profiles" views, don't constrain to a single service
+    if (profileMetricId != null && profileMetricId !== '') {
+      return filterExpression ? `${profileMetricId}{${filterExpression}}` : `${profileMetricId}{}`;
+    }
+    return filterExpression ? `{${filterExpression}}` : `{}`;
+  }, [filterExpression, profileMetricId, serviceName, shouldIncludeServiceName]);
 }

--- a/src/pages/ProfilesExplorerView/infrastructure/helpers/getExplorationType.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/helpers/getExplorationType.ts
@@ -1,0 +1,14 @@
+import { SceneObject } from '@grafana/scenes';
+
+// ExplorationType.ALL_SERVICES = 'all' — using string literals avoids a circular import
+// (SceneProfilesExplorer imports infrastructure files, so infrastructure cannot import SceneProfilesExplorer)
+export function getExplorationType(sceneObject: SceneObject): string {
+  let current: SceneObject | undefined = sceneObject.parent;
+  while (current) {
+    if ((current.state as any).key === 'profiles-explorer') {
+      return (current.state as any).explorationType || '';
+    }
+    current = current.parent;
+  }
+  return '';
+}

--- a/src/pages/ProfilesExplorerView/infrastructure/helpers/interpolateQueryRunnerVariables.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/helpers/interpolateQueryRunnerVariables.ts
@@ -5,6 +5,7 @@ import { clone, defaults, uniqBy } from 'lodash';
 import { GridItemData } from '../../components/SceneByVariableRepeaterGrid/types/GridItemData';
 import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { getSceneVariableValue } from '../../helpers/getSceneVariableValue';
+import { getExplorationType } from './getExplorationType';
 
 type InterpolatedQueryRunnerParams = GridItemData['queryRunnerParams'] & {
   serviceName: string;
@@ -23,8 +24,10 @@ export function interpolateQueryRunnerVariables(
     profileMetricId: getSceneVariableValue(sceneObject, 'profileMetricId'),
   });
 
+  // Use filters-all for the all-services view so var-filters is never read there
+  const filtersVariableName = getExplorationType(sceneObject) === 'all' ? 'filters-all' : 'filters';
   // state.filters has the AdHocFilterWithLabels[] type so we get rid of keyLabel and valueLabel
-  const parsedFilters = (sceneGraph.lookupVariable('filters', sceneObject) as FiltersVariable).state.filters.map(
+  const parsedFilters = (sceneGraph.lookupVariable(filtersVariableName, sceneObject) as FiltersVariable).state.filters.map(
     ({ key, operator, value }) => ({ key, operator, value })
   );
 

--- a/src/pages/ProfilesExplorerView/infrastructure/series/SeriesDataSource.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/SeriesDataSource.ts
@@ -7,13 +7,15 @@ import {
   TestDataSourceResponse,
   TimeRange,
 } from '@grafana/data';
-import { RuntimeDataSource } from '@grafana/scenes';
+import { RuntimeDataSource, sceneGraph } from '@grafana/scenes';
 import { ApiClient } from '@shared/infrastructure/http/ApiClient';
 import { logger } from '@shared/infrastructure/tracking/logger';
 
+import { FiltersVariable } from '../../domain/variables/FiltersVariable/FiltersVariable';
 import { ProfileMetricVariable } from '../../domain/variables/ProfileMetricVariable';
 import { ServiceNameVariable } from '../../domain/variables/ServiceNameVariable/ServiceNameVariable';
 import { PYROSCOPE_SERIES_DATA_SOURCE } from '../pyroscope-data-sources';
+import { getExplorationType } from '../helpers/getExplorationType';
 import { formatSeriesToProfileMetrics } from './formatSeriesToProfileMetrics';
 import { formatSeriesToServices } from './formatSeriesToServices';
 import { safeInterpolate } from './helpers/safeInterpolate';
@@ -26,11 +28,11 @@ export class SeriesDataSource extends RuntimeDataSource {
     super(PYROSCOPE_SERIES_DATA_SOURCE.type, PYROSCOPE_SERIES_DATA_SOURCE.uid);
   }
 
-  async fetchSeries(dataSourceUid: string, timeRange: TimeRange, variableName?: string) {
+  async fetchSeries(dataSourceUid: string, timeRange: TimeRange, variableName?: string, matchers?: string[]) {
     seriesRepository.setApiClient(DataSourceProxyClientBuilder.build(dataSourceUid, SeriesApiClient));
 
     try {
-      return await seriesRepository.list({ timeRange });
+      return await seriesRepository.list({ timeRange, matchers });
     } catch (error) {
       logger.error(error as Error, {
         info: 'Error while loading Pyroscope series!',
@@ -68,12 +70,36 @@ export class SeriesDataSource extends RuntimeDataSource {
     const serviceName = safeInterpolate(sceneObject, '$serviceName');
     const profileMetricId = safeInterpolate(sceneObject, '$profileMetricId');
 
+    // Use filters-all for the all-services view, filters for all other views
+    const explorationType = getExplorationType(sceneObject);
+    let filters: string;
+    if (explorationType === 'all') {
+      try {
+        const filtersAllVar = sceneGraph.findByKeyAndType(sceneObject, 'filters-all', FiltersVariable);
+        filters = filtersAllVar.state.filterExpression || '';
+      } catch {
+        filters = safeInterpolate(sceneObject, '$filters');
+      }
+    } else {
+      filters = safeInterpolate(sceneObject, '$filters');
+    }
+
     // Fallback to default datasource if interpolation not ready yet
     if (!dataSourceUid) {
       dataSourceUid = ApiClient.selectDefaultDataSource().uid as string;
     }
 
-    const pyroscopeSeries = await this.fetchSeries(dataSourceUid, options.range as TimeRange, options.variable?.name);
+    // Build matchers array from filters
+    // Filters are in format: foo="bar",baz!="qux"
+    // Matchers need to be: ["{foo=\"bar\",baz!=\"qux\"}"]
+    const matchers = filters ? [`{${filters}}`] : undefined;
+
+    const pyroscopeSeries = await this.fetchSeries(
+      dataSourceUid,
+      options.range as TimeRange,
+      options.variable?.name,
+      matchers
+    );
 
     switch (query) {
       // queries that depend only on the selected data source

--- a/src/pages/ProfilesExplorerView/infrastructure/series/http/SeriesApiClient.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/http/SeriesApiClient.ts
@@ -16,8 +16,8 @@ export class SeriesApiClient extends DataSourceProxyClient {
     super(options);
   }
 
-  async list(options: { from: number; to: number }): Promise<PyroscopeSeries> {
-    const { from, to } = options;
+  async list(options: { from: number; to: number; matchers?: string[] }): Promise<PyroscopeSeries> {
+    const { from, to, matchers = [] } = options;
 
     return this.fetch('/querier.v1.QuerierService/Series', {
       method: 'POST',
@@ -25,7 +25,7 @@ export class SeriesApiClient extends DataSourceProxyClient {
         start: from,
         end: to,
         labelNames: ['service_name', '__profile_type__'],
-        matchers: [],
+        matchers,
       }),
     })
       .then((response) => response.json())

--- a/src/pages/ProfilesExplorerView/infrastructure/series/http/seriesRepository.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/series/http/seriesRepository.ts
@@ -10,10 +10,11 @@ class SeriesRepository extends AbstractRepository<SeriesApiClient, MemoryCacheCl
     super(options);
   }
 
-  async list(options: { timeRange: TimeRange }): Promise<PyroscopeSeries> {
+  async list(options: { timeRange: TimeRange; matchers?: string[] }): Promise<PyroscopeSeries> {
     const { from, to } = computeRoundedTimeRange(options.timeRange);
+    const { matchers } = options;
 
-    const cacheParams = [this.apiClient!.baseUrl, from, to];
+    const cacheParams = [this.apiClient!.baseUrl, from, to, JSON.stringify(matchers || [])];
 
     const responseFromCacheP = this.cacheClient!.get(cacheParams);
     if (responseFromCacheP) {
@@ -26,7 +27,7 @@ class SeriesRepository extends AbstractRepository<SeriesApiClient, MemoryCacheCl
       return { services, profileMetrics };
     }
 
-    const fetchP = this.apiClient!.list({ from, to });
+    const fetchP = this.apiClient!.list({ from, to, matchers });
     this.cacheClient!.set(cacheParams, fetchP);
 
     try {

--- a/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
@@ -30,7 +30,7 @@ export function buildTimeSeriesQueryRunner(
         refId: `${profileMetricId || '$profileMetricId'}-${selector}-${groupBy?.label || 'no-group-by'}`,
         queryType: 'metrics',
         profileTypeId: profileMetricId || '$profileMetricId',
-        labelSelector: `{${selector},$filters}`,
+        labelSelector: `{${selector}}`,
         groupBy: groupBy?.label ? [groupBy.label] : [],
         limit,
         annotations,


### PR DESCRIPTION
Currently the all services view shows a long list of service_names, but
doesn't allow you to filter down to particular
workloads/cluster/namespaces.

This brings the filters field to that first tab and allow to navigate to
more detailed view of the cluster

Context: 

<img width="1694" height="619" alt="image" src="https://github.com/user-attachments/assets/6f24a978-6436-4fa5-aeb4-4852fec68c56" />

https://raintank-corp.slack.com/archives/C0ACDKUA006/p1770819754656519
