### PR TITLE
docs: Add GenAI policy, contributor guide updates and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[bug] '
-labels: bug
+title: '[BUG]:'
+labels: bug, needs-triage
 assignees: ''
 ---
 
@@ -28,3 +28,8 @@ assignees: ''
 #### Expected behaviour
 
 <!-- A clear and concise description of what you expected to happen -->
+
+**AI disclosure** (optional)
+See the [Generative AI Contribution Policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md).
+
+- [ ] This issue was substantially generated with AI assistance.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: '[feature] '
-labels: ''
+title: '[FEAT]:'
+labels: enhancement
 assignees: ''
 ---
 
@@ -27,3 +27,8 @@ assignees: ''
 ### Additional context
 
 <!-- Add any other context about the feature request here. -->
+
+**AI disclosure** (optional)
+See the [Generative AI Contribution Policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md).
+
+- [ ] This feature request was substantially generated with AI assistance.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,8 @@ Related issue(s): <!-- Link to the issue this PR is related to but does not reso
 
 <!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->
 
+- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))
+
 ### 🧪 How to test?
 
 <!-- Steps required to test the PR or pointer to the automated tests -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@
 | File                                 | What it's for                                                                                                                   |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | **`AGENTS.md`** (this file)          | **Entry point.** Pyroscope & profiling workflow, expected vs bug, Scenes patterns, security. Points to every other doc below.   |
+| **`docs/CONTRIBUTING.md`**           | **Human contributors.** Dev setup, issues vs PRs, i18n, PR checklist, link to GenAI policy.                                     |
+| **`docs/genai.md`**                  | **AI-assisted contributions.** Disclosure, acceptable use, Profiles Drilldown-specific pitfalls.                                  |
 | **`.config/AGENTS/instructions.md`** | **Plugin tooling only** — webpack, `plugin.json`, E2E, rules about `.config`.                                                   |
 | **`docs/project-intent.md`**         | **Why** we built the app — philosophy, principles. Use when reasoning about tradeoffs or scope.                                 |
 | **`docs/application-structure.md`**  | **How the product is organized** — user journeys, views, exploration types, links in/out. Use when changing UI or URL behavior. |
@@ -26,6 +28,7 @@
 | **Build / plugin** — plugin.json, webpack, .config, E2E                          | `.config/AGENTS/instructions.md`                      | project-intent, application-structure               |
 | **Shipped user docs** — get-started, concepts, structure                         | Relevant file in `docs/sources/` + `docs/README.md`   | Others unless aligning to UI                        |
 | **Bug in profiles / Pyroscope / data**                                           | This file (Pyroscope links) + code                    | application-structure only if UI or URL involved    |
+| **AI-assisted contribution** — drafting or reviewing with GenAI                  | `docs/genai.md`                                       | AGENTS.md, CONTRIBUTING.md unless filing a PR       |
 
 **Default:** Stay shallow; open another doc only when the task clearly fits. For renames, lint, or single-file UI tweaks, skip application-structure and other deep docs.
 
@@ -72,3 +75,5 @@ Profiles Drilldown uses [@grafana/scenes](https://grafana.com/developers/scenes/
 ## Usage
 
 Start with the **How these files fit together** table above, then open the doc that matches your task.
+
+**Human contributors:** follow [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for how to file issues, open pull requests, run local checks, and use AI tools responsibly. The full GenAI policy is in [docs/genai.md](docs/genai.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 Welcome! We're excited that you're interested in contributing. Below are some basic guidelines.
 
+We love accepting contributions! To help us create a safe and positive community experience, we require all participants to adhere to the [Grafana Code of Conduct](https://github.com/grafana/grafana/blob/main/CODE_OF_CONDUCT.md).
+
+## Filing issues
+
+Use [GitHub Issues](https://github.com/grafana/profiles-drilldown/issues/new) to report bugs, ask questions, or propose larger changes.
+
+| Situation | What to do |
+|-----------|------------|
+| **Bug** — something is broken or regressed | [Open a bug report](https://github.com/grafana/profiles-drilldown/issues/new?template=bug_report.md) with reproduction steps, expected vs actual behavior, Grafana/Pyroscope versions, and screenshots or recordings if helpful. |
+| **Small fix** — typo, clear one-file change, docs tweak | Open a pull request directly; link a related issue if one exists. |
+| **Feature or larger change** — new UI, behavior change, refactor | [Open a feature request](https://github.com/grafana/profiles-drilldown/issues/new?template=feature_request.md) to discuss scope, or open a draft PR with context in the description. |
+| **Documentation only** | Open a PR and add the `type/doc` label. |
+
+For bugs, check [Pyroscope](https://grafana.com/docs/grafana/latest/datasources/pyroscope/) and [Grafana profiling](https://grafana.com/docs/grafana/latest/explore/simplified-exploration/profiles/) behavior first — missing profile data outside the selected time window or filters may be expected, not a plugin bug.
+
 ## Workflow
 
 Grafana Profiles Drilldown follows a standard GitHub pull request workflow. If you're unfamiliar with this workflow, read the very helpful [Understanding the GitHub flow](https://guides.github.com/introduction/flow/) guide from GitHub.
@@ -113,6 +128,33 @@ When opening a Pull Request (PR), please make sure that the title is properly pr
 We encourage you to write tests, whether they are unit tests or end-to-end tests. They will give us the confidence that the plugin behaves as intended and help us capture any regression early.
 
 For end-to-end testing (E2E), please have a look at our [E2E testing documentation](../e2e/README.md).
+
+### Before you open a pull request
+
+- Fill out the [pull request template](../.github/pull_request_template.md) with a clear summary and test steps.
+- Use a [conventional commit](https://www.conventionalcommits.org/) style PR title (enforced by CI).
+- Run `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test:ci` locally.
+- Add or update tests when behavior changes. Prefer focused unit tests (Jest) or Playwright E2E when UI flows are affected.
+- Do not modify files under `.config/` unless you are following the plugin-tools guidance in `.config/AGENTS/instructions.md`.
+
+### Internationalization (i18n)
+
+User-facing strings must use Grafana i18n APIs — `t` or `Trans` from `@grafana/i18n` with a stable `i18nKey`, not hard-coded text in components.
+
+After adding or changing copy:
+
+1. Run `pnpm run i18n-extract` to update `src/locales/en-US/grafana-pyroscope-app.json`.
+2. Commit the extracted English locale file with your PR.
+
+CI runs an i18n verification workflow on pull requests. Translations for other locales are managed via Crowdin and synced after changes merge to `main`; you do not need to hand-edit non-English locale files in most PRs.
+
+## Using AI and coding assistants
+
+Generative AI tools can help you explore the codebase, draft code, and write documentation. **You are always responsible for what you submit.**
+
+Read the full [Generative AI Contribution Policy](genai.md) for acceptable use, disclosure, Profiles Drilldown-specific guidance (Pyroscope, Scenes, tests), and rules for agentic tools. Point coding assistants at [AGENTS.md](../AGENTS.md) for technical conventions.
+
+When AI generated the bulk of a pull request, check the disclosure box in the pull request template.
 
 ## Common problems & solutions
 

--- a/docs/genai.md
+++ b/docs/genai.md
@@ -1,0 +1,75 @@
+# Generative AI Contribution Policy
+
+Generative AI (GenAI) tools such as large language model (LLM) assistants can help you write code, documentation, and proposals for Grafana Profiles Drilldown. This policy explains what is an acceptable use of GenAI tools when contributing to the project.
+
+## Core principle
+
+**The human contributor is always in control and fully responsible for their contribution.**
+
+GenAI is a tool that assists you. It is not a substitute for your own understanding, judgment, or accountability. By submitting a contribution, you vouch for it as your own work, regardless of which tools helped you produce it. You are expected to understand, review, and provide rationale for everything you submit.
+
+## Acceptable use
+
+You are welcome to use GenAI tools to:
+
+- Write or refactor code and documentation, as long as you actively review and refine the output.
+- Understand the Profiles Drilldown codebase, Grafana Scenes, Pyroscope, or profile semantics before contributing or reviewing.
+- Draft issues, proposals, or design documents that you then verify and shape into your own reasoning.
+- Suggest tests, formatting, or lint fixes that you verify locally with `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test:ci`.
+
+In all cases, you remain the author. You read the output, you correct it, and you ensure your contribution meets the project's standards before submitting an issue, pull request, or comment.
+
+## Not acceptable
+
+Do not:
+
+- Submit unreviewed, bulk AI-generated content to pull requests, issues, or proposals. If you did not read and understand it, do not submit it.
+- Use GenAI as a substitute for human judgment in code review. An AI tool may help you understand a change, but the review and its conclusions must be yours.
+- File automated, bot-driven issues or pull requests from tools that have not been approved by the Profiles Drilldown team. This policy covers humans using AI assistance, not autonomous agents acting on their own, including agentic IDE tools that file pull requests without human review.
+- Paste generated text into a discussion without adding your own analysis and context.
+- Wire up an AI agent to respond automatically to reviewers or other community members on your behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words, rather than connecting it directly to maintainers.
+- Submit pull requests without using the [pull request template](../.github/pull_request_template.md), or file bugs without reproduction steps and expected vs actual behavior.
+
+Maintainers may close low-effort AI-generated contributions. When they do, they should explain why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort submissions will trigger stricter review, and maintainers may block repeat offenders from contributing.
+
+## Approved automation
+
+Some automated tools are explicitly approved and are an acceptable exception to the rule against bot-driven contributions. Examples include Dependabot, Copilot, release-please, and other repository automation maintained by the team. The team may approve more over time. Contributions from these tools are clearly marked as bot-generated so that reviewers can tell them apart from human contributions.
+
+## Disclosure
+
+When GenAI generates the **bulk** of a contribution, disclose it. For pull requests, check the **"This pull request was substantially generated with AI assistance"** box in the [pull request template](../.github/pull_request_template.md). For issues, use the optional AI disclosure in the [bug](../.github/ISSUE_TEMPLATE/bug_report.md) or [feature](../.github/ISSUE_TEMPLATE/feature_request.md) template. Minor, incidental help such as autocomplete or small edits does not need to be disclosed.
+
+Disclosure is not a mark against your contribution. It helps reviewers know where to focus, and it keeps expectations clear for everyone.
+
+## Profiles Drilldown-specific guidance
+
+LLMs frequently hallucinate Pyroscope query behavior, Grafana Scenes APIs, profile type semantics, and flame graph data shapes. To reduce these errors, point the tool at authoritative sources rather than relying on its training data:
+
+- [AGENTS.md][agents] for architecture, Scenes patterns, and expected vs buggy behavior.
+- [docs/application-structure.md][application-structure] for UI layout, exploration views, and URL state.
+- [Pyroscope documentation][pyroscope-docs] and [Grafana profiling][profiling-docs] for profile types, labels, and flame graph semantics.
+
+Always validate AI-generated code against the real component definitions and the project's checks before submitting. Run `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test:ci` locally. Use `pnpm run lint:fix` for formatting when appropriate; do not commit unrelated drive-by changes.
+
+### Tests and formatting
+
+- Add tests that cover behavior you changed. Do not paste large blocks of shallow or incorrect AI-generated tests just to increase coverage.
+- Prefer focused Jest unit tests or Playwright E2E when UI flows are affected.
+- Match existing conventions in surrounding code. Keep scope tight — avoid unrelated refactors, new dependencies, or edits under `.config/` unless required and agreed.
+
+### User-facing strings
+
+New or changed UI copy must use translation keys (`t`, `Trans` from `@grafana/i18n`), not hard-coded strings. After editing copy, run `pnpm run i18n-extract` and commit the updated `src/locales/en-US/grafana-pyroscope-app.json`. CI verifies i18n markup; other locales are synced via Crowdin after merge to `main`.
+
+For larger changes or new features, file an [issue][new-issue] first so we can discuss scope. A proposal must reflect your own reasoning. AI may help you draft it, but you own the argument in the discussion.
+
+### Guidance for AI agents
+
+If you use an agentic tool, point it at [AGENTS.md][agents] first. Agents should prefer small, focused diffs; grep before reading entire large files; and respect frontend security practices (sanitized HTML/URLs, no unsafe DOM APIs).
+
+[agents]: ../AGENTS.md
+[application-structure]: application-structure.md
+[pyroscope-docs]: https://grafana.com/docs/grafana/latest/datasources/pyroscope/
+[profiling-docs]: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/profiles/
+[new-issue]: https://github.com/grafana/profiles-drilldown/issues/new

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -64,7 +64,7 @@
       },
       {
         "name": "Report bug",
-        "url": "https://github.com/grafana/profiles-drilldown/issues/new"
+        "url": "https://github.com/grafana/profiles-drilldown/issues/new?template=bug_report.md"
       }
     ]
   },


### PR DESCRIPTION
### ✨ Description

Expands docs/CONTRIBUTING.md with the Grafana Code of Conduct, when to file issues vs open PRs, PR checklist, i18n workflow, and GenAI guidance.

Adds docs/genai.md for AI-assisted contributions (disclosure, acceptable use, Pyroscope/Scenes guidance) and links it from AGENTS.md, the PR template, and issue templates.

Updates .github/ISSUE_TEMPLATE/ bug and feature templates with optional AI disclosure. Updates src/plugin.json Report bug link to use the bug report template.