### PR TITLE
chore(cd): remove github-draft-release

### DIFF
--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -56,6 +56,3 @@ jobs:
       playwright-config: e2e/config/playwright.config.ci.ts
       playwright-docker-compose-file: docker-compose.e2e.yaml
       playwright-report-path: 'e2e/test-reports/'
-
-      # Publish the github release
-      github-draft-release: false


### PR DESCRIPTION
### ✨ Description
Related issue(s): https://github.com/grafana/logs-drilldown/pull/1785
In Logs Drilldown we set `github-draft-release: false` in our cd.yml and ran into issues with the version number zip files not being uploaded into the release. In case you run into that error as well. I've reverted the change in this PR.

