### PR TITLE
chore(ci): fix flaky tests

### DIFF
--- a/e2e/config/playwright.config.ci.ts
+++ b/e2e/config/playwright.config.ci.ts
@@ -6,6 +6,21 @@ import { config } from './playwright.config.common';
 
 const shouldAuthenticate = !ENV_VARS.E2E_BASE_URL.startsWith('http://localhost');
 
+// Recording-rules tests modify shared plugin settings and must not run in parallel
+// with settings-view tests (which reset all settings in afterEach). We isolate them
+// into a separate project that runs after the main tests complete.
+const recordingRulesProject = (deps: string[]) => ({
+  name: 'recording-rules',
+  dependencies: deps,
+  testDir: path.join(process.cwd(), 'e2e', 'tests'),
+  testMatch: ['recording-rules/**'],
+  use: {
+    ...devices['Desktop Chrome'],
+    viewport: CHROMIUM_VIEWPORT,
+    ...(shouldAuthenticate ? { storageState: AUTH_FILE } : {}),
+  },
+});
+
 const projects = shouldAuthenticate
   ? [
       {
@@ -16,21 +31,25 @@ const projects = shouldAuthenticate
         name: 'chromium',
         dependencies: ['authenticate'],
         testDir: path.join(process.cwd(), 'e2e', 'tests'),
+        testIgnore: ['recording-rules/**'],
         use: {
           ...devices['Desktop Chrome'],
           viewport: CHROMIUM_VIEWPORT,
           storageState: AUTH_FILE, // Use prepared auth state.
         },
       },
+      recordingRulesProject(['chromium']),
     ]
   : [
       {
         name: 'chromium',
+        testIgnore: ['recording-rules/**'],
         use: {
           ...devices['Desktop Chrome'],
           viewport: CHROMIUM_VIEWPORT,
         },
       },
+      recordingRulesProject(['chromium']),
     ];
 
 export default config({

--- a/e2e/config/playwright.config.local.ts
+++ b/e2e/config/playwright.config.local.ts
@@ -7,6 +7,22 @@ import { config } from './playwright.config.common';
 const shouldAuthenticate = !ENV_VARS.E2E_BASE_URL.startsWith('http://localhost');
 const failOnUncaughtExceptions = false;
 
+// Recording-rules tests modify shared plugin settings and must not run in parallel
+// with settings-view tests (which reset all settings in afterEach). We isolate them
+// into a separate project that runs after the main tests complete.
+const recordingRulesProject = (deps: string[]) => ({
+  name: 'recording-rules',
+  dependencies: deps,
+  testDir: path.join(process.cwd(), 'e2e', 'tests'),
+  testMatch: ['recording-rules/**'],
+  use: {
+    ...devices['Desktop Chrome'],
+    viewport: CHROMIUM_VIEWPORT,
+    failOnUncaughtExceptions,
+    ...(shouldAuthenticate ? { storageState: AUTH_FILE } : {}),
+  },
+});
+
 const projects = shouldAuthenticate
   ? [
       {
@@ -17,6 +33,7 @@ const projects = shouldAuthenticate
         name: 'chromium',
         dependencies: ['authenticate'],
         testDir: path.join(process.cwd(), 'e2e', 'tests'),
+        testIgnore: ['recording-rules/**'],
         use: {
           ...devices['Desktop Chrome'],
           viewport: CHROMIUM_VIEWPORT,
@@ -24,16 +41,19 @@ const projects = shouldAuthenticate
           failOnUncaughtExceptions,
         },
       },
+      recordingRulesProject(['chromium']),
     ]
   : [
       {
         name: 'chromium',
+        testIgnore: ['recording-rules/**'],
         use: {
           ...devices['Desktop Chrome'],
           viewport: CHROMIUM_VIEWPORT,
           failOnUncaughtExceptions,
         },
       },
+      recordingRulesProject(['chromium']),
     ];
 
 export default config({

--- a/e2e/fixtures/pages/ExploreProfilesPage.ts
+++ b/e2e/fixtures/pages/ExploreProfilesPage.ts
@@ -248,7 +248,7 @@ export class ExploreProfilesPage extends PyroscopePage {
   }
 
   async assertQuickFilter(explectedPlaceholder: string, expectedValue: string, expectedResultsCount: number) {
-    await expect(await this.getQuickFilterInput().getAttribute('placeholder')).toBe(explectedPlaceholder);
+    await expect(this.getQuickFilterInput()).toHaveAttribute('placeholder', explectedPlaceholder);
     await expect(this.getQuickFilterInput()).toHaveValue(expectedValue);
     await this.assertQuickFilterResultsCount(expectedResultsCount);
   }
@@ -446,15 +446,34 @@ export class ExploreProfilesPage extends PyroscopePage {
   async selectGroupByLabel(label: string) {
     const container = this.getGroupByContainer();
     const radios = container.getByRole('radio');
+    const prefix = label.replace(/\s*\(\d+\)\s*$/, '');
+    const prefixRegex = new RegExp(`^${escapeRegex(prefix)}\\b`);
+    const targetRadio = container.getByRole('radio', { name: prefixRegex });
 
-    if ((await radios.count()) > 0) {
+    // Wait for group-by labels to load (radios may appear after the initial "All" radio)
+    await expect
+      .poll(
+        async () => {
+          if ((await targetRadio.count()) > 0) {
+            return true;
+          }
+          // Narrow layout fallback: no radios at all, only a Select
+          if ((await radios.count()) === 0) {
+            return (await container.locator('input[role="combobox"]').count()) > 0;
+          }
+          return false;
+        },
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
+
+    if ((await targetRadio.count()) > 0) {
+      // Wide layout: prefer exact name match, fall back to prefix
       const exactRadio = container.getByRole('radio', { name: label, exact: true });
       if ((await exactRadio.count()) > 0) {
         await exactRadio.click();
         return;
       }
-      // Same label name, different cardinality e.g. vehicle (3) vs vehicle (4)
-      const prefix = label.replace(/\s*\(\d+\)\s*$/, '');
       const withCount = container.getByRole('radio', {
         name: new RegExp(`^${escapeRegex(prefix)}\\s*\\(\\d+\\)$`),
       });
@@ -462,10 +481,7 @@ export class ExploreProfilesPage extends PyroscopePage {
         await withCount.first().click();
         return;
       }
-      await container
-        .getByRole('radio', { name: new RegExp(`^${escapeRegex(prefix)}\\b`) })
-        .first()
-        .click();
+      await targetRadio.first().click();
       return;
     }
 

--- a/e2e/fixtures/pages/ExploreProfilesPage.ts
+++ b/e2e/fixtures/pages/ExploreProfilesPage.ts
@@ -342,7 +342,7 @@ export class ExploreProfilesPage extends PyroscopePage {
 
   async clickOnPanelAction(panelTitle: string, actionLabel: string) {
     const panel = await this.getPanelByTitle(panelTitle);
-    await panel.getByLabel(actionLabel).click();
+    await panel.getByRole('button', { name: actionLabel, exact: true }).click();
 
     // we have to move the mouse to prevent the action tooltip to cover (e.g.) the profile type selector
     await this.mouse.move(0, 0);

--- a/e2e/tests/favorites-view/favorites-view.spec.ts
+++ b/e2e/tests/favorites-view/favorites-view.spec.ts
@@ -73,8 +73,10 @@ test.describe('Favorites view', () => {
 
     await exploreProfilesPage.selectHidePanelsWithoutNoData();
 
+    // Wait for the panel with data to be visible first (the grid re-renders all items and then
+    // removes no-data panels as queries complete), then verify the final count.
+    await expect(exploreProfilesPage.getPanelByTitle('pyroscope · cpu (process_cpu)')).toBeVisible({ timeout: 15000 });
     await expect(exploreProfilesPage.getPanels()).toHaveCount(1);
-    await expect(exploreProfilesPage.getPanelByTitle('pyroscope · cpu (process_cpu)')).toBeVisible();
   });
 
   test.describe('Panel actions', () => {

--- a/e2e/tests/profile-types-view/profile-types.spec.ts
+++ b/e2e/tests/profile-types-view/profile-types.spec.ts
@@ -76,6 +76,7 @@ test.describe('Profile types view', () => {
       await exploreProfilesPage.assertSelectedService('ride-sharing-app');
       await exploreProfilesPage.assertSelectedProfileType('memory/alloc_space');
 
+      await exploreProfilesPage.waitForSceneBodyRendered();
       await expect(exploreProfilesPage.getSceneBody()).toHaveScreenshot({
         stylePath: './e2e/fixtures/css/hide-all-controls.css',
       });

--- a/e2e/tests/recording-rules/recording-rules.spec.ts
+++ b/e2e/tests/recording-rules/recording-rules.spec.ts
@@ -43,6 +43,7 @@ test.describe('Recording rules', () => {
       await exploreProfilesPage.page.reload();
       await exploreProfilesPage.assertNoSpinner();
       await expect(exploreProfilesPage.getFlamegraph()).toBeVisible({ timeout: 15000 });
+      await expect(exploreProfilesPage.recordingRulesButton).toBeVisible({ timeout: 15000 });
       await exploreProfilesPage.clickOnFlameGraphNode({ x: 250, y: 10 });
       await expect(exploreProfilesPage.getFlameGraphContextualMenuItem('Create recording rule')).toBeVisible({
         timeout: 15000,
@@ -50,7 +51,7 @@ test.describe('Recording rules', () => {
     });
 
     test('create a recording rule for all services', async ({ settingsPage, exploreProfilesPage }) => {
-      await settingsPage.getMetricsFromProfilesCheckbox().click();
+      await settingsPage.getMetricsFromProfilesCheckbox().check();
       await settingsPage.getSaveSettingsButton().click();
       await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
 
@@ -64,7 +65,7 @@ test.describe('Recording rules', () => {
     });
 
     test('create a recording rule for a single service', async ({ settingsPage, exploreProfilesPage }) => {
-      await settingsPage.getMetricsFromProfilesCheckbox().click();
+      await settingsPage.getMetricsFromProfilesCheckbox().check();
       await settingsPage.getSaveSettingsButton().click();
       await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
 
@@ -79,7 +80,7 @@ test.describe('Recording rules', () => {
   });
 
   test('Create and display', async ({ settingsPage, exploreProfilesPage }) => {
-    await settingsPage.getMetricsFromProfilesCheckbox().click();
+    await settingsPage.getMetricsFromProfilesCheckbox().check();
     await settingsPage.getSaveSettingsButton().click();
     await expect(settingsPage.getSuccessAlertDialog()).toBeVisible();
 


### PR DESCRIPTION
A few tests are known to be flaky. In Grafana 13.0.0 some of these tests fail even more consistently (see https://github.com/grafana/profiles-drilldown/actions/runs/24405660297/job/71290506659)

The main issue with the recording-rules tests is that the settings they rely on are global (per tenant), so other tests can interfere with the state they expect. In this case, the settings tests are resetting the fields that the recording-rules tests are trying to set up, since they run close together:

```
Tue, 14 Apr 2026 17:00:16 GMT
playwright-e2e  |   ✓  76 [chromium] › e2e/tests/recording-rules/recording-rules.spec.ts:17:9 › Recording rules › Settings › is not available by default (2.3s)
Tue, 14 Apr 2026 17:00:16 GMT
playwright-e2e  |   ✓  77 [chromium] › e2e/tests/settings-view/settings-view.spec.ts:16:7 › Plugin Settings › Main UI elements (1.4s)
Tue, 14 Apr 2026 17:00:19 GMT
playwright-e2e  |   ✓  79 [chromium] › e2e/tests/settings-view/settings-view.spec.ts:25:9 › Plugin Settings › Flame graph settings › Can be modified (2.7s)
Tue, 14 Apr 2026 17:00:35 GMT
playwright-e2e  |   ✘  78 [chromium] › e2e/tests/recording-rules/recording-rules.spec.ts:27:9 › Recording rules › Settings › can be enabled (19.0s)
```

I've addressed this by moving recording rules tests to their own project, and have them run at the end.
The other changes address various minor timing issues.