### PR TITLE
chore(deps): update diff to 4.0.4 to address CVE-2026-24001

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typecheck": "tsc --noEmit"
   },
   "resolutions": {
+    "diff": "4.0.4",
     "esbuild": ">=0.25.0",
     "tar": "7.5.7",
     "lodash": "4.17.23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6330,10 +6330,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "diff@npm:4.0.2"
-  checksum: 10/ec09ec2101934ca5966355a229d77afcad5911c92e2a77413efda5455636c4cf2ce84057e2d7715227a2eeeda04255b849bd3ae3a4dd22eb22e86e76456df069
+"diff@npm:4.0.4":
+  version: 4.0.4
+  resolution: "diff@npm:4.0.4"
+  checksum: 10/5019b3f5ae124ea9e95137119e1a83a59c252c75ddac873cc967832fd7a834570a58a4d58b941bdbd07832ebf98dcb232b27c561b7f5584357da6dae59bcac62
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Updates diff (jsdiff) from 4.0.2 to 4.0.4 to fix CVE-2026-24001
- Fixes denial of service vulnerability in parsePatch and applyPatch functions

## Security Impact
- **Severity**: LOW
- **CVE**: CVE-2026-24001
- **Description**: jsdiff: denial of service vulnerability in parsePatch and applyPatch

## Test plan
- [x] yarn install completes successfully
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)