### PR TITLE
fix: update Crowdin workflows for get-vault-secrets breaking change

### DIFF
--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Create tasks in Crowdin
         uses: grafana/grafana-github-actions/crowdin-create-tasks@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 42

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Download from Crowdin
         uses: grafana/grafana-github-actions/crowdin-download@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 42
           pr_labels: 'i18n'
           github_board_id: 42

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Upload to Crowdin
         uses: grafana/grafana-github-actions/crowdin-upload@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 42


### PR DESCRIPTION
Closes https://github.com/grafana/profiles-drilldown/issues/1009

## Summary
- `grafana/shared-workflows` [PR #1957](https://github.com/grafana/shared-workflows/pull/1957) (merged June 4) removed env var export from `get-vault-secrets`, breaking all three Crowdin workflows
- Secrets are now only available via JSON output: `${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}`
- Updated `i18n-crowdin-upload.yml`, `i18n-crowdin-download.yml`, and `i18n-crowdin-create-tasks.yml`

## Test plan
- [ ] Trigger `Crowdin Upload Action` workflow via `workflow_dispatch` and confirm the "Upload to Crowdin" step succeeds