### PR TITLE
fix: Avoid error exporting png from top table diff

### DIFF
--- a/src/locales/en-US/grafana-pyroscope-app.json
+++ b/src/locales/en-US/grafana-pyroscope-app.json
@@ -176,10 +176,12 @@
     "error-flamegraph-com": "Failed to export to flamegraph.com!",
     "error-loading-profile": "Error while loading flamebearer profile data!",
     "error-png": "Failed to export to png!",
+    "error-png-no-canvas": "Please ensure the flame graph is visible before exporting to png.",
     "error-pprof": "Failed to export to pprof!",
     "json": "json",
     "json-label": "json",
     "png": "png",
+    "png-disabled-description": "Switch to the flame graph view to export it as a png",
     "png-label": "png",
     "pprof": "pprof",
     "tooltip": "Export profile data"

--- a/src/locales/es-ES/grafana-pyroscope-app.json
+++ b/src/locales/es-ES/grafana-pyroscope-app.json
@@ -176,10 +176,12 @@
     "error-flamegraph-com": "¡Error al exportar a flamegraph.com!",
     "error-loading-profile": "¡Error al cargar los datos del perfil de Flamebearer!",
     "error-png": "¡Error al exportar a PNG!",
+    "error-png-no-canvas": "",
     "error-pprof": "¡Error al exportar a PPROF!",
     "json": "json",
     "json-label": "json",
     "png": "png",
+    "png-disabled-description": "",
     "png-label": "png",
     "pprof": "PPROF",
     "tooltip": "Exportar datos del perfil"

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
@@ -6,6 +6,7 @@ import { displayError } from '@shared/domain/displayStatus';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import { saveProfileJsonToFile } from '@shared/domain/saveProfileJsonToFile';
 import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
+import { useIsFlameGraphCanvasPresent } from '@shared/domain/useIsFlameGraphCanvasPresent';
 import { DEFAULT_SETTINGS } from '@shared/infrastructure/settings/PluginSettings';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { DomainHookReturnValue } from '@shared/types/DomainHookReturnValue';
@@ -183,7 +184,7 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
     };
 
     // png export captures the flame graph <canvas>, which is not rendered in the "Top table" view
-    const isPngExportDisabled = !document.querySelector('canvas[data-testid="flameGraph"]');
+    const isPngExportDisabled = !useIsFlameGraphCanvasPresent();
 
     return {
       data: {

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneExportMenu/SceneExportMenu.tsx
@@ -101,7 +101,18 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
 
       const filename = `${getExportFilename(query, timeRange)}.png`;
 
-      (document.querySelector('canvas[data-testid="flameGraph"]') as HTMLCanvasElement).toBlob((blob) => {
+      const canvasElement = document.querySelector('canvas[data-testid="flameGraph"]') as HTMLCanvasElement | null;
+
+      if (!canvasElement) {
+        const error = new Error('No flame graph canvas found, the image cannot be created.');
+        displayError(error, [
+          t('export-menu.error-png', 'Failed to export to png!'),
+          t('export-menu.error-png-no-canvas', 'Please ensure the flame graph is visible before exporting to png.'),
+        ]);
+        return;
+      }
+
+      canvasElement.toBlob((blob) => {
         if (!blob) {
           const error = new Error('Error while creating the image, no blob.');
           displayError(error, [t('export-menu.error-png', 'Failed to export to png!'), error.message]);
@@ -171,9 +182,13 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
       }
     };
 
+    // png export captures the flame graph <canvas>, which is not rendered in the "Top table" view
+    const isPngExportDisabled = !document.querySelector('canvas[data-testid="flameGraph"]');
+
     return {
       data: {
         shouldDisplayFlamegraphDotCom: Boolean(settings?.enableFlameGraphDotComExport),
+        isPngExportDisabled,
       },
       actions: {
         downloadPng,
@@ -185,13 +200,22 @@ export class SceneExportMenu extends SceneObjectBase<SceneExportMenuState> {
   };
 
   static Component = ({ model, query, timeRange }: SceneComponentProps<SceneExportMenu> & ExtraProps) => {
-    const { actions } = model.useSceneExportMenu({ query, timeRange });
+    const { data, actions } = model.useSceneExportMenu({ query, timeRange });
 
     return (
       <Dropdown
         overlay={
           <Menu>
-            <Menu.Item label={t('export-menu.png', 'png')} onClick={actions.downloadPng} />
+            <Menu.Item
+              label={t('export-menu.png', 'png')}
+              disabled={data.isPngExportDisabled}
+              description={
+                data.isPngExportDisabled
+                  ? t('export-menu.png-disabled-description', 'Switch to the flame graph view to export it as a png')
+                  : undefined
+              }
+              onClick={actions.downloadPng}
+            />
             <Menu.Item label={t('export-menu.json', 'json')} onClick={actions.downloadJson} />
             <Menu.Item label={t('export-menu.pprof', 'pprof')} onClick={actions.downloadPprof} />
           </Menu>

--- a/src/shared/components/FlameGraph/components/ExportMenu.tsx
+++ b/src/shared/components/FlameGraph/components/ExportMenu.tsx
@@ -6,11 +6,20 @@ import { useExportMenu } from './domain/useExportMenu';
 import { ExportDataProps } from './ExportData';
 
 export function ExportMenu(props: ExportDataProps) {
-  const { actions } = useExportMenu(props);
+  const { data, actions } = useExportMenu(props);
 
   return (
     <Menu>
-      <Menu.Item label={t('export-menu.png-label', 'png')} onClick={actions.downloadPng} />
+      <Menu.Item
+        label={t('export-menu.png-label', 'png')}
+        disabled={data.isPngExportDisabled}
+        description={
+          data.isPngExportDisabled
+            ? t('export-menu.png-disabled-description', 'Switch to the flame graph view to export it as a png')
+            : undefined
+        }
+        onClick={actions.downloadPng}
+      />
       <Menu.Item label={t('export-menu.json-label', 'json')} onClick={actions.downloadJson} />
     </Menu>
   );

--- a/src/shared/components/FlameGraph/components/__tests__/ExportMenu.test.tsx
+++ b/src/shared/components/FlameGraph/components/__tests__/ExportMenu.test.tsx
@@ -1,0 +1,58 @@
+import { FlamebearerProfile } from '@shared/types/FlamebearerProfile';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { ExportMenu } from '../ExportMenu';
+
+// compression-streams-polyfill relies on TransformStream, which is not available in jsdom
+jest.mock('compression-streams-polyfill', () => ({}));
+
+jest.mock('@shared/domain/reportInteraction', () => ({
+  reportInteraction: jest.fn(),
+}));
+
+const profile = {
+  metadata: { appName: 'simple.golang.app.cpu' },
+} as FlamebearerProfile;
+
+describe('<ExportMenu />', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // getExportFilename reads the diff time ranges from the URL
+    Object.defineProperty(window, 'location', {
+      value: {
+        search:
+          '?diffFrom=2024-09-16T12:21:51.298Z&diffTo=2024-09-16T12:25:35.688Z&diffFrom-2=2024-09-16T12:31:56.176Z&diffTo-2=2024-09-16T12:34:56.664Z',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    window.location = originalLocation;
+  });
+
+  describe('when there is no flame graph canvas (e.g. the "Top table" view is selected)', () => {
+    it('disables the png menu item and explains why', () => {
+      render(<ExportMenu profile={profile} />);
+
+      expect(screen.getByText('png').closest('button')).toBeDisabled();
+      expect(screen.getByText('Switch to the flame graph view to export it as a png')).toBeInTheDocument();
+    });
+  });
+
+  describe('when the flame graph canvas is present', () => {
+    it('enables the png menu item', () => {
+      const canvas = document.createElement('canvas');
+      canvas.setAttribute('data-testid', 'flameGraph');
+      document.body.appendChild(canvas);
+
+      render(<ExportMenu profile={profile} />);
+
+      expect(screen.getByText('png').closest('button')).toBeEnabled();
+      expect(screen.queryByText('Switch to the flame graph view to export it as a png')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/shared/components/FlameGraph/components/__tests__/ExportMenu.test.tsx
+++ b/src/shared/components/FlameGraph/components/__tests__/ExportMenu.test.tsx
@@ -16,22 +16,8 @@ const profile = {
 } as FlamebearerProfile;
 
 describe('<ExportMenu />', () => {
-  const originalLocation = window.location;
-
-  beforeEach(() => {
-    // getExportFilename reads the diff time ranges from the URL
-    Object.defineProperty(window, 'location', {
-      value: {
-        search:
-          '?diffFrom=2024-09-16T12:21:51.298Z&diffTo=2024-09-16T12:25:35.688Z&diffFrom-2=2024-09-16T12:31:56.176Z&diffTo-2=2024-09-16T12:34:56.664Z',
-      },
-      writable: true,
-    });
-  });
-
   afterEach(() => {
     document.body.innerHTML = '';
-    window.location = originalLocation;
   });
 
   describe('when there is no flame graph canvas (e.g. the "Top table" view is selected)', () => {

--- a/src/shared/components/FlameGraph/components/domain/__tests__/useExportMenu.spec.ts
+++ b/src/shared/components/FlameGraph/components/domain/__tests__/useExportMenu.spec.ts
@@ -34,23 +34,22 @@ const profile = {
 } as FlamebearerProfile;
 
 describe('useExportMenu(props)', () => {
-  const originalLocation = window.location;
-
   beforeEach(() => {
-    // getExportFilename reads the diff time ranges from the URL
-    Object.defineProperty(window, 'location', {
-      value: {
-        search:
-          '?diffFrom=2024-09-16T12:21:51.298Z&diffTo=2024-09-16T12:25:35.688Z&diffFrom-2=2024-09-16T12:31:56.176Z&diffTo-2=2024-09-16T12:34:56.664Z',
-      },
-      writable: true,
-    });
+    // getExportFilename reads the diff time ranges from the URL.
+    // We update the URL via history.replaceState rather than redefining window.location: once
+    // @testing-library/react is imported the location property is non-configurable, so
+    // Object.defineProperty(window, 'location', ...) throws "Cannot redefine property: location".
+    window.history.replaceState(
+      {},
+      '',
+      '?diffFrom=2024-09-16T12:21:51.298Z&diffTo=2024-09-16T12:25:35.688Z&diffFrom-2=2024-09-16T12:31:56.176Z&diffTo-2=2024-09-16T12:34:56.664Z'
+    );
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     document.body.innerHTML = '';
-    window.location = originalLocation;
+    window.history.replaceState({}, '', '/');
   });
 
   describe('data.isPngExportDisabled', () => {

--- a/src/shared/components/FlameGraph/components/domain/__tests__/useExportMenu.spec.ts
+++ b/src/shared/components/FlameGraph/components/domain/__tests__/useExportMenu.spec.ts
@@ -1,0 +1,111 @@
+import { AppEvents } from '@grafana/data';
+import { FlamebearerProfile } from '@shared/types/FlamebearerProfile';
+import { renderHook } from '@testing-library/react';
+
+import { useExportMenu } from '../useExportMenu';
+
+// appEvents dependency
+const appEvents = {
+  publish: jest.fn(),
+};
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: () => appEvents,
+}));
+
+// file-saver dependency
+const saveAs = jest.fn();
+jest.mock('file-saver', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => saveAs(...args),
+}));
+
+// reportInteraction dependency
+jest.mock('@shared/domain/reportInteraction', () => ({
+  reportInteraction: jest.fn(),
+}));
+
+// compression-streams-polyfill relies on TransformStream, which is not available in jsdom
+jest.mock('compression-streams-polyfill', () => ({}));
+
+const profile = {
+  metadata: { appName: 'simple.golang.app.cpu' },
+} as FlamebearerProfile;
+
+describe('useExportMenu(props)', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // getExportFilename reads the diff time ranges from the URL
+    Object.defineProperty(window, 'location', {
+      value: {
+        search:
+          '?diffFrom=2024-09-16T12:21:51.298Z&diffTo=2024-09-16T12:25:35.688Z&diffFrom-2=2024-09-16T12:31:56.176Z&diffTo-2=2024-09-16T12:34:56.664Z',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+    window.location = originalLocation;
+  });
+
+  describe('data.isPngExportDisabled', () => {
+    it('is true when there is no flame graph canvas (e.g. the "Top table" view is selected)', () => {
+      const { result } = renderHook(() => useExportMenu({ profile }));
+
+      expect(result.current.data.isPngExportDisabled).toBe(true);
+    });
+
+    it('is false when the flame graph canvas is present', () => {
+      const canvas = document.createElement('canvas');
+      canvas.setAttribute('data-testid', 'flameGraph');
+      document.body.appendChild(canvas);
+
+      const { result } = renderHook(() => useExportMenu({ profile }));
+
+      expect(result.current.data.isPngExportDisabled).toBe(false);
+    });
+  });
+
+  describe('actions.downloadPng()', () => {
+    describe('when there is no flame graph canvas (e.g. the "Top table" view is selected)', () => {
+      it('does not throw and publishes an error application event', () => {
+        // prevent console noise in the output
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { result } = renderHook(() => useExportMenu({ profile }));
+
+        expect(() => result.current.actions.downloadPng()).not.toThrow();
+
+        expect(appEvents.publish).toHaveBeenCalledWith({
+          type: AppEvents.alertError.name,
+          payload: ['Failed to export to png!', 'Please ensure the flame graph is visible before exporting to png.'],
+        });
+
+        expect(saveAs).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the flame graph canvas is present', () => {
+      it('saves the canvas contents as a png file', () => {
+        const blob = new Blob();
+        const canvas = document.createElement('canvas');
+        canvas.setAttribute('data-testid', 'flameGraph');
+        canvas.toBlob = jest.fn((callback) => callback(blob));
+        document.body.appendChild(canvas);
+
+        const { result } = renderHook(() => useExportMenu({ profile }));
+
+        result.current.actions.downloadPng();
+
+        expect(canvas.toBlob).toHaveBeenCalledWith(expect.any(Function), 'image/png');
+        expect(saveAs).toHaveBeenCalledWith(blob, expect.stringMatching(/^simple\.golang\.app\.cpu.*\.png$/));
+        expect(appEvents.publish).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/shared/components/FlameGraph/components/domain/useExportMenu.ts
+++ b/src/shared/components/FlameGraph/components/domain/useExportMenu.ts
@@ -17,7 +17,16 @@ export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportD
     const filename = `${customExportName}.png`;
 
     // TODO use ref, this won't work for comparison side by side (??!)
-    const canvasElement = document.querySelector('canvas[data-testid="flameGraph"]') as HTMLCanvasElement;
+    const canvasElement = document.querySelector('canvas[data-testid="flameGraph"]') as HTMLCanvasElement | null;
+
+    if (!canvasElement) {
+      const error = new Error('No flame graph canvas found, the image cannot be created.');
+      displayError(error, [
+        'Failed to export to png!',
+        'Please ensure the flame graph is visible before exporting to png.',
+      ]);
+      return;
+    }
 
     canvasElement.toBlob((blob) => {
       if (!blob) {
@@ -65,9 +74,13 @@ export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportD
     document.body.removeChild(dlLink);
   };
 
+  // png export captures the flame graph <canvas>, which is not rendered in the "Top table" view
+  const isPngExportDisabled = !document.querySelector('canvas[data-testid="flameGraph"]');
+
   return {
     data: {
       shouldDisplayFlamegraphDotCom: Boolean(enableFlameGraphDotComExport),
+      isPngExportDisabled,
     },
     actions: {
       downloadPng,

--- a/src/shared/components/FlameGraph/components/domain/useExportMenu.ts
+++ b/src/shared/components/FlameGraph/components/domain/useExportMenu.ts
@@ -1,6 +1,8 @@
+import { t } from '@grafana/i18n';
 import { displayError } from '@shared/domain/displayStatus';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import { saveProfileJsonToFile } from '@shared/domain/saveProfileJsonToFile';
+import { useIsFlameGraphCanvasPresent } from '@shared/domain/useIsFlameGraphCanvasPresent';
 import 'compression-streams-polyfill';
 import saveAs from 'file-saver';
 
@@ -22,8 +24,8 @@ export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportD
     if (!canvasElement) {
       const error = new Error('No flame graph canvas found, the image cannot be created.');
       displayError(error, [
-        'Failed to export to png!',
-        'Please ensure the flame graph is visible before exporting to png.',
+        t('export-menu.error-png', 'Failed to export to png!'),
+        t('export-menu.error-png-no-canvas', 'Please ensure the flame graph is visible before exporting to png.'),
       ]);
       return;
     }
@@ -31,7 +33,7 @@ export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportD
     canvasElement.toBlob((blob) => {
       if (!blob) {
         const error = new Error('No Blob, the image cannot be created.');
-        displayError(error, ['Failed to export to png!', error.message]);
+        displayError(error, [t('export-menu.error-png', 'Failed to export to png!'), error.message]);
         return;
       }
 
@@ -75,7 +77,7 @@ export function useExportMenu({ profile, enableFlameGraphDotComExport }: ExportD
   };
 
   // png export captures the flame graph <canvas>, which is not rendered in the "Top table" view
-  const isPngExportDisabled = !document.querySelector('canvas[data-testid="flameGraph"]');
+  const isPngExportDisabled = !useIsFlameGraphCanvasPresent();
 
   return {
     data: {

--- a/src/shared/domain/useIsFlameGraphCanvasPresent.ts
+++ b/src/shared/domain/useIsFlameGraphCanvasPresent.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+const FLAME_GRAPH_CANVAS_SELECTOR = 'canvas[data-testid="flameGraph"]';
+
+const isCanvasPresent = () => Boolean(document.querySelector(FLAME_GRAPH_CANVAS_SELECTOR));
+
+/**
+ * Reactively tracks whether the flame graph <canvas> is present in the DOM.
+ *
+ * The canvas is created/removed by the <FlameGraph /> component when users switch between views
+ * (e.g. "Flame graph" ↔ "Top table"), so we observe the DOM to avoid a stale value that was only
+ * computed during the initial render.
+ */
+export function useIsFlameGraphCanvasPresent(): boolean {
+  const [isPresent, setIsPresent] = useState(isCanvasPresent);
+
+  useEffect(() => {
+    const update = () => setIsPresent(isCanvasPresent());
+
+    // ensure we're in sync with the DOM after mount, in case it changed before the observer was attached
+    update();
+
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return isPresent;
+}


### PR DESCRIPTION
### ✨ Description

Fixes: #937

### 📖 Summary of the changes

- Guard against no canvas when generating PNGs for flame graphs.
- Disable the png generation button when viewing the top table.

### 🧪 How to test?

New tests added.

Manual testing could be done by copying the steps from #937.
