### PR TITLE
Default comparison view filters to existing flamegraph/labels view filters

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -345,6 +345,14 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
       this.resetVariables(type);
     }
 
+    if (type as ExplorationType == ExplorationType.DIFF_FLAME_GRAPH && bodySceneOptions === undefined) {
+      const filters = sceneGraph.findByKeyAndType(this, 'filters', FiltersVariable).state.filters;
+      bodySceneOptions = {
+        baselineFilters: filters,
+        comparisonFilters: filters
+      }
+    }
+
     this.setState({
       explorationType: type,
       body: this.buildBodyScene(type, item, bodySceneOptions),


### PR DESCRIPTION
### ✨ Description

Fixes: #580

This is probably not the most elegant way of doing this, but it does the job and it scratches a pretty big itch.

### 🧪 How to test?

1. Open labels view, select some filters.
2. Open diff view, observe filters applied to both panels.
