### PR TITLE
feat: remove data-driven annotations, add an extension point on the flame graph panel header

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -30,6 +30,7 @@ import { AIButton } from '../SceneAiPanel/components/AiButton/AIButton';
 import { SceneAiPanel } from '../SceneAiPanel/SceneAiPanel';
 import { useCreateRecordingRulesMenu } from '../SceneCreateMetricModal/domain/useMenuOption';
 import { SceneCreateRecordingRuleModal } from '../SceneCreateMetricModal/SceneCreateRecordingRuleModal';
+import { SamplingIndicatorExtensionPoint } from './components/SamplingIndicatorExtensionPoint';
 import { SceneExportMenu } from './components/SceneExportMenu/SceneExportMenu';
 import { useGitHubIntegration } from './components/SceneFunctionDetailsPanel/domain/useGitHubIntegration';
 import { SceneFunctionDetailsPanel } from './components/SceneFunctionDetailsPanel/SceneFunctionDetailsPanel';
@@ -268,6 +269,7 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
                   <Trans i18nKey="flame-graph.explain-button">Explain Flame Graph</Trans>
                 </AIButton>
               )}
+              <SamplingIndicatorExtensionPoint scene={model} />
             </>
           }
         >

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SamplingIndicatorExtensionPoint/index.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SamplingIndicatorExtensionPoint/index.tsx
@@ -1,0 +1,34 @@
+import { usePluginComponent } from '@grafana/runtime';
+import { sceneGraph, SceneObject } from '@grafana/scenes';
+import React from 'react';
+
+type SamplingIndicatorExtensionProps = {
+  serviceName: string;
+  datasourceUID: string;
+};
+
+const SERVICE_NAME_EXPR = '${serviceName}';
+const DATASOURCE_UID_EXPR = '${dataSource}';
+
+export function SamplingIndicatorExtensionPoint({ scene }: { scene: SceneObject }) {
+  const { component: Extension } = usePluginComponent<SamplingIndicatorExtensionProps>(
+    'grafana-adaptiveprofiles-app/adaptive-profiles-indicator/v1'
+  );
+
+  if (!Extension) {
+    return null;
+  }
+
+  const serviceName = sceneGraph.interpolate(scene, SERVICE_NAME_EXPR);
+  // interpolation failed if the expression is returned back unchanged
+  if (serviceName === SERVICE_NAME_EXPR) {
+    return null;
+  }
+
+  const datasourceUID = sceneGraph.interpolate(scene, DATASOURCE_UID_EXPR);
+  if (datasourceUID === DATASOURCE_UID_EXPR) {
+    return null;
+  }
+
+  return <Extension datasourceUID={datasourceUID} serviceName={serviceName} />;
+}

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SamplingIndicatorExtensionPoint/index.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SamplingIndicatorExtensionPoint/index.tsx
@@ -14,7 +14,7 @@ const DATASOURCE_UID_EXPR = '${dataSource}';
 
 export function SamplingIndicatorExtensionPoint({ scene }: { scene: SceneObject }) {
   const { component: Extension } = usePluginComponent<SamplingIndicatorExtensionProps>(
-    'grafana-adaptiveprofiles-app/adaptive-profiles-indicator/v1'
+    'grafana-adaptiveprofiles-app/sampling-indicator/v1'
   );
 
   if (!Extension) {

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SamplingIndicatorExtensionPoint/index.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/SamplingIndicatorExtensionPoint/index.tsx
@@ -1,6 +1,8 @@
 import { usePluginComponent } from '@grafana/runtime';
-import { sceneGraph, SceneObject } from '@grafana/scenes';
+import { SceneObject } from '@grafana/scenes';
 import React from 'react';
+
+import { safeInterpolate } from '../../../../infrastructure/series/helpers/safeInterpolate';
 
 type SamplingIndicatorExtensionProps = {
   serviceName: string;
@@ -19,14 +21,14 @@ export function SamplingIndicatorExtensionPoint({ scene }: { scene: SceneObject 
     return null;
   }
 
-  const serviceName = sceneGraph.interpolate(scene, SERVICE_NAME_EXPR);
-  // interpolation failed if the expression is returned back unchanged
-  if (serviceName === SERVICE_NAME_EXPR) {
+  // interpolation can fail during variable bootstrap or return the expression unchanged; fail closed
+  const serviceName = safeInterpolate(scene, SERVICE_NAME_EXPR);
+  if (!serviceName || serviceName === SERVICE_NAME_EXPR) {
     return null;
   }
 
-  const datasourceUID = sceneGraph.interpolate(scene, DATASOURCE_UID_EXPR);
-  if (datasourceUID === DATASOURCE_UID_EXPR) {
+  const datasourceUID = safeInterpolate(scene, DATASOURCE_UID_EXPR);
+  if (!datasourceUID || datasourceUID === DATASOURCE_UID_EXPR) {
     return null;
   }
 

--- a/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries/SceneLabelValuesTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneLabelValuesTimeseries/SceneLabelValuesTimeseries.tsx
@@ -49,7 +49,6 @@ interface SceneLabelValuesTimeseriesState extends SceneObjectState {
   displayAllValues: boolean;
   legendPlacement: VizLegendOptions['placement'];
   overrides?: (series: DataFrame[]) => VizPanelState['fieldConfig']['overrides'];
-  annotations?: boolean;
 }
 
 const styles = {
@@ -74,7 +73,6 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     legendPlacement,
     data,
     overrides,
-    annotations,
     includeExemplars,
   }: {
     item: SceneLabelValuesTimeseriesState['item'];
@@ -83,7 +81,6 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     legendPlacement?: SceneLabelValuesTimeseriesState['legendPlacement'];
     data?: SceneDataTransformer;
     overrides?: SceneLabelValuesTimeseriesState['overrides'];
-    annotations?: boolean;
     includeExemplars?: boolean;
   }) {
     const profilesExemplarsEnabled = getProfilesExemplarsFromOpenFeature();
@@ -100,7 +97,6 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
       displayAllValues: Boolean(displayAllValues),
       legendPlacement: legendPlacement || 'bottom',
       overrides,
-      annotations,
       body: PanelBuilders.timeseries()
         // TODO: remove `as any` once @grafana/scenes exposes `multiLane` on the annotations option type
         .setOption('annotations' as any, { multiLane: true })
@@ -111,7 +107,6 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
               $data: buildTimeSeriesQueryRunner(
                 item.queryRunnerParams,
                 displayAllValues ? undefined : LabelsDataSource.MAX_TIMESERIES_LABEL_VALUES,
-                annotations,
                 includeExemplars && profilesExemplarsEnabled
               ),
               transformations: [],
@@ -249,7 +244,7 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
   }
 
   handleExemplarToggleChange(includeExemplars: boolean) {
-    const { body, item, displayAllValues, annotations } = this.state;
+    const { body, item, displayAllValues } = this.state;
     if (!includeExemplars) {
       // Hide exemplars (annotations) by filtering them out from the data without running queries
       const { $data } = body.state;
@@ -270,7 +265,6 @@ export class SceneLabelValuesTimeseries extends SceneObjectBase<SceneLabelValues
     const { queries } = buildTimeSeriesQueryRunner(
       item.queryRunnerParams,
       displayAllValues ? undefined : LabelsDataSource.MAX_TIMESERIES_LABEL_VALUES,
-      annotations,
       includeExemplars
     ).state;
 

--- a/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneMainServiceTimeseries.tsx
@@ -119,7 +119,6 @@ export class SceneMainServiceTimeseries extends SceneObjectBase<SceneMainService
     return new SceneLabelValuesTimeseries({
       item: timeseriesItem,
       headerActions,
-      annotations: true,
       includeExemplars: includeExemplars,
       // we pass data for the scenarios where we land on the page from a shared link
       // we do this to prevent rendering a timeseries without groupBy for a second then with groupBy

--- a/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
+++ b/src/pages/ProfilesExplorerView/infrastructure/timeseries/buildTimeSeriesQueryRunner.ts
@@ -16,7 +16,6 @@ export type TimeSeriesQuery = {
 export function buildTimeSeriesQueryRunner(
   { serviceName, profileMetricId, groupBy, filters }: TimeSeriesQueryRunnerParams,
   limit?: number,
-  annotations?: boolean,
   includeExemplars?: boolean
 ) {
   const completeFilters = filters ? [...filters] : [];
@@ -36,7 +35,6 @@ export function buildTimeSeriesQueryRunner(
         labelSelector: `{${selector},$filters}`,
         groupBy: groupBy?.label ? [groupBy.label] : [],
         limit,
-        annotations,
         includeExemplars,
       },
     ],

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -34,7 +34,7 @@
       "exposedComponents": [
         "grafana-o11yinsights-app/insights-launcher/v1",
         "grafana-adaptiveprofiles-app/resolution-boost/v1",
-        "grafana-adaptiveprofiles-app/adaptive-profiles-indicator/v1",
+        "grafana-adaptiveprofiles-app/sampling-indicator/v1",
         "grafana/query-library-context/v1",
         "grafana/add-to-dashboard-form/v1"
       ]

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -34,6 +34,7 @@
       "exposedComponents": [
         "grafana-o11yinsights-app/insights-launcher/v1",
         "grafana-adaptiveprofiles-app/resolution-boost/v1",
+        "grafana-adaptiveprofiles-app/adaptive-profiles-indicator/v1",
         "grafana/query-library-context/v1",
         "grafana/add-to-dashboard-form/v1"
       ]


### PR DESCRIPTION
### ✨ Description

The region annotations we render on the main service timeseries overlap with near-zero exemplars, and the signal they carry describes the flame graph rather than the timeseries. This PR stops requesting annotations with the timeseries queries and instead adds an extension point on the flame graph panel header, where an app plugin can contribute an indicator about the displayed profile data (same pattern as the existing resolution boost extension point).

- The `annotations` query flag is removed end to end; exemplars (`includeExemplars`) and the comparison-view range annotations are untouched.
- The new extension point always renders as the right-most header element and renders nothing when no app provides the component.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

1. `pnpm build && pnpm server`, open the flame graph view for a service.
2. In the network tab, check the `queryType: "metrics"` payloads on `/api/ds/query`: they no longer contain an `annotations` field.
3. Exemplars still render/toggle on the timeseries, and range selection in the diff view still works.
4. The flame graph header shows no extra element (no app provides the extension component locally) and there are no console errors.