### PR TITLE
chore: update tar to 7.5.8 to address CVE-2026-26960

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typecheck": "tsc --noEmit"
   },
   "resolutions": {
-    "tar": "7.5.7",
+    "tar": "7.5.8",
     "lodash": "4.17.23"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13988,16 +13988,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.7":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+"tar@npm:7.5.8":
+  version: 7.5.8
+  resolution: "tar@npm:7.5.8"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/0d6938dd32fe5c0f17c8098d92bd9889ee0ed9d11f12381b8146b6e8c87bb5aa49feec7abc42463f0597503d8e89e4c4c0b42bff1a5a38444e918b4878b7fd21
+  checksum: 10/5fddc22e0fd03e73d5e9e922e71d8681f85443dee4f21403059a757e186ae4004abc9a709cdc7f4143d7d75758a2935f7306b3cc193123d46b6f786dd2b99c2a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Updates tar from 7.5.7 to 7.5.8 to fix CVE-2026-26960
- Fixes arbitrary file read/write vulnerability via hardlink target escape through symlink chain

## Security Impact
- **Severity**: HIGH
- **CVE**: CVE-2026-26960
- **Description**: Arbitrary File Read/Write via Hardlink Target Escape Through Symlink Chain in node-tar

## Test plan
- [x] yarn install completes successfully
- [x] Trivy security scan passes for HIGH and CRITICAL vulnerabilities
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)