### PR TITLE
chore: Update which feature flags are on by default

### DIFF
--- a/src/shared/infrastructure/featureFlags/featureFlags.tsx
+++ b/src/shared/infrastructure/featureFlags/featureFlags.tsx
@@ -26,7 +26,7 @@ export function useFlagMetricsFromProfiles(): boolean {
 }
 
 export function useFlagGrafanaAssistantInProfilesDrilldown(): boolean {
-  return useBooleanFlagDetails(grafanaAssistantInProfilesDrilldownKey, false).value;
+  return useBooleanFlagDetails(grafanaAssistantInProfilesDrilldownKey, true).value;
 }
 
 export function getProfilesExemplarsFromOpenFeature(): boolean {
@@ -34,7 +34,7 @@ export function getProfilesExemplarsFromOpenFeature(): boolean {
 }
 
 export function getPyroscopeUTF8LabelNamesFromOpenFeature(): boolean {
-  return getPluginOpenFeatureBoolean(pyroscopeUTF8LabelNamesKey, false);
+  return getPluginOpenFeatureBoolean(pyroscopeUTF8LabelNamesKey, true);
 }
 
 export function getQueryLibraryFromOpenFeature(): boolean {


### PR DESCRIPTION
### ✨ Description

chore: Update which feature flags are on by default

### 🧪 How to test?

You can go to ops if you like and check that only the `Analyze with Assistant` button appears above the flame graph and not the `Explain Flame Graph` button.
