### PR TITLE
feat: add kernel/user space color scheme, show executable in function details

### DIFF
--- a/src/pages/AdHocView/ui/AdHocFlameGraph.tsx
+++ b/src/pages/AdHocView/ui/AdHocFlameGraph.tsx
@@ -3,6 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { FlameGraph } from '@shared/components/FlameGraph/FlameGraph';
 import { FlamebearerProfile } from '@shared/types/FlamebearerProfile';
+import { DataSourceType } from '@shared/types/DataSourceType';
 import React from 'react';
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -16,7 +17,7 @@ export function AdHocFlameGraph({ profile, diff }: { profile: FlamebearerProfile
 
   return (
     <div className={styles.flamegraph} data-testid="flamegraph">
-      <FlameGraph profile={profile} diff={diff} />
+      <FlameGraph profile={profile} diff={diff} dataSource={DataSourceType.PprofPyroscope}/>
     </div>
   );
 }

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
@@ -27,6 +27,7 @@ import { EventDiffAutoSelect } from '../../domain/events/EventDiffAutoSelect';
 import { SceneExploreDiffFlameGraph } from '../../SceneExploreDiffFlameGraph';
 import { useFetchDiffProfile } from './infrastructure/useFetchDiffProfile';
 import { MissingSelectionsBanner } from './ui/MissingSelectionsBanner';
+import { DataSourceType } from "@shared/types/DataSourceType";
 
 interface SceneDiffFlameGraphState extends SceneObjectState {
   aiPanel: SceneAiPanel;
@@ -235,6 +236,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
               collapsedFlamegraphs={data.settings?.collapsedFlamegraphs}
               /** Grafana assistant does not support diff flame graphs yet, we will use LLM plugin if enabled */
               showAnalyzeWithAssistant={false}
+              dataSource={DataSourceType.PprofPyroscope}
             />
           )}
         </Panel>

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -38,6 +38,7 @@ import { RemoveSpanSelector } from './domain/events/RemoveSpanSelector';
 import { ProfileIdSelectorLabel } from './ProfileIdSelectorLabel';
 import { SceneExploreServiceFlameGraph } from './SceneExploreServiceFlameGraph';
 import { SpanSelectorLabel } from './SpanSelectorLabel';
+import { DataSourceType } from "@shared/types/DataSourceType";
 
 interface SceneFlameGraphState extends SceneObjectState {
   $data: SceneQueryRunner;
@@ -294,6 +295,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
               }
               keepFocusOnDataChange
               enableNewUI={flameGraphWithCallTree}
+              dataSource={DataSourceType.PprofPyroscope}
             />
           )}
         </Panel>

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
@@ -223,6 +223,19 @@ export class SceneFunctionDetailsPanel extends SceneObjectBase<SceneFunctionDeta
               </InlineSpinner>
             </div>
 
+            {data.functionDetails.executableName && (
+              <div className={styles.row} data-testid="row-executable">
+                <InlineLabel
+                    tooltip={t('function-details.executable-tooltip', 'The executable or shared library where this function is defined')}
+                    width={SceneFunctionDetailsPanel.LABEL_WIDTH}>
+                  <Trans i18nKey="function-details.executable">Executable</Trans>
+                </InlineLabel>
+                <Tooltip content={data.functionDetails.executableName} placement="top">
+                  <span className={styles.textValue}>&lrm;{formatFileName(data.functionDetails.executableName)}</span>
+                </Tooltip>
+              </div>
+            )}
+
             {data.shouldDisplayGitHubBanner && (
               <div className={styles.row} data-testid="row-github-banner">
                 <GitHubIntegrationBanner onDismiss={actions.dismissGitHubBanner} />

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/__tests__/convertPprofToFunctionDetails.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/__tests__/convertPprofToFunctionDetails.spec.ts
@@ -33,10 +33,12 @@ function buildJsonPprof(fnName: string, location: Location[]): PprofProfile {
       {
         id: '1',
         buildId: '1',
+        filename: '9',
       },
       {
         id: '2',
         buildId: '2',
+        filename: '10',
       },
     ],
     sample: [
@@ -103,7 +105,7 @@ function buildJsonPprof(fnName: string, location: Location[]): PprofProfile {
       '/little/func.go',
     ],
     defaultSampleType: '',
-  });
+  }) as PprofProfile;
 }
 
 describe('convertPprofToFunctionDetails(fnName, profile)', () => {
@@ -140,6 +142,7 @@ describe('convertPprofToFunctionDetails(fnName, profile)', () => {
             repository: 'github.com/grafana/pyroscope',
           },
           startLine: 6,
+          executableName: '/opt/homebrew/Cellar/go/1.21.1/libexec/src/net/http/server.go',
           fileName: '/opt/homebrew/Cellar/go/1.21.1/libexec/src/net/http/server.go',
           callSites: expect.any(Map),
           unit: 'nanoseconds',
@@ -173,6 +176,7 @@ describe('convertPprofToFunctionDetails(fnName, profile)', () => {
             repository: 'github.com/grafana/pyroscope',
           },
           startLine: 6,
+          executableName: '/opt/homebrew/Cellar/go/1.21.1/libexec/src/net/http/server.go',
           fileName: '/opt/homebrew/Cellar/go/1.21.1/libexec/src/net/http/server.go',
           callSites: expect.any(Map),
           unit: 'nanoseconds',
@@ -443,6 +447,7 @@ describe('convertPprofToFunctionDetails(fnName, profile)', () => {
               git_ref: '369ca83',
             },
             startLine: 107,
+            executableName: '/usr/bin/pyroscope',
             fileName: '/home/runner/work/pyroscope/pyroscope/pkg/phlaredb/symdb/dedup_slice.go',
             callSites: new Map<number, CallSiteProps>([
               [138, { cum: 27030000000, flat: 1490000000, line: 138 }],

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/convertPprofToFunctionDetails.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/convertPprofToFunctionDetails.ts
@@ -15,6 +15,7 @@ const buildDetails = (profile: PprofProfile, func: Function, mapping?: Mapping) 
     version,
     startLine: !Number.isNaN(Number(func.startLine)) ? Number(func.startLine) : undefined,
     fileName: profile.stringTable[Number(func.filename)],
+    executableName: mapping ? profile.stringTable[Number(mapping.filename)] : undefined,
     callSites: new Map<number, CallSiteProps>(),
     unit: profile.stringTable[Number(profile.sampleType[0].unit)],
     commit: PLACEHOLDER_COMMIT_DATA,

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/formatFileName.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/formatFileName.ts
@@ -1,4 +1,9 @@
 // when using direction=rtl, the first / is ending up at the end of the string
 // so we add a / at the end of the string to make it look better
-export const formatFileName = (fileName: string): string =>
-  fileName?.[0] === '/' ? fileName.substring(1) + '/' : fileName;
+export const formatFileName = (fileName: string): string => {
+  if (!fileName) return fileName;
+  const withoutKernel = fileName.startsWith('[kernel] ')
+    ? fileName.slice('[kernel] '.length)
+    : fileName;
+  return withoutKernel[0] === '/' ? withoutKernel.substring(1) + '/' : withoutKernel;
+};

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/types/FunctionDetails.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/types/FunctionDetails.ts
@@ -20,6 +20,7 @@ export type FunctionDetails = {
   version?: FunctionVersion;
   startLine?: number;
   fileName: string;
+  executableName?: string;
   callSites: Map<number, CallSiteProps>;
   unit: string;
   commit: Commit;

--- a/src/shared/components/FlameGraph/FlameGraph.tsx
+++ b/src/shared/components/FlameGraph/FlameGraph.tsx
@@ -5,6 +5,7 @@ import { useFlagFlameGraphWithCallTree } from '@shared/infrastructure/featureFla
 import React, { memo, useMemo } from 'react';
 
 import type { FlamebearerProfile } from '../../types/FlamebearerProfile';
+import { DataSourceType } from '../../types/DataSourceType';
 import { ExportData } from './components/ExportData';
 import { flamebearerToDataFrameDTO } from './domain/flamebearerToDataFrameDTO';
 
@@ -16,6 +17,7 @@ type FlameGraphProps = {
   collapsedFlamegraphs?: boolean;
   getExtraContextMenuButtons?: Props['getExtraContextMenuButtons'];
   showAnalyzeWithAssistant?: boolean;
+  dataSource?: DataSourceType;
 };
 
 function FlameGraphComponent({
@@ -53,6 +55,7 @@ function FlameGraphComponent({
       keepFocusOnDataChange
       showAnalyzeWithAssistant={showAnalyzeWithAssistant}
       enableNewUI={flameGraphWithCallTree}
+      dataSource={dataSource}
     />
   );
 }

--- a/src/shared/types/DataSourceType.ts
+++ b/src/shared/types/DataSourceType.ts
@@ -1,0 +1,4 @@
+export enum DataSourceType {
+  PprofPyroscope = 'pprof-pyroscope',
+  Unknown = 'unknown',
+}

--- a/src/shared/types/PprofProfile.ts
+++ b/src/shared/types/PprofProfile.ts
@@ -30,6 +30,7 @@ export type Line = {
 export type Mapping = {
   id: string;
   buildId: string;
+  filename?: string;
 };
 
 export type PprofProfile = {


### PR DESCRIPTION
### ✨ Description

Adds kernel/user space color scheme to the flame graph and shows the executable name in the Function Details panel when available.

<img width="1900" height="906" alt="executable_name" src="https://github.com/user-attachments/assets/13ba24c7-3af8-4ac0-846f-144421fbd5d4" />

Related PR: [grafana/pyroscope#5201](https://github.com/grafana/pyroscope/pull/5201), [grafana/grafana#125627](https://github.com/grafana/grafana/pull/125627)

### 📖 Summary of the changes

This PR adds two improvements to the flame graph experience in Profiles Drilldown:

**1. Kernel/user space color scheme**

Passes `DataSourceType.PprofPyroscope` to `FlameGraphContainer` in all flame graph entry points (`AdHocFlameGraph`, `SceneFlameGraph`, `SceneDiffFlameGraph`). This enables the new "By kernel/user space" color scheme option, which colors frames orange (kernel), yellow (user space), or pink (unknown) based on the `[kernel]` prefix in the mapping filename received from the Pyroscope.

**2. Executable name in Function Details panel**

Shows the executable or shared library path (e.g. `/usr/bin/pyroscope`) in the Function Details panel when available in the pprof profile's mapping data.

- Add `executableName` field to `FunctionDetails` type
- Populate it in `convertPprofToFunctionDetails()` from `mapping.filename` via `profile.stringTable`
- Display it as a new "Executable" row in `SceneFunctionDetailsPanel`
- Update `formatFileName()` to strip the `[kernel]` prefix before formatting for display

### 🧪 How to test?

1. Open Profiles Drilldown with a Pyroscope data source
2. Open a flame graph and click the color scheme button - verify the "By kernel/user space" option is available
3. Select "By kernel/user space" - verify frames are colored correctly (orange for kernel frames, yellow for user space, pink for unknown)
4. Click on a function and open the Function Details panel - verify the "Executable" row appears and shows the correct binary/library path
5. For a kernel frame, verify the `[kernel]` prefix is stripped in the displayed filename