### PR TITLE
chore: remove grafana version from plugin info

### DIFF
--- a/src/locales/en-US/grafana-pyroscope-app.json
+++ b/src/locales/en-US/grafana-pyroscope-app.json
@@ -449,7 +449,7 @@
     "commit-sha": "Commit SHA: {{shortCommitSha}}",
     "contribute": "Contribute",
     "documentation": "Documentation",
-    "grafana-version": "Grafana {{edition}} v{{version}} ({{env}})",
+    "grafana-version": "Grafana {{edition}} ({{env}})",
     "last-update": "Last update: {{updated}}",
     "report-issue": "Report an issue",
     "title": "Plugin info",

--- a/src/shared/ui/PluginInfo.tsx
+++ b/src/shared/ui/PluginInfo.tsx
@@ -69,9 +69,8 @@ function InfoMenu() {
       />
       <Menu.Divider />
       <Menu.Item
-        label={t('plugin-info.grafana-version', 'Grafana {{edition}} v{{version}} ({{env}})', {
+        label={t('plugin-info.grafana-version', 'Grafana {{edition}} ({{env}})', {
           edition: grafanaBuildInfo.edition,
-          version: grafanaBuildInfo.version,
           env: grafanaBuildInfo.env,
         })}
         icon="github"


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** <!-- Paste a GitHub issue URL or another pull request URL -->
Resolves <!-- Paste Github issue that is resolved by this pull request -->

Remove grafana version. See here for context https://raintank-corp.slack.com/archives/C075BDBTX96/p1780488924349469

### Test

1. open plugin info and see that the specific grafana version is not listed