### PR TITLE
fix: Use expression constants when interpolating service name and datasource UID

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/ResolutionBoostExtensionPoint/index.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/components/ResolutionBoostExtensionPoint/index.tsx
@@ -21,16 +21,14 @@ export function ResolutionBoostExtensionPoint({ scene }: { scene: SceneExploreSe
     return;
   }
 
-  const serviceName = sceneGraph.interpolate(scene, '${serviceName}');
-  // serviceNameUnavailable if the interpolation failed (returning the EXPR back again)
+  const serviceName = sceneGraph.interpolate(scene, SERVICE_NAME_EXPR);
   const serviceNameUnavailable = serviceName === SERVICE_NAME_EXPR;
 
   if (serviceNameUnavailable) {
     return;
   }
 
-  const datasourceUID = sceneGraph.interpolate(scene, '${DATASOURCE_UID_EXPR}');
-  // datasourceUIDUnavailable if the interpolation failed (returning the EXPR back again)
+  const datasourceUID = sceneGraph.interpolate(scene, DATASOURCE_UID_EXPR);
   const datasourceUIDUnavailable = datasourceUID === DATASOURCE_UID_EXPR;
 
   if (datasourceUIDUnavailable) {


### PR DESCRIPTION
## What do these changes accomplish?

Uses the `SERVICE_NAME_EXPR` and `DATASOURCE_UID_EXPR` constants when interpolating scene variables in `ResolutionBoostExtensionPoint`, instead of hand-written string literals.

## Why?

The datasource interpolation passed the literal string `'${DATASOURCE_UID_EXPR}'` — the name of the constant, not its value — so it never resolved the actual datasource UID variable. Reusing the constants fixes that mismatch and keeps the interpolation expression and the failure check (`=== *_EXPR`) in sync by construction.

## Screenshots

N/A — no visual changes.
