### PR TITLE
chore: add other drilldown teams as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 * @grafana/observability-traces-and-profiling
+* @grafana/observability-logs
+* @grafana/observability-metrics
 


### PR DESCRIPTION
Updates the CODEOWNERS file so that all Drilldown teams can approve PRs.
