### PR TITLE
chore(deps): bump @openfeature/ofrep-web-provider from 0.3.6 to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@grafana/scenes": "^6.23.0",
     "@grafana/schema": "12.4.2",
     "@grafana/ui": "12.4.2",
-    "@openfeature/ofrep-web-provider": "^0.3.6",
+    "@openfeature/ofrep-web-provider": "^0.4.1",
     "@openfeature/react-sdk": "^1.2.0",
     "@react-aria/utils": "^3.25.3",
     "@tanstack/react-query": "5.100.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: 12.4.2
         version: 12.4.2(@react-spectrum/provider@3.11.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.28)(eslint@9.39.4(jiti@2.7.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.6.2)
       '@openfeature/ofrep-web-provider':
-        specifier: ^0.3.6
-        version: 0.3.6(@openfeature/core@1.10.0)(@openfeature/web-sdk@1.8.0(@openfeature/core@1.10.0))
+        specifier: ^0.4.1
+        version: 0.4.1(@openfeature/core@1.10.0)(@openfeature/web-sdk@1.8.0(@openfeature/core@1.10.0))
       '@openfeature/react-sdk':
         specifier: ^1.2.0
         version: 1.3.0(@openfeature/web-sdk@1.8.0(@openfeature/core@1.10.0))(react@18.2.0)
@@ -1437,8 +1437,18 @@ packages:
     peerDependencies:
       '@openfeature/core': ^1.6.0
 
+  '@openfeature/ofrep-core@2.2.0':
+    resolution: {integrity: sha512-YbeT8mYS4Ggo/JFcYY1IzN0O0UvsCx7RPk1m40TFc4ip0gJdFVpYc5a8WDwZC2v/YqxreJ7NWBDxHxP5SOevsA==}
+    peerDependencies:
+      '@openfeature/core': ^1.6.0
+
   '@openfeature/ofrep-web-provider@0.3.6':
     resolution: {integrity: sha512-fV4BHab6gg0IMPeJJZ3lxtyfStSpea7N81sHJeBjgf7wYrU/SIYmdWV9Vy5HwlONjcsV58EKtOndV3WdkCqnAQ==}
+    peerDependencies:
+      '@openfeature/web-sdk': ^1.4.0
+
+  '@openfeature/ofrep-web-provider@0.4.1':
+    resolution: {integrity: sha512-DoWFtDT+9r+KyqvOYLPTgPgZLKIlUejaUkM++y/VSmVwWZiuKuJP3c8bqBMV+Mi8GSQ9ihJETLzk/BLNXWChpg==}
     peerDependencies:
       '@openfeature/web-sdk': ^1.4.0
 
@@ -8424,9 +8434,20 @@ snapshots:
     dependencies:
       '@openfeature/core': 1.10.0
 
+  '@openfeature/ofrep-core@2.2.0(@openfeature/core@1.10.0)':
+    dependencies:
+      '@openfeature/core': 1.10.0
+
   '@openfeature/ofrep-web-provider@0.3.6(@openfeature/core@1.10.0)(@openfeature/web-sdk@1.8.0(@openfeature/core@1.10.0))':
     dependencies:
       '@openfeature/ofrep-core': 2.1.0(@openfeature/core@1.10.0)
+      '@openfeature/web-sdk': 1.8.0(@openfeature/core@1.10.0)
+    transitivePeerDependencies:
+      - '@openfeature/core'
+
+  '@openfeature/ofrep-web-provider@0.4.1(@openfeature/core@1.10.0)(@openfeature/web-sdk@1.8.0(@openfeature/core@1.10.0))':
+    dependencies:
+      '@openfeature/ofrep-core': 2.2.0(@openfeature/core@1.10.0)
       '@openfeature/web-sdk': 1.8.0(@openfeature/core@1.10.0)
     transitivePeerDependencies:
       - '@openfeature/core'

--- a/src/shared/infrastructure/featureFlags/openFeature.tsx
+++ b/src/shared/infrastructure/featureFlags/openFeature.tsx
@@ -86,7 +86,8 @@ export function ensureOpenFeaturePluginInitialized(): Promise<void> {
         PLUGIN_OPEN_FEATURE_DOMAIN,
         new OFREPWebProvider({
           baseUrl,
-          pollInterval: -1,
+          disableVisibilityRefresh: true, // Do not refresh
+          cacheMode: 'disabled', // Do not write to localStorage
           timeoutMs: 10_000,
         }),
         evaluationContext


### PR DESCRIPTION
### ✨ Description

Updates the OFREP Web Provider for OpenFeature across a breaking change, disabling the new refresh on window focus functionality, disabling the localStorage caching functionality, and removing the polling disable (as it is now disabled by default).

cc https://github.com/grafana/grafana-backend-services-squad/pull/16 https://github.com/open-feature/js-sdk-contrib/pull/1535

### 📖 Summary of the changes

See above.

### 🧪 How to test?

Feature flags continue to load.
