### PR TITLE
fix: include profile ID selector in function details query

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel.tsx
@@ -44,13 +44,14 @@ export class SceneFunctionDetailsPanel extends SceneObjectBase<SceneFunctionDeta
     const dataSourceName = sceneGraph.findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable).useState()
       .text as string;
     const serviceName = getSceneVariableValue(this, 'serviceName');
+    const profileIdSelector = getSceneVariableValue(this, 'profileIdSelector');
     const query = useBuildPyroscopeQuery(this, 'filters');
 
     const {
       functionsDetails,
       error: fetchFunctionDetailsError,
       isFetching,
-    } = useFetchFunctionsDetails({ dataSourceUid, query, timeRange, stackTrace });
+    } = useFetchFunctionsDetails({ dataSourceUid, query, timeRange, stackTrace, profileIdSelector });
 
     const [prevFunctionsDetails, setPrevFunctionsDetails] = useState<FunctionDetails[]>();
     const [currentFunctionDetails, setCurrentFunctionDetails] = useState<FunctionDetails>(functionsDetails[0]);

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/infrastructure/useFetchFunctionsDetails.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/infrastructure/useFetchFunctionsDetails.ts
@@ -18,6 +18,7 @@ type FetchParams = {
   query: string;
   timeRange: TimeRange;
   stackTrace: string[];
+  profileIdSelector?: string;
 };
 
 type FetchResponse = {
@@ -37,7 +38,13 @@ const DEFAULT_FUNCTION_VERSION: FunctionVersion = {
   root_path: '',
 };
 
-export function useFetchFunctionsDetails({ dataSourceUid, query, timeRange, stackTrace }: FetchParams): FetchResponse {
+export function useFetchFunctionsDetails({
+  dataSourceUid,
+  query,
+  timeRange,
+  stackTrace,
+  profileIdSelector,
+}: FetchParams): FetchResponse {
   const { profileMetricId, labelsSelector, serviceId } = parseQuery(query);
   const [start, end] = [timeRange.from.unix(), timeRange.to.unix()];
   const { isLoggedIn: isGitHubLogged } = useGitHubContext();
@@ -67,6 +74,7 @@ export function useFetchFunctionsDetails({ dataSourceUid, query, timeRange, stac
       stackTrace,
       isGitHubLogged,
       defaultFunctionVersion,
+      profileIdSelector,
     ],
     queryFn: async () => {
       const pprof = await pprofApiClient.selectMergeProfileJson({
@@ -76,6 +84,7 @@ export function useFetchFunctionsDetails({ dataSourceUid, query, timeRange, stac
         end,
         stackTrace,
         maxNodes: MAX_NODES,
+        profileIdSelector,
       });
 
       const functionsDetails = convertPprofToFunctionDetails(stackTrace[stackTrace.length - 1], pprof).sort(

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/infrastructure/PprofApiClient.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/infrastructure/PprofApiClient.ts
@@ -18,6 +18,7 @@ type SelectMergeProfileJsonParams = {
   end: number;
   stackTrace: string[];
   maxNodes: number;
+  profileIdSelector?: string;
 };
 
 export class PprofApiClient extends DataSourceProxyClient {
@@ -49,6 +50,7 @@ export class PprofApiClient extends DataSourceProxyClient {
     end,
     stackTrace,
     maxNodes,
+    profileIdSelector,
   }: SelectMergeProfileJsonParams): Promise<PprofProfile> {
     const response = await this.fetch('/querier.v1.QuerierService/SelectMergeProfile', {
       method: 'POST',
@@ -61,6 +63,7 @@ export class PprofApiClient extends DataSourceProxyClient {
           call_site: stackTrace.map((name) => ({ name })),
         },
         maxNodes,
+        ...(profileIdSelector && { profileIdSelector: [profileIdSelector] }),
       }),
     });
 


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/pyroscope-squad/issues/831
Related issue(s): <!-- Link to the issue this PR is related to but does not resolve it -->

When inspecting a single exemplar's flame graph (the profile ID selector added in #796), the flame graph query is scoped to that single profile via `profileIdSelector`. However, the Function Details / GitHub integration panel fetches its own data through `SelectMergeProfile` (`PprofApiClient.selectMergeProfileJson`) and did **not** pass the profile ID selector.

As a result, while the flame graph was scoped to the selected profile, the Function Details panel queried across **all** profiles matching the label selector, so users saw unexpected profile values in the panel.

This threads the `profileIdSelector` scene variable from `SceneFunctionDetailsPanel` → `useFetchFunctionsDetails` → `PprofApiClient.selectMergeProfileJson`, which now includes it in the `SelectMergeProfile` request (as an array, matching how the Grafana Pyroscope datasource sends the same field). It's added to the react-query key so the panel refetches when the selection changes, and it is only included in the request body when set (so non-flame-graph views are unaffected).

### 🧪 How to test?

<!-- Steps required to test the PR or pointer to the automated tests -->
<!-- For UI changes, don't hesitate to provide before/after screenshots -->

1. Open a service flame graph that has exemplars.
2. Click an exemplar to inspect a single profile (adds the profile ID selector — you'll see the "profile id selector" label on the flame graph).
3. Open the Function Details panel for a function in the flame graph.
4. Before this change, the values shown were computed across all matching profiles; after this change, they match the single selected profile.
