### PR TITLE
fix(Recording Rules): Stop dropping profile type, service name, and function name on submit

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.test.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.test.tsx
@@ -1,0 +1,92 @@
+import { sceneGraph } from '@grafana/scenes';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { SceneCreateRecordingRuleModal } from './SceneCreateRecordingRuleModal';
+
+jest.mock('react-inlinesvg', () => {
+  const React = require('react');
+  return { __esModule: true, default: () => React.createElement('svg', {}) };
+});
+
+const mockSave = jest.fn();
+jest.mock('./domain/useCreateRecordingRule', () => ({
+  useCreateRecordingRule: () => ({ actions: { save: mockSave } }),
+}));
+
+jest.mock('@shared/infrastructure/labels/labelsRepository', () => ({
+  labelsRepository: { listLabels: () => Promise.resolve([{ value: 'service_repository' }]) },
+}));
+
+jest.mock('@grafana/i18n', () => ({
+  ...jest.requireActual('@grafana/i18n'),
+  t: (_key: string, def: string) => def,
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('../../domain/variables/FiltersVariable/FiltersVariable', () => ({ FiltersVariable: class {} }));
+jest.mock('../../domain/variables/ProfileMetricVariable', () => ({ ProfileMetricVariable: class {} }));
+jest.mock('../../domain/variables/ServiceNameVariable/ServiceNameVariable', () => ({ ServiceNameVariable: class {} }));
+jest.mock('../SceneProfilesExplorer/SceneProfilesExplorer', () => ({
+  ExplorationType: { ALL_SERVICES: 'all', FAVORITES: 'favorites' },
+  SceneProfilesExplorer: class {},
+}));
+
+function findByKeyAndTypeMock(_obj: unknown, key: string) {
+  if (key === 'profileMetricId') {
+    return { state: { value: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds' } };
+  }
+  if (key === 'serviceName') {
+    return { state: { value: 'pyroscope' }, toString: () => 'pyroscope' };
+  }
+  if (key === 'filters') {
+    return {
+      state: {
+        filters: [{ key: 'service_repository', operator: '=', value: 'https://github.com/grafana/pyroscope' }],
+      },
+    };
+  }
+  if (key === 'profiles-explorer') {
+    return { useState: () => ({ explorationType: 'flame-graph' }) };
+  }
+  return {};
+}
+
+describe('SceneCreateRecordingRuleModal', () => {
+  beforeEach(() => {
+    mockSave.mockReset();
+    jest.spyOn(sceneGraph, 'findByKeyAndType').mockImplementation(findByKeyAndTypeMock as any);
+    jest.spyOn(sceneGraph, 'getTimeRange').mockReturnValue({
+      state: { value: { from: { unix: () => 0 }, to: { unix: () => 1 } } },
+    } as any);
+  });
+
+  test('submits all wizard values to the API (regression: shouldUnregister dropped hidden inputs)', async () => {
+    const model = new SceneCreateRecordingRuleModal();
+
+    render(
+      <SceneCreateRecordingRuleModal.Component
+        model={model}
+        isModalOpen={true}
+        onDismiss={() => {}}
+        onCreated={() => {}}
+        functionName="runtime.netpoll"
+      />
+    );
+
+    fireEvent.input(screen.getByLabelText('Metric name'), { target: { value: 'test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(mockSave).toHaveBeenCalledTimes(1));
+
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricName: 'profiles_recorded_test',
+        serviceName: 'pyroscope',
+        profileType: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+        functionName: 'runtime.netpoll',
+        matchers: ['{service_repository="https://github.com/grafana/pyroscope"}'],
+      })
+    );
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/SceneCreateRecordingRuleModal.tsx
@@ -90,7 +90,6 @@ export class SceneCreateRecordingRuleModal extends SceneObjectBase<SceneCreateRe
       formState: { errors },
     } = useForm<RecordingRuleForm>({
       mode: 'onChange',
-      shouldUnregister: true,
       values: {
         functionName,
         metricName: '',


### PR DESCRIPTION
## Evidence / reproduce bug
1. Create a recording rule, from a service flame graph, with a filter on it:
<img width="752" height="606" alt="image" src="https://github.com/user-attachments/assets/b0a96b6c-29a7-4ce5-b480-1a09dfb267d8" />
2. Message sent to backend has no service_name, no function_name, and wrong __profile_type__:
<img width="446" height="141" alt="Screenshot 2026-05-21 at 11 35 19" src="https://github.com/user-attachments/assets/453fc9d7-def5-4b85-a201-d212ab7ed8d9" />
3. The listed new rule shows this bug as well:
<img width="1206" height="167" alt="Screenshot 2026-05-21 at 11 35 34" src="https://github.com/user-attachments/assets/c16a635b-38fc-491f-98c6-330d914c8fb2" />


## Summary

- The create-recording-rule wizard was silently dropping `profileType`, `serviceName`, and (when prefilled from the flame-graph context menu) `functionName`, sending `{ __profile_type__="undefined" }` to the backend and omitting the `service_name=` matcher and `stacktraceFilter` entirely.
- Root cause is a react-hook-form behavior change introduced in **7.60.0**: with `shouldUnregister: true`, field values supplied only through `values:` (never typed by the user) are no longer included in submitted data. The pnpm migration (#949) bumped react-hook-form from `7.54.2` to `7.72.1`, crossing that boundary.
- Bisect: 7.55.0–7.59.0 ✅, 7.60.0–7.75.0 ❌.

## Fix

One-line change: drop `shouldUnregister: true` from the modal's `useForm` config. The form has no use case for it (no dynamically appearing fields, no need to wipe state between opens — the modal unmounts entirely).

## Test plan

- [x] Added unit test that mounts the modal with a prefilled `functionName`, submits, and asserts the payload to `actions.save()` contains all five fields. Verified it fails when `shouldUnregister: true` is restored.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec eslint` clean (one pre-existing `MultiSelect` deprecation warning, unrelated).
- [ ] Manual smoke: open Create recording rule wizard, fill it in, confirm the request body contains the correct `__profile_type__`, `service_name=` matcher, and `stacktraceFilter`.
