### PR TITLE
chore: upgrade pnpm from v10 to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,27 +148,5 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-  "pnpm": {
-    "overrides": {
-      "esbuild": "~0.28.0",
-      "i18next": "~26.0.5",
-      "lodash": "~4.18.1",
-      "minimatch@^5": "~5.1.9",
-      "minimatch@^9": "~9.0.9",
-      "ajv@^8": "~8.18.0",
-      "dompurify": "~3.4.0",
-      "immutable": "~5.1.5",
-      "qs": "~6.14.2",
-      "@tootallnate/once": "~3.0.1",
-      "diff": "~4.0.4",
-      "flatted": "~3.4.2",
-      "protobufjs@^7.3.0": "~8.2.0",
-      "protobufjs@8.0.0": "~8.0.1",
-      "protocol-buffers-schema": "~3.6.1",
-      "serialize-javascript": "~7.0.5",
-      "smol-toml": "~1.6.1",
-      "uuid": ">=14.0.0"
-    }
-  }
+  "packageManager": "pnpm@11.4.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,30 @@
 packages:
   - '.'
 
-onlyBuiltDependencies:
-  - '@bufbuild/buf'
-  - '@parcel/watcher'
-  - '@swc/core'
-  - esbuild
-  - protobufjs
-  - unrs-resolver
+overrides:
+  esbuild: '~0.28.0'
+  i18next: '~26.0.5'
+  lodash: '~4.18.1'
+  minimatch@^5: '~5.1.9'
+  minimatch@^9: '~9.0.9'
+  ajv@^8: '~8.18.0'
+  dompurify: '~3.4.0'
+  immutable: '~5.1.5'
+  qs: '~6.14.2'
+  '@tootallnate/once': '~3.0.1'
+  diff: '~4.0.4'
+  flatted: '~3.4.2'
+  protobufjs@^7.3.0: '~8.2.0'
+  protobufjs@8.0.0: '~8.0.1'
+  protocol-buffers-schema: '~3.6.1'
+  serialize-javascript: '~7.0.5'
+  smol-toml: '~1.6.1'
+  uuid: '>=14.0.0'
+
+allowBuilds:
+  '@bufbuild/buf': true
+  '@parcel/watcher': true
+  '@swc/core': true
+  esbuild: true
+  protobufjs: true
+  unrs-resolver: true


### PR DESCRIPTION
pnpm 11 is a major version with a redesigned configuration system.
The `pnpm` key in `package.json` is silently ignored in v11, so
overrides must be migrated to `pnpm-workspace.yaml`.

Changes:
- **package.json**: Removed `pnpm.overrides` block, bumped `packageManager` to `pnpm@11.4.0`
- **pnpm-workspace.yaml**: Added `overrides` (moved from `package.json`), replaced `onlyBuiltDependencies` with `allowBuilds` map

Notable new pnpm 11 defaults to be aware of:
- `minimumReleaseAge: 1440` — newly-published packages are quarantined for 24h before resolution
- `strictDepBuilds: true` — build scripts blocked unless explicitly allowed via `allowBuilds`
- `verifyDepsBeforeRun: install` — auto-runs install if deps are stale before script execution

### How to test

- `pnpm install`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`
- Verify security overrides are applied: `pnpm why dompurify`, `pnpm why protobufjs`, `pnpm why serialize-javascript` — all resolve to at least the override floor versions

See also: [metrics-drilldown#1272](https://github.com/grafana/metrics-drilldown/pull/1272), [logs-drilldown#1909](https://github.com/grafana/logs-drilldown/pull/1909)