### PR TITLE
chore(remote): add remote provisioning for the llm app and traces

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -15,10 +15,21 @@
 ## Override the default port
 # GRAFANA_PORT=3003
 
+# Grafana feature toggles (comma-separated), consumed by docker-compose.local.yaml and
+# docker-compose.remote.yaml. profilesHeatmap + profilesExemplars enable the span profiles
+# heatmap; metricsFromProfiles is required by it.
+GF_FEATURE_TOGGLES_ENABLE=localizationForPlugins,profilesHeatmap,profilesExemplars,metricsFromProfiles
+
 # Credentials for fetching remote profile data
 REMOTE_BACKEND_URL=
 REMOTE_BASIC_AUTH_USER=
 REMOTE_BASIC_AUTH_PASSWORD=
+
+# Credentials for the remote Tempo datasource (span profiles -> traces).
+# Enables the "Tempo datasource" picker in the span exemplar table (server:remote).
+REMOTE_TRACE_BACKEND_URL=
+REMOTE_TRACE_BASIC_AUTH_USER=
+REMOTE_TRACE_BASIC_AUTH_PASSWORD=
 
 # E2E tests
 E2E_BASE_URL=http://localhost:3000

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -3,13 +3,6 @@ ARG grafana_version=12.3.0@sha256:96a793a92c9a77cf543d6e5c55100cd296ed9e22487dc3
 
 FROM grafana/${grafana_image}:${grafana_version}
 
-ARG backendUrl
-ARG basicAuthUser
-ARG basicAuthPassword
-ARG traceBackendUrl
-ARG traceBasicAuthUser
-ARG traceBasicAuthPassword
-
 # Make it as simple as possible to access the grafana instance for development purposes
 # Do NOT enable these settings in a public facing / production grafana instance
 ENV GF_AUTH_ANONYMOUS_ORG_ROLE="Admin"
@@ -18,16 +11,6 @@ ENV GF_AUTH_BASIC_ENABLED="false"
 # Set development mode so plugins can be loaded without the need to sign
 ENV GF_DEFAULT_APP_MODE="development"
 
-# Credentials for fecthing remote profile data
-ENV REMOTE_BACKEND_URL=$backendUrl
-ENV REMOTE_BASIC_AUTH_USER=$basicAuthUser
-ENV REMOTE_BASIC_AUTH_PASSWORD=$basicAuthPassword
-
-# Credentials for the remote Tempo datasource (span profiles -> traces)
-ENV REMOTE_TRACE_BACKEND_URL=$traceBackendUrl
-ENV REMOTE_TRACE_BASIC_AUTH_USER=$traceBasicAuthUser
-ENV REMOTE_TRACE_BASIC_AUTH_PASSWORD=$traceBasicAuthPassword
-
 USER root
 
 # Install grafana-llm-app into the image (it is required by the provisioning below).
@@ -35,12 +18,3 @@ USER root
 # disables GF_INSTALL_PLUGINS, so install it here instead. It lives outside the mounted
 # plugin dir and is left untouched by the disabled preinstall.
 RUN grafana cli --pluginsDir "/var/lib/grafana/plugins" plugins install grafana-llm-app
-
-# This ensures that the basicAuthUser value is a string and not a number
-# which would make the requests to the backend fail
-COPY ./samples/provisioning-remote/plugins/app.yaml  /etc/grafana/provisioning/plugins
-RUN sed -i "s/\$REMOTE_BASIC_AUTH_USER/'$REMOTE_BASIC_AUTH_USER'/g" /etc/grafana/provisioning/plugins/app.yaml
-
-COPY ./samples/provisioning-remote/datasources/datasources.yaml  /etc/grafana/provisioning/datasources
-RUN sed -i "s/\$REMOTE_BASIC_AUTH_USER/'$REMOTE_BASIC_AUTH_USER'/g" /etc/grafana/provisioning/datasources/datasources.yaml
-

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -6,6 +6,9 @@ FROM grafana/${grafana_image}:${grafana_version}
 ARG backendUrl
 ARG basicAuthUser
 ARG basicAuthPassword
+ARG traceBackendUrl
+ARG traceBasicAuthUser
+ARG traceBasicAuthPassword
 
 # Make it as simple as possible to access the grafana instance for development purposes
 # Do NOT enable these settings in a public facing / production grafana instance
@@ -20,7 +23,18 @@ ENV REMOTE_BACKEND_URL=$backendUrl
 ENV REMOTE_BASIC_AUTH_USER=$basicAuthUser
 ENV REMOTE_BASIC_AUTH_PASSWORD=$basicAuthPassword
 
+# Credentials for the remote Tempo datasource (span profiles -> traces)
+ENV REMOTE_TRACE_BACKEND_URL=$traceBackendUrl
+ENV REMOTE_TRACE_BASIC_AUTH_USER=$traceBasicAuthUser
+ENV REMOTE_TRACE_BASIC_AUTH_PASSWORD=$traceBasicAuthPassword
+
 USER root
+
+# Install grafana-llm-app into the image (it is required by the provisioning below).
+# Preinstall is disabled at runtime to protect the pyroscope ./dist bind mount, which also
+# disables GF_INSTALL_PLUGINS, so install it here instead. It lives outside the mounted
+# plugin dir and is left untouched by the disabled preinstall.
+RUN grafana cli --pluginsDir "/var/lib/grafana/plugins" plugins install grafana-llm-app
 
 # This ensures that the basicAuthUser value is a string and not a number
 # which would make the requests to the backend fail

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -14,9 +14,13 @@ services:
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
       GF_INSTALL_PLUGINS: grafana-llm-app
+      # Grafana 12.3+ preinstalls & auto-updates grafana-pyroscope-app from the catalog,
+      # which deletes the ./dist bind mount used for local development. Disable preinstall
+      # so the mounted dev build is used.
+      GF_PLUGINS_PREINSTALL_DISABLED: 'true'
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
-      GF_FEATURE_TOGGLES_ENABLE: localizationForPlugins
+      GF_FEATURE_TOGGLES_ENABLE: ${GF_FEATURE_TOGGLES_ENABLE:-localizationForPlugins}
 
   qdrant:
     image: qdrant/qdrant:v1.17.0@sha256:f1c7272cdac52b38c1a0e89313922d940ba50afd90d593a1605dbbc214e66ffb

--- a/docker-compose.remote.yaml
+++ b/docker-compose.remote.yaml
@@ -9,15 +9,22 @@ services:
         backendUrl: ${REMOTE_BACKEND_URL}
         basicAuthUser: ${REMOTE_BASIC_AUTH_USER}
         basicAuthPassword: ${REMOTE_BASIC_AUTH_PASSWORD}
+        traceBackendUrl: ${REMOTE_TRACE_BACKEND_URL}
+        traceBasicAuthUser: ${REMOTE_TRACE_BASIC_AUTH_USER}
+        traceBasicAuthPassword: ${REMOTE_TRACE_BASIC_AUTH_PASSWORD}
     ports:
-      - 3000:3000/tcp
+      - ${GRAFANA_PORT:-3000}:3000/tcp
     volumes:
       - ./dist:/var/lib/grafana/plugins/grafana-pyroscope-app
     environment:
       GF_INSTALL_PLUGINS: grafana-llm-app
+      # Grafana 12.3+ preinstalls & auto-updates grafana-pyroscope-app from the catalog,
+      # which deletes the ./dist bind mount used for local development. Disable preinstall
+      # so the mounted dev build is used.
+      GF_PLUGINS_PREINSTALL_DISABLED: 'true'
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
-      GF_FEATURE_TOGGLES_ENABLE: localizationForPlugins
+      GF_FEATURE_TOGGLES_ENABLE: ${GF_FEATURE_TOGGLES_ENABLE:-localizationForPlugins}
 
   qdrant:
     image: qdrant/qdrant:v1.17.0@sha256:f1c7272cdac52b38c1a0e89313922d940ba50afd90d593a1605dbbc214e66ffb

--- a/docker-compose.remote.yaml
+++ b/docker-compose.remote.yaml
@@ -6,16 +6,11 @@ services:
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-12.3.0@sha256:96a793a92c9a77cf543d6e5c55100cd296ed9e22487dc3d069331364c456247b}
-        backendUrl: ${REMOTE_BACKEND_URL}
-        basicAuthUser: ${REMOTE_BASIC_AUTH_USER}
-        basicAuthPassword: ${REMOTE_BASIC_AUTH_PASSWORD}
-        traceBackendUrl: ${REMOTE_TRACE_BACKEND_URL}
-        traceBasicAuthUser: ${REMOTE_TRACE_BASIC_AUTH_USER}
-        traceBasicAuthPassword: ${REMOTE_TRACE_BASIC_AUTH_PASSWORD}
     ports:
       - ${GRAFANA_PORT:-3000}:3000/tcp
     volumes:
       - ./dist:/var/lib/grafana/plugins/grafana-pyroscope-app
+      - ./samples/provisioning-remote:/etc/grafana/provisioning
     environment:
       GF_INSTALL_PLUGINS: grafana-llm-app
       # Grafana 12.3+ preinstalls & auto-updates grafana-pyroscope-app from the catalog,
@@ -25,6 +20,7 @@ services:
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
       GF_FEATURE_TOGGLES_ENABLE: ${GF_FEATURE_TOGGLES_ENABLE:-localizationForPlugins}
+    env_file: ".env"
 
   qdrant:
     image: qdrant/qdrant:v1.17.0@sha256:f1c7272cdac52b38c1a0e89313922d940ba50afd90d593a1605dbbc214e66ffb

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,10 @@ services:
       - ./samples/dashboards:/var/lib/grafana/dashboards
     environment:
       GF_INSTALL_PLUGINS: grafana-llm-app
+      # Grafana 12.3+ preinstalls & auto-updates grafana-pyroscope-app from the catalog,
+      # which deletes the ./dist bind mount used for local development. Disable preinstall
+      # so the mounted dev build is used.
+      GF_PLUGINS_PREINSTALL_DISABLED: 'true'
       OPENAI_API_KEY: $OPENAI_API_KEY
       OPENAI_ORGANIZATION_ID: $OPENAI_ORGANIZATION_ID
       GF_FEATURE_TOGGLES_ENABLE: ${GF_FEATURE_TOGGLES_ENABLE:-metricsFromProfiles,localizationForPlugins}

--- a/samples/provisioning-remote/datasources/datasources.yaml
+++ b/samples/provisioning-remote/datasources/datasources.yaml
@@ -4,22 +4,22 @@ datasources:
   - uid: grafanacloud-profiles-dev
     type: grafana-pyroscope-datasource
     name: Dev (profiles-dev-001)
-    url: $REMOTE_BACKEND_URL
+    url: ${REMOTE_BACKEND_URL}
     isDefault: true
     jsonData:
       keepCookies: [pyroscope_git_session]
     basicAuth: true
     # 1. our plugin backend expects a string
     # 2. this value must match the one in samples/provisioning/plugins/app.yaml
-    basicAuthUser: $REMOTE_BASIC_AUTH_USER
+    basicAuthUser: ${REMOTE_BASIC_AUTH_USER}
     secureJsonData:
-      basicAuthPassword: $REMOTE_BASIC_AUTH_PASSWORD
+      basicAuthPassword: ${REMOTE_BASIC_AUTH_PASSWORD}
   - uid: grafanacloud-tempo-dev
     type: tempo
     name: Dev (tempo-dev-01)
-    url: $REMOTE_TRACE_BACKEND_URL
+    url: ${REMOTE_TRACE_BACKEND_URL}
     basicAuth: true
-    basicAuthUser: $REMOTE_TRACE_BASIC_AUTH_USER
+    basicAuthUser: ${REMOTE_TRACE_BASIC_AUTH_USER}
     jsonData:
       streamingEnabled:
         search: true
@@ -27,4 +27,4 @@ datasources:
         datasourceUid: grafanacloud-profiles-dev
         profileTypeId: process_cpu:cpu:nanoseconds:cpu:nanoseconds
     secureJsonData:
-      basicAuthPassword: $REMOTE_TRACE_BASIC_AUTH_PASSWORD
+      basicAuthPassword: ${REMOTE_TRACE_BASIC_AUTH_PASSWORD}

--- a/samples/provisioning-remote/datasources/datasources.yaml
+++ b/samples/provisioning-remote/datasources/datasources.yaml
@@ -14,3 +14,17 @@ datasources:
     basicAuthUser: $REMOTE_BASIC_AUTH_USER
     secureJsonData:
       basicAuthPassword: $REMOTE_BASIC_AUTH_PASSWORD
+  - uid: grafanacloud-tempo-dev
+    type: tempo
+    name: Dev (tempo-dev-01)
+    url: $REMOTE_TRACE_BACKEND_URL
+    basicAuth: true
+    basicAuthUser: $REMOTE_TRACE_BASIC_AUTH_USER
+    jsonData:
+      streamingEnabled:
+        search: true
+      tracesToProfiles:
+        datasourceUid: grafanacloud-profiles-dev
+        profileTypeId: process_cpu:cpu:nanoseconds:cpu:nanoseconds
+    secureJsonData:
+      basicAuthPassword: $REMOTE_TRACE_BASIC_AUTH_PASSWORD


### PR DESCRIPTION
## Summary 📝

- Provisions the `grafana-llm-app` and a remote Tempo datasource for the `server:remote` dev environment, wiring span-profiles-to-traces so the span exemplar table's "Tempo datasource" picker works against remote data.
- Adds `GF_PLUGINS_PREINSTALL_DISABLED=true` across all docker-compose files so Grafana 12.3+ no longer overwrites the `./dist` bind mount with the catalog build of `grafana-pyroscope-app`, and installs `grafana-llm-app` directly in `Dockerfile.remote` (since disabling preinstall also disables `GF_INSTALL_PLUGINS`).
- Enables the span profiles heatmap feature toggles via a configurable `GF_FEATURE_TOGGLES_ENABLE` env var and makes the remote Grafana port overridable with `GRAFANA_PORT`.

## Test 🧪

- [x] Ran `server:remote` with `REMOTE_TRACE_*` credentials set and confirmed the "Dev (tempo-dev-01)" Tempo datasource is provisioned and selectable in the span exemplar table
- [x] Verified the mounted `./dist` build of `grafana-pyroscope-app` is used (not overwritten) with `GF_PLUGINS_PREINSTALL_DISABLED=true` on Grafana 12.3+
- [x] Confirmed `grafana-llm-app` is installed in the remote image and the profiles heatmap renders with the enabled feature toggles
