### PR TITLE
fix: avoid checking LLM plugin status when grafana-llm-app is not installed

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@ export const PYROSCOPE_APP_ID = plugin.id;
 export const PLUGIN_BASE_URL = `/a/${PYROSCOPE_APP_ID}`;
 export const PLUGIN_API_URL = `/api/plugin-proxy/${PYROSCOPE_APP_ID}`;
 
+export const GRAFANA_LLM_APP_ID = 'grafana-llm-app';
+
 export enum ROUTES {
   EXPLORE = '/explore',
   ADHOC = '/ad-hoc',

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/infrastructure/__tests__/useFetchLlmPluginStatus.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/infrastructure/__tests__/useFetchLlmPluginStatus.spec.ts
@@ -1,0 +1,145 @@
+import { isAppPluginInstalled } from '@grafana/runtime';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { useFetchLlmPluginStatus } from '../useFetchLlmPluginStatus';
+
+const mockGet = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  isAppPluginInstalled: jest.fn(),
+  getBackendSrv: () => ({
+    get: (...args: unknown[]) => mockGet(...args),
+  }),
+}));
+
+jest.mock('@shared/infrastructure/tracking/logger');
+
+class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  Wrapper.displayName = 'TestQueryClientWrapper';
+  return Wrapper;
+};
+
+describe('useFetchLlmPluginStatus()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isAppPluginInstalled as jest.Mock).mockResolvedValue(false);
+  });
+
+  describe('when the Grafana LLM app is not installed', () => {
+    it('does not call the settings endpoint and returns isEnabled=false', async () => {
+      const { result } = renderHook(() => useFetchLlmPluginStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(mockGet).not.toHaveBeenCalled();
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.error).toBeFalsy();
+    });
+  });
+
+  describe('when the Grafana LLM app is installed', () => {
+    beforeEach(() => {
+      (isAppPluginInstalled as jest.Mock).mockResolvedValue(true);
+    });
+
+    it('returns isEnabled=true when settings.enabled and the health check reports a configured, ok provider', async () => {
+      mockGet.mockResolvedValueOnce({ enabled: true }).mockResolvedValueOnce({
+        details: { llmProvider: { configured: true, ok: true } },
+      });
+
+      const { result } = renderHook(() => useFetchLlmPluginStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isEnabled).toBe(true);
+      });
+
+      expect(mockGet).toHaveBeenCalledWith(
+        '/api/plugins/grafana-llm-app/settings',
+        undefined,
+        undefined,
+        expect.objectContaining({ showErrorAlert: false, showSuccessAlert: false })
+      );
+    });
+
+    it('returns isEnabled=false without calling the health endpoint when settings.enabled is false', async () => {
+      mockGet.mockResolvedValueOnce({ enabled: false });
+
+      const { result } = renderHook(() => useFetchLlmPluginStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(result.current.isEnabled).toBe(false);
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns isEnabled=false when the health check reports the provider is not configured/ok', async () => {
+      mockGet.mockResolvedValueOnce({ enabled: true }).mockResolvedValueOnce({
+        details: { llmProvider: { configured: false, ok: false } },
+      });
+
+      const { result } = renderHook(() => useFetchLlmPluginStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(result.current.isEnabled).toBe(false);
+    });
+
+    it('returns isEnabled=false, without an error or toast, when the settings endpoint returns a 403 (Access Denied)', async () => {
+      mockGet.mockRejectedValueOnce(new HttpError(403, 'Access Denied'));
+
+      const { result } = renderHook(() => useFetchLlmPluginStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.error).toBeFalsy();
+      expect(mockGet).toHaveBeenCalledWith(
+        '/api/plugins/grafana-llm-app/settings',
+        undefined,
+        undefined,
+        expect.objectContaining({ showErrorAlert: false, showSuccessAlert: false })
+      );
+    });
+
+    it('returns isEnabled=false when the settings endpoint is unreachable (plugin not installed server-side)', async () => {
+      mockGet.mockRejectedValueOnce(new Error('not found'));
+
+      const { result } = renderHook(() => useFetchLlmPluginStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(result.current.isEnabled).toBe(false);
+      expect(result.current.error).toBeFalsy();
+    });
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/infrastructure/useFetchLlmPluginStatus.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneAiPanel/components/AiButton/infrastructure/useFetchLlmPluginStatus.ts
@@ -1,11 +1,57 @@
-import { openai } from '@grafana/llm';
+import { getBackendSrv, isAppPluginInstalled } from '@grafana/runtime';
 import { logger } from '@shared/infrastructure/tracking/logger';
 import { useQuery } from '@tanstack/react-query';
+import { GRAFANA_LLM_APP_ID } from 'src/constants';
+
+const LLM_PLUGIN_ROUTE = `/api/plugins/${GRAFANA_LLM_APP_ID}`;
+
+// Request options shared across the calls below to prevent `getBackendSrv()` from surfacing a
+// non-actionable toast notification, e.g. "Access Denied" when the user lacks permission to read
+// the plugin settings (a 403 from `/settings`), similar in spirit to issue #757.
+const SILENT_REQUEST_OPTIONS = { showSuccessAlert: false, showErrorAlert: false };
+
+type LlmProviderHealth = { configured: boolean; ok: boolean };
+
+/**
+ * Mirrors `openai.enabled()` from `@grafana/llm`, but suppresses error toasts so that a 403
+ * ("Access Denied") response from `/settings` (e.g. missing RBAC permission) is treated the same
+ * as the LLM plugin being disabled, instead of flashing a non-actionable pop-up.
+ */
+async function isLlmPluginEnabled(): Promise<boolean> {
+  const isLlmAppInstalled = await isAppPluginInstalled(GRAFANA_LLM_APP_ID);
+
+  if (!isLlmAppInstalled) {
+    return false;
+  }
+
+  try {
+    const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
+      ...SILENT_REQUEST_OPTIONS,
+    });
+
+    if (!settings?.enabled) {
+      return false;
+    }
+
+    const health = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/health`, undefined, undefined, {
+      ...SILENT_REQUEST_OPTIONS,
+    });
+
+    const details = health?.details;
+    const provider: LlmProviderHealth | undefined = details?.llmProvider ?? details?.openAI;
+
+    return Boolean(provider?.configured && provider?.ok);
+  } catch {
+    // Expected if the plugin is not installed, the settings/health checks fail, or the user is
+    // not allowed to read the plugin settings (403 "Access Denied").
+    return false;
+  }
+}
 
 export function useFetchLlmPluginStatus() {
   const { data, isFetching, error } = useQuery({
     queryKey: ['llm'],
-    queryFn: () => openai.enabled(),
+    queryFn: isLlmPluginEnabled,
   });
 
   if (error) {


### PR DESCRIPTION
### ✨ Description

Fixes: #757

`useFetchLlmPluginStatus()` called `openai.enabled()`, which shows non-actionable pop-ups when `grafana-llm-app` isn't installed, or when `/settings` returns 403 "Access Denied" (missing RBAC permission).

- Only checks LLM status when the plugin is installed, via `isAppPluginInstalled()` (replaces deprecated `config.apps`).
- Probes settings/health directly with alerts suppressed, so a 403 is treated as "not enabled" silently instead of showing a toast.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

- Without `grafana-llm-app` installed, or with it installed but `/settings` returning 403: open the flame graph — no pop-up, AI button shows disabled.
- `pnpm exec jest .../useFetchLlmPluginStatus.spec.ts`