### PR TITLE
chore: Fix loading translations before i18n available

### DIFF
--- a/src/exposedComponents/index.tsx
+++ b/src/exposedComponents/index.tsx
@@ -2,9 +2,21 @@ import { Trans } from '@grafana/i18n';
 import { OpenFeaturePluginScope } from '@shared/infrastructure/featureFlags/openFeature';
 import React, { lazy, Suspense } from 'react';
 
+import pluginJson from '../plugin.json';
 import { EmbeddedProfilesExplorationState } from './types';
 
-const EmbeddedProfilesExploration = lazy(() => import('./EmbeddedProfilesExploration/EmbeddedProfilesExploration'));
+/** Same sequencing as `app/Root.tsx` — embedded extensions skip the root page, so we init locales before the chunk runs `t()`. */
+const EmbeddedProfilesExploration = lazy(async () => {
+  const { initPluginTranslations } = await import('@grafana/i18n');
+
+  const { loadResources: scenesLoadResources } = await import('@grafana/scenes');
+  await initPluginTranslations('grafana-scenes', [scenesLoadResources]);
+
+  const { loadResources } = await import('../i18n/loadResources');
+  await initPluginTranslations(pluginJson.id, [loadResources]);
+
+  return import('./EmbeddedProfilesExploration/EmbeddedProfilesExploration');
+});
 
 export function SuspendedEmbeddedProfilesExploration(props: EmbeddedProfilesExplorationState) {
   return (

--- a/src/locales/en-US/grafana-pyroscope-app.json
+++ b/src/locales/en-US/grafana-pyroscope-app.json
@@ -328,6 +328,7 @@
   },
   "labels": {
     "compare": {
+      "aria-label": "Compare",
       "button_one": "Compare ({{count}}/2)",
       "button_other": "Compare ({{count}}/2)",
       "clear-tooltip": "Clear comparison selection",

--- a/src/locales/es-ES/grafana-pyroscope-app.json
+++ b/src/locales/es-ES/grafana-pyroscope-app.json
@@ -328,6 +328,7 @@
   },
   "labels": {
     "compare": {
+      "aria-label": "",
       "button_one": "Comparar ({{count}}/2)",
       "button_many": "",
       "button_other": "Comparar ({{count}}/2)",

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/ScenePresetsPicker/ScenePresetsPicker.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/ScenePresetsPicker/ScenePresetsPicker.tsx
@@ -26,24 +26,31 @@ interface ScenePresetsPickerState extends SceneObjectState {
   value: string | null;
 }
 
+// Shared English defaults (same string appears in multiple `t(...)` or fallback + `t()`).
+const PRESETS_LABEL_DEFAULT = 'Comparison presets';
+const PRESET_DESCRIPTION_1H_WINDOW_DEFAULT = '1h window';
+
 export class ScenePresetsPicker extends SceneObjectBase<ScenePresetsPickerState> {
-  private static OPTIONS: Array<ComboboxOption<string>> = [
-    {
-      label: t('diff-flame-graph.presets.1h-ago-vs-now', '1h ago vs now'),
-      value: '1h ago vs now',
-      description: t('diff-flame-graph.presets.1h-ago-vs-now-description', '30m window'),
-    },
-    {
-      label: t('diff-flame-graph.presets.6h-ago-vs-now', '6h ago vs now'),
-      value: '6h ago vs now',
-      description: t('diff-flame-graph.presets.6h-ago-vs-now', '1h window'),
-    },
-    {
-      label: t('diff-flame-graph.presets.24h-ago-vs-now', '24h ago vs now'),
-      value: '24h ago vs now',
-      description: t('diff-flame-graph.presets.24h-ago-vs-now', '1h window'),
-    },
-  ];
+  /** Must not call `t()` at module load — embedded extensions initialize i18n after lazy chunks run. */
+  private static getOptions(): Array<ComboboxOption<string>> {
+    return [
+      {
+        label: t('diff-flame-graph.presets.1h-ago-vs-now', '1h ago vs now'),
+        value: '1h ago vs now',
+        description: t('diff-flame-graph.presets.1h-ago-vs-now-description', '30m window'),
+      },
+      {
+        label: t('diff-flame-graph.presets.6h-ago-vs-now', '6h ago vs now'),
+        value: '6h ago vs now',
+        description: t('diff-flame-graph.presets.6h-ago-vs-now', PRESET_DESCRIPTION_1H_WINDOW_DEFAULT),
+      },
+      {
+        label: t('diff-flame-graph.presets.24h-ago-vs-now', '24h ago vs now'),
+        value: '24h ago vs now',
+        description: t('diff-flame-graph.presets.24h-ago-vs-now', PRESET_DESCRIPTION_1H_WINDOW_DEFAULT),
+      },
+    ];
+  }
 
   private static PRESETS: Record<string, PresetOption> = {
     '1h ago vs now': {
@@ -63,7 +70,8 @@ export class ScenePresetsPicker extends SceneObjectBase<ScenePresetsPickerState>
   constructor() {
     super({
       name: 'compare-presets',
-      label: t('diff-flame-graph.presets.label', 'Comparison presets'),
+      // English fallback until `onActivate` runs `t()` — constructors run before i18n in embedded lazy chunks (same default as PRESETS_LABEL_DEFAULT).
+      label: PRESETS_LABEL_DEFAULT,
       value: null,
     });
 
@@ -71,6 +79,8 @@ export class ScenePresetsPicker extends SceneObjectBase<ScenePresetsPickerState>
   }
 
   onActivate() {
+    this.setState({ label: t('diff-flame-graph.presets.label', PRESETS_LABEL_DEFAULT) });
+
     [CompareTarget.BASELINE, CompareTarget.COMPARISON].forEach((compareTarget) => {
       const panel = sceneGraph.findByKeyAndType(this, `${compareTarget}-panel`, SceneComparePanel);
       const timeRange = sceneGraph.getTimeRange(panel);
@@ -105,7 +115,7 @@ export class ScenePresetsPicker extends SceneObjectBase<ScenePresetsPickerState>
         <Combobox
           placeholder={t('diff-flame-graph.presets.placeholder', 'Choose a preset')}
           value={value}
-          options={ScenePresetsPicker.OPTIONS}
+          options={ScenePresetsPicker.getOptions()}
           onChange={model.onChange}
         />
       </div>

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/ui/CompareControls.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceLabels/components/SceneGroupByLabels/ui/CompareControls.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { t, Trans } from '@grafana/i18n';
+import { t } from '@grafana/i18n';
 import { Button, useStyles2 } from '@grafana/ui';
 import { noOp } from '@shared/domain/noOp';
 import React, { useMemo } from 'react';
@@ -46,16 +46,14 @@ export function CompareControls({ compare, onClickCompare, onClickClear }: Compa
   return (
     <div className={styles.container}>
       <Button
-        arial-label="Compare"
+        aria-label={t('labels.compare.aria-label', 'Compare')}
         className={styles.compareButton}
         variant="primary"
         disabled={compareIsDisabled}
         onClick={compareIsDisabled ? noOp : onClickCompare}
         tooltip={tooltip}
       >
-        <Trans i18nKey="labels.compare.button" values={{ count: compare.size }}>
-          Compare ({{ count: compare.size }}/2)
-        </Trans>
+        {t('labels.compare.button', 'Compare ({{count}}/2)', { count: compare.size })}
       </Button>
 
       <Button

--- a/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneProfilesExplorer/SceneProfilesExplorer.tsx
@@ -129,7 +129,8 @@ export class SceneProfilesExplorer extends SceneObjectBase<SceneProfilesExplorer
     ];
   }
 
-  static DEFAULT_EXPLORATION_TYPE = SceneProfilesExplorer.EXPLORATION_TYPE_OPTIONS[0].value;
+  /** Must not read `EXPLORATION_TYPE_OPTIONS` here — that getter calls `t()` and runs while the class body initializes (before i18n in embedded lazy chunks). */
+  static DEFAULT_EXPLORATION_TYPE = ExplorationType.ALL_SERVICES;
 
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['explorationType'] });
   private initialFilters?: AdHocVariableFilter[];

--- a/src/pages/ProfilesExplorerView/domain/variables/FavoriteVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/FavoriteVariable.tsx
@@ -5,11 +5,13 @@ import { lastValueFrom } from 'rxjs';
 
 import { PYROSCOPE_FAVORITES_DATA_SOURCE } from '../../infrastructure/pyroscope-data-sources';
 
+const FAVORITE_LABEL_DEFAULT = '🔖 Favorite';
+
 export class FavoriteVariable extends QueryVariable {
   constructor() {
     super({
       name: 'favorite',
-      label: t('variables.favorite.label', '🔖 Favorite'),
+      label: FAVORITE_LABEL_DEFAULT,
       datasource: PYROSCOPE_FAVORITES_DATA_SOURCE,
       // "hack": we want to subscribe to changes of dataSource
       query: '$dataSource',
@@ -17,6 +19,12 @@ export class FavoriteVariable extends QueryVariable {
       refresh: VariableRefresh.never,
       skipUrlSync: true,
     });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  private onActivate() {
+    this.setState({ label: t('variables.favorite.label', FAVORITE_LABEL_DEFAULT) });
   }
 
   async update() {

--- a/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/FiltersVariable/FiltersVariable.tsx
@@ -12,6 +12,8 @@ import { useBuildPyroscopeQuery } from '../../useBuildPyroscopeQuery';
 import { ProfilesDataSourceVariable } from '../ProfilesDataSourceVariable';
 import { convertPyroscopeToVariableFilter } from './filters-ops';
 
+const FILTERS_LABEL_DEFAULT = 'Filters';
+
 export class FiltersVariable extends AdHocFiltersVariable {
   static DEFAULT_VALUE = [];
   private initialFilters?: AdHocVariableFilter[];
@@ -20,7 +22,7 @@ export class FiltersVariable extends AdHocFiltersVariable {
     super({
       key,
       name: key,
-      label: t('variables.filters.label', 'Filters'),
+      label: FILTERS_LABEL_DEFAULT,
       filters: FiltersVariable.DEFAULT_VALUE,
       expressionBuilder: (filters) => buildFilterExpressionParts(filters),
     });
@@ -39,6 +41,7 @@ export class FiltersVariable extends AdHocFiltersVariable {
   }
 
   onActivate() {
+    this.setState({ label: t('variables.filters.label', FILTERS_LABEL_DEFAULT) });
     this.setInitialValue();
 
     // VariableDependencyConfig does not work :man_shrug: (never called)

--- a/src/pages/ProfilesExplorerView/domain/variables/GroupByVariable/GroupByVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/GroupByVariable/GroupByVariable.tsx
@@ -13,6 +13,8 @@ import { GridItemData } from 'src/pages/ProfilesExplorerView/components/SceneByV
 import { PYROSCOPE_LABELS_DATA_SOURCE } from '../../../infrastructure/pyroscope-data-sources';
 import { GroupBySelector } from './GroupBySelector';
 
+const GROUP_BY_LABEL_DEFAULT = 'Group by labels';
+
 export type OptionWithIndex = VariableValueOption & {
   index: number;
   value: string;
@@ -29,7 +31,7 @@ export class GroupByVariable extends QueryVariable {
     super({
       key: 'groupBy',
       name: 'groupBy',
-      label: t('variables.group-by.label', 'Group by labels'),
+      label: GROUP_BY_LABEL_DEFAULT,
       datasource: PYROSCOPE_LABELS_DATA_SOURCE,
       // "hack": we want to subscribe to changes of dataSource, serviceName and profileMetricId
       // we could also add filters, but the Service labels exploration type would reload all labels each time they are modified
@@ -44,9 +46,10 @@ export class GroupByVariable extends QueryVariable {
   }
 
   onActivate() {
-    if (!this.state.value) {
-      this.setState({ value: GroupByVariable.DEFAULT_VALUE });
-    }
+    this.setState({
+      label: t('variables.group-by.label', GROUP_BY_LABEL_DEFAULT),
+      ...(!this.state.value ? { value: GroupByVariable.DEFAULT_VALUE } : {}),
+    });
   }
 
   update = async () => {

--- a/src/pages/ProfilesExplorerView/domain/variables/ProfileIdSelectorVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ProfileIdSelectorVariable.tsx
@@ -1,14 +1,22 @@
 import { t } from '@grafana/i18n';
 import { CustomVariable } from '@grafana/scenes';
 
+const PROFILE_ID_SELECTOR_LABEL_DEFAULT = 'Profile Id Selector';
+
 export class ProfileIdSelectorVariable extends CustomVariable {
   constructor() {
     super({
       key: 'profileIdSelector',
       name: 'profileIdSelector',
-      label: t('variables.profile-id-selector.label', 'Profile Id Selector'),
+      label: PROFILE_ID_SELECTOR_LABEL_DEFAULT,
       value: undefined,
     });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  private onActivate() {
+    this.setState({ label: t('variables.profile-id-selector.label', PROFILE_ID_SELECTOR_LABEL_DEFAULT) });
   }
 
   reset() {

--- a/src/pages/ProfilesExplorerView/domain/variables/ProfileMetricVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ProfileMetricVariable.tsx
@@ -13,6 +13,8 @@ import { lastValueFrom } from 'rxjs';
 
 import { PYROSCOPE_SERIES_DATA_SOURCE } from '../../infrastructure/pyroscope-data-sources';
 
+const PROFILE_METRIC_LABEL_DEFAULT = 'Profile type';
+
 type ProfileMetricOptions = Array<{
   value: string;
   label: string;
@@ -38,7 +40,7 @@ export class ProfileMetricVariable extends QueryVariable {
     super({
       key: 'profileMetricId',
       name: 'profileMetricId',
-      label: t('variables.profile-metric.label', 'Profile type'),
+      label: PROFILE_METRIC_LABEL_DEFAULT,
       datasource: PYROSCOPE_SERIES_DATA_SOURCE,
       query: ProfileMetricVariable.QUERY_DEFAULT,
       loading: true,
@@ -52,9 +54,10 @@ export class ProfileMetricVariable extends QueryVariable {
   }
 
   onActivate() {
-    if (!this.state.value) {
-      this.setState({ value: ProfileMetricVariable.DEFAULT_VALUE });
-    }
+    this.setState({
+      label: t('variables.profile-metric.label', PROFILE_METRIC_LABEL_DEFAULT),
+      ...(!this.state.value ? { value: ProfileMetricVariable.DEFAULT_VALUE } : {}),
+    });
   }
 
   async update(force = false) {

--- a/src/pages/ProfilesExplorerView/domain/variables/ProfilesDataSourceVariable.ts
+++ b/src/pages/ProfilesExplorerView/domain/variables/ProfilesDataSourceVariable.ts
@@ -3,13 +3,16 @@ import { DataSourceVariable } from '@grafana/scenes';
 import { ApiClient } from '@shared/infrastructure/http/ApiClient';
 import { userStorage } from '@shared/infrastructure/userStorage';
 
+const DATA_SOURCE_LABEL_DEFAULT = 'Data source';
+
 export class ProfilesDataSourceVariable extends DataSourceVariable {
   constructor({ initialDS }: { initialDS?: string }) {
     super({
       pluginId: 'grafana-pyroscope-datasource',
       key: 'dataSource',
       name: 'dataSource',
-      label: t('variables.data-source.label', 'Data source'),
+      // English fallback until `onActivate` — embedded exploration constructs variables before i18n is ready.
+      label: DATA_SOURCE_LABEL_DEFAULT,
       skipUrlSync: true,
       // we ensure that we'll always have the expected default data source (when the "var-dataSource" URL search param is missing, incorrect, etc.)
       value: initialDS ?? ApiClient.selectDefaultDataSource().uid,
@@ -19,7 +22,10 @@ export class ProfilesDataSourceVariable extends DataSourceVariable {
   }
 
   onActivate() {
-    this.setState({ skipUrlSync: false });
+    this.setState({
+      skipUrlSync: false,
+      label: t('variables.data-source.label', DATA_SOURCE_LABEL_DEFAULT),
+    });
 
     this.subscribeToState((newState, prevState) => {
       if (newState.value && newState.value !== prevState.value) {

--- a/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/ServiceNameVariable/ServiceNameVariable.tsx
@@ -19,6 +19,8 @@ import { lastValueFrom } from 'rxjs';
 import { PYROSCOPE_SERIES_DATA_SOURCE } from '../../../infrastructure/pyroscope-data-sources';
 import { buildServiceNameCascaderOptions } from './domain/useBuildServiceNameOptions';
 
+const SERVICE_NAME_LABEL_DEFAULT = 'Service';
+
 type QueryVariableInitialState = ConstructorParameters<typeof QueryVariable>[0];
 
 type ServiceNameVariableState = {
@@ -41,7 +43,7 @@ export class ServiceNameVariable extends QueryVariable {
     super({
       key: 'serviceName',
       name: 'serviceName',
-      label: t('variables.service-name.label', 'Service'),
+      label: SERVICE_NAME_LABEL_DEFAULT,
       datasource: PYROSCOPE_SERIES_DATA_SOURCE,
       query: ServiceNameVariable.QUERY_DEFAULT,
       // Must be false so SceneByVariableRepeaterGrid.onActivate can call update().
@@ -59,6 +61,7 @@ export class ServiceNameVariable extends QueryVariable {
   }
 
   onActivate() {
+    this.setState({ label: t('variables.service-name.label', SERVICE_NAME_LABEL_DEFAULT) });
     this.setInitialValue();
 
     this.subscribeToState((newState, prevState) => {

--- a/src/pages/ProfilesExplorerView/domain/variables/SpanSelectorVariable.tsx
+++ b/src/pages/ProfilesExplorerView/domain/variables/SpanSelectorVariable.tsx
@@ -1,14 +1,22 @@
 import { t } from '@grafana/i18n';
 import { CustomVariable } from '@grafana/scenes';
 
+const SPAN_SELECTOR_LABEL_DEFAULT = 'Span selector';
+
 export class SpanSelectorVariable extends CustomVariable {
   constructor() {
     super({
       key: 'spanSelector',
       name: 'spanSelector',
-      label: t('variables.span-selector.label', 'Span selector'),
+      label: SPAN_SELECTOR_LABEL_DEFAULT,
       value: undefined,
     });
+
+    this.addActivationHandler(this.onActivate.bind(this));
+  }
+
+  private onActivate() {
+    this.setState({ label: t('variables.span-selector.label', SPAN_SELECTOR_LABEL_DEFAULT) });
   }
 
   reset() {

--- a/src/shared/components/SavedSearches/SaveSearchModal.tsx
+++ b/src/shared/components/SavedSearches/SaveSearchModal.tsx
@@ -78,9 +78,11 @@ export function SaveSearchModal({ dsUid, onClose, sceneRef }: Props) {
             <Box flex={1} marginBottom={2}>
               {existingSearch && (
                 <Alert title="" severity="warning">
-                  <Trans i18nKey="saved-searches.save.existing-search-warning">
-                    There is a previously saved search with the same query: {{ title: existingSearch.title }}
-                  </Trans>
+                  {t(
+                    'saved-searches.save.existing-search-warning',
+                    'There is a previously saved search with the same query: {{title}}',
+                    { title: existingSearch.title }
+                  )}
                 </Alert>
               )}
               <Field label={t('saved-searches.save.title-label', 'Title')} noMargin htmlFor="save-search-title">


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/asserts-app-plugin/issues/3241
Related issue(s): <!-- Link to the issue this PR is related to but does not resolve it -->

Fixes loading of translations before i18n available that was causing a React error in embedded mode.

### 🧪 How to test?

Test embedded mode of Profiles Drilldown in the Knowledge Graph to see it loads - or see urls in linked issue.
