### PR TITLE
fix(deps): bump dompurify override to ~3.4.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   minimatch@^5: ~5.1.9
   minimatch@^9: ~9.0.9
   ajv@^8: ~8.18.0
-  dompurify: ~3.4.9
+  dompurify: ~3.4.11
   hono: '>=4.12.25'
   js-yaml: '>=4.2.0'
   '@opentelemetry/core': '>=2.8.0'
@@ -3123,8 +3123,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -6873,7 +6873,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       eventemitter3: 5.0.1
       fast_array_intersect: 1.1.0
       history: 4.10.1
@@ -9544,7 +9544,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ overrides:
   minimatch@^5: ~5.1.9
   minimatch@^9: ~9.0.9
   ajv@^8: ~8.18.0
-  dompurify: ~3.4.9
+  dompurify: ~3.4.11
   hono: '>=4.12.25'
   js-yaml: '>=4.2.0'
   '@opentelemetry/core': '>=2.8.0'


### PR DESCRIPTION
## Summary
- Bumps `dompurify` override from ~3.4.9 to ~3.4.11 in `pnpm-workspace.yaml`
- Fixes GHSA-cmwh-pvxp-8882 (moderate: permanent ALLOWED_ATTR pollution via setConfig())

## Test plan
- [x] `pnpm audit` passes with 0 vulnerabilities