### PR TITLE
fix(deps): patch CVEs via yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,11 @@
     "@tootallnate/once": "3.0.1",
     "diff": "4.0.4",
     "flatted": "3.4.2",
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "protobufjs@npm:^7.3.0": "7.5.5",
+    "protobufjs@npm:8.0.0": "8.0.1",
+    "protocol-buffers-schema": "3.6.1",
+    "smol-toml": "1.6.1"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12578,9 +12578,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:8.0.0":
-  version: 8.0.0
-  resolution: "protobufjs@npm:8.0.0"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -12594,31 +12594,11 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/f9f2bc0acd37ca85ad4afb030fb3973cb93129e54623d7d36255a0406f852505afae4a94a88b305bca3a6384675bb34c7602dfa64cab6b67f95597234a94681d
+  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.3.0":
-  version: 7.3.2
-  resolution: "protobufjs@npm:7.3.2"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10/816604aa0649a93fd5d3ef2858ef038f482d18eebcfb4201fe85c0d3bcccc12410f9e3e73262f1219e6b5bed4f27b28c3bf7c931c409dfb1fd563a304d541d89
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^8.0.0":
+"protobufjs@npm:8.0.1, protobufjs@npm:^8.0.0":
   version: 8.0.1
   resolution: "protobufjs@npm:8.0.1"
   dependencies:
@@ -12638,10 +12618,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protocol-buffers-schema@npm:^3.3.1":
-  version: 3.6.0
-  resolution: "protocol-buffers-schema@npm:3.6.0"
-  checksum: 10/55a1caed123fb2385eae5ea4770dc36b3017d1fe2005ffb1ef20c97dadf43a91876238ebc23bc240ef1f8501d054bdd9d12992796e9abed18ddf958e4f942eea
+"protocol-buffers-schema@npm:3.6.1":
+  version: 3.6.1
+  resolution: "protocol-buffers-schema@npm:3.6.1"
+  checksum: 10/a7ca74e71227932f903feab9df8ffde80703b656fd024179b3a9439edb3907eca4c78f0cd6f47ad7698e832ae565a8df7585d9cedcc4f043794e6ba8e480cdec
   languageName: node
   linkType: hard
 
@@ -14405,10 +14385,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smol-toml@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "smol-toml@npm:1.3.1"
-  checksum: 10/b999828ea46cf44ae90b6293884d6a139dfb4545ac6f86cbd1002568a943a43d8895ad82413855d095eec0c0bc21d23413c0a25a26c7fad6395c2ce42c2fdbd0
+"smol-toml@npm:1.6.1":
+  version: 1.6.1
+  resolution: "smol-toml@npm:1.6.1"
+  checksum: 10/9a0d86cc7f8abef429c915b373b9a1f369fe57a87efbbec46b967fb41dc28af753a2fa62c9c4848907c3b47c282be15c8854aa4e2942ef1fa86ff95a76d13856
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### ✨ Description

Fixes four dependency vulnerabilities flagged via `yarn npm audit`.

| Advisory | Severity | Package | Installed | Fixed |
|---|---|---|---|---|
| CVE-2026-41242 | Critical | `protobufjs` | 7.3.2 | 7.5.5 |
| CVE-2026-41242 | Critical | `protobufjs` | 8.0.0 | 8.0.1 |
| CVE-2026-5758 | Moderate | `protocol-buffers-schema` | 3.6.0 | 3.6.1 |
| GHSA-v3rj-xjv7-4jmq | Moderate | `smol-toml` | 1.3.1 | 1.6.1 |

### 📖 Summary of the changes

All four packages are transitive dependencies, so the fixes are applied via `resolutions` in `package.json` - matching the existing pattern for other pinned security fixes (e.g. `serialize-javascript`, `dompurify`).

- `protobufjs` lives at two majors in the tree:
  - `7.3.2` is pulled in by `@grafana/faro-core@1.19.0 → @opentelemetry/otlp-transformer@0.202.0` (range `^7.3.0`) → scoped resolution `"protobufjs@npm:^7.3.0": "7.5.5"` keeps it on v7.
  - `8.0.0` is pinned exactly by `@grafana/faro-core@2.2.4 → @opentelemetry/otlp-transformer@0.212.0` → scoped resolution `"protobufjs@npm:8.0.0": "8.0.1"` bumps just that copy.
- `protocol-buffers-schema` (via `ol → pbf → resolve-protobuf-schema`) and `smol-toml` (via `knip`, dev-only) are safe same-major bumps, so they use global resolutions.

All four bumps stay within the same major version, so breaking-change risk is minimal.

### 🧪 How to test?

1. `yarn install`
2. `yarn npm audit --all --recursive` — only deprecation notices should remain; no CVEs.
3. `yarn typecheck && yarn test:ci && yarn build` — confirm the resolution changes don't regress the build.
