### PR TITLE
chore: Surface backend error of creating a recording rule

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/domain/useCreateRecordingRule.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/domain/useCreateRecordingRule.ts
@@ -16,7 +16,7 @@ export function useCreateRecordingRule() {
           await mutate(rule);
           displaySuccess([`Recording rule ${rule.metricName} created successfully!`]);
         } catch (e) {
-          displayError(e as Error, [`Failed to save recording rule ${rule.metricName}.`]);
+          displayError(e as Error, [`Failed to save recording rule ${rule.metricName}. Reason: ${(e as Error).message}`]);
         }
       },
     },

--- a/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/domain/useCreateRecordingRule.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneCreateMetricModal/domain/useCreateRecordingRule.ts
@@ -16,7 +16,7 @@ export function useCreateRecordingRule() {
           await mutate(rule);
           displaySuccess([`Recording rule ${rule.metricName} created successfully!`]);
         } catch (e) {
-          displayError(e as Error, [`Failed to save recording rule ${rule.metricName}. Reason: ${(e as Error).message}`]);
+          displayError(e as Error, [`Failed to save recording rule ${rule.metricName}. Reason: ${(e as Error).message}.`]);
         }
       },
     },


### PR DESCRIPTION
### ✨ Description

We are adding a backend limit on the number of recording rules a tenant can define.
When failing due to a limit exceeded, we want the user know, so they can change or ask support to change that limit.

### 📖 Summary of the changes

We are only surfacing the backend error to the frontend.
<img width="613" height="117" alt="Screenshot 2026-06-11 at 11 44 16" src="https://github.com/user-attachments/assets/9c0f4f6a-4e5d-41a6-8704-1ab4b4c90334" />

