### PR TITLE
fix: show persistent settings-fetch error only on settings page

### DIFF
--- a/src/locales/en-US/grafana-pyroscope-app.json
+++ b/src/locales/en-US/grafana-pyroscope-app.json
@@ -138,10 +138,6 @@
       "label": "Comparison presets",
       "placeholder": "Choose a preset"
     },
-    "settings-error": {
-      "message": "Some features might not work as expected (e.g. flamegraph export options). Please try to reload the page, sorry for the inconvenience.",
-      "title": "Error while retrieving the plugin settings!"
-    },
     "title": "Diff flame graph for {{serviceName}} ({{profileMetricType}})"
   },
   "error-page": {
@@ -217,10 +213,6 @@
       "name": "Profile id",
       "remove": "Remove profile id selector from query",
       "tooltip": "You have added a profile id selector to the flamegraph query ({{profileIdSelector}})."
-    },
-    "settings-error": {
-      "message": "Some features might not work as expected (e.g. collapsed flame graphs). Please try to reload the page, sorry for the inconvenience.",
-      "title": "Error while retrieving the plugin settings!"
     },
     "span-selector": {
       "filter-label": "Filter label",
@@ -658,7 +650,9 @@
         "tooltip": "The function details feature enables mapping of resource usage to lines of source code. If the GitHub integration is configured, then the source code will be downloaded from GitHub."
       },
       "fetch-error": {
-        "message": "Please try to reload the page, sorry for the inconvenience.",
+        "cloud-hint": "On Grafana Cloud, check with your organization administrator that you have permission to read and write plugin settings for this data source.",
+        "message": "The settings below show default values instead of what was previously saved. What you can do:",
+        "oss-hint": "With Grafana Pyroscope OSS, make sure the data source URL exposes the tenant-settings endpoint.",
         "title": "Error while retrieving the plugin settings!"
       },
       "flame-graph": {

--- a/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreDiffFlameGraph/components/SceneDiffFlameGraph/SceneDiffFlameGraph.tsx
@@ -4,7 +4,6 @@ import { t, Trans } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Spinner, useStyles2 } from '@grafana/ui';
 import { FlameGraph } from '@shared/components/FlameGraph/FlameGraph';
-import { displayWarning } from '@shared/domain/displayStatus';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import { useToggleSidePanel } from '@shared/domain/useToggleSidePanel';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
@@ -65,7 +64,7 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
     const baselineQuery = useBuildPyroscopeQuery(this, 'filtersBaseline');
     const comparisonQuery = useBuildPyroscopeQuery(this, 'filtersComparison');
 
-    const { settings, error: fetchSettingsError } = useFetchPluginSettings();
+    const { settings } = useFetchPluginSettings();
 
     const dataSourceUid = sceneGraph.findByKeyAndType(this, 'dataSource', ProfilesDataSourceVariable).useState()
       .value as string;
@@ -112,7 +111,6 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
         hasMissingSelections,
         profile: profile as FlamebearerProfile,
         settings,
-        fetchSettingsError,
         ai: {
           panel: aiPanel,
           fetchParams: [
@@ -150,16 +148,6 @@ export class SceneDiffFlameGraph extends SceneObjectBase<SceneDiffFlameGraphStat
         sidePanel.close();
       }
     }, [isAiButtonDisabled, sidePanel]);
-
-    if (data.fetchSettingsError) {
-      displayWarning([
-        t('diff-flame-graph.settings-error.title', 'Error while retrieving the plugin settings!'),
-        t(
-          'diff-flame-graph.settings-error.message',
-          'Some features might not work as expected (e.g. flamegraph export options). Please try to reload the page, sorry for the inconvenience.'
-        ),
-      ]);
-    }
 
     const panelTitle = useMemo(
       () => (

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceFlameGraph/SceneFlameGraph.tsx
@@ -10,7 +10,6 @@ import {
   SceneTimeRange,
 } from '@grafana/scenes';
 import { Spinner, useStyles2, useTheme2 } from '@grafana/ui';
-import { displayWarning } from '@shared/domain/displayStatus';
 import { useMaxNodesFromUrl } from '@shared/domain/url-params/useMaxNodesFromUrl';
 import { useToggleSidePanel } from '@shared/domain/useToggleSidePanel';
 import {
@@ -122,19 +121,9 @@ export class SceneFlameGraph extends SceneObjectBase<SceneFlameGraphState> {
     const getTheme = useMemo(() => () => createTheme({ colors: { mode: isLight ? 'light' : 'dark' } }), [isLight]);
 
     const [maxNodes] = useMaxNodesFromUrl();
-    const { settings, error: isFetchingSettingsError } = useFetchPluginSettings();
+    const { settings } = useFetchPluginSettings();
     const { $timeRange, $data, lastTimeRange, exportMenu, aiPanel, functionDetailsPanel, createRecordingRuleModal } =
       this.useState();
-
-    if (isFetchingSettingsError) {
-      displayWarning([
-        t('flame-graph.settings-error.title', 'Error while retrieving the plugin settings!'),
-        t(
-          'flame-graph.settings-error.message',
-          'Some features might not work as expected (e.g. collapsed flame graphs). Please try to reload the page, sorry for the inconvenience.'
-        ),
-      ]);
-    }
 
     useEffect(() => {
       const runner = buildFlameGraphQueryRunner({

--- a/src/pages/SettingsView/components/UISettingsView/UISettingsView.tsx
+++ b/src/pages/SettingsView/components/UISettingsView/UISettingsView.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Alert, FieldSet, InlineField, InlineFieldRow, InlineSwitch, Input, useStyles2 } from '@grafana/ui';
-import { displayError } from '@shared/domain/displayStatus';
 import { useFlagMetricsFromProfiles } from '@shared/infrastructure/featureFlags/featureFlags';
 import React from 'react';
 
@@ -13,13 +12,6 @@ export function UISettingsView({ children }: { children: React.ReactNode }) {
   const metricsFromProfiles = useFlagMetricsFromProfiles();
   const { data, actions } = useUISettingsView();
 
-  if (data.fetchError) {
-    displayError(data.fetchError, [
-      t('settings.ui.fetch-error.title', 'Error while retrieving the plugin settings!'),
-      t('settings.ui.fetch-error.message', 'Please try to reload the page, sorry for the inconvenience.'),
-    ]);
-  }
-
   function onSubmit(event: React.FormEvent) {
     event.preventDefault();
     actions.saveSettings();
@@ -27,6 +19,32 @@ export function UISettingsView({ children }: { children: React.ReactNode }) {
 
   return (
     <form className={styles.settingsForm} onSubmit={onSubmit}>
+      {data.fetchError && (
+        <Alert
+          severity="error"
+          title={t('settings.ui.fetch-error.title', 'Error while retrieving the plugin settings!')}
+          className={css({ maxWidth: '1000px' })}
+        >
+          <p>
+            <Trans i18nKey="settings.ui.fetch-error.message">
+              The settings below show default values instead of what was previously saved. What you can do:
+            </Trans>
+          </p>
+          <ul className={styles.fetchErrorList}>
+            <li>
+              <Trans i18nKey="settings.ui.fetch-error.cloud-hint">
+                On Grafana Cloud, check with your organization administrator that you have permission to read and
+                write plugin settings for this data source.
+              </Trans>
+            </li>
+            <li>
+              <Trans i18nKey="settings.ui.fetch-error.oss-hint">
+                With Grafana Pyroscope OSS, make sure the data source URL exposes the tenant-settings endpoint.
+              </Trans>
+            </li>
+          </ul>
+        </Alert>
+      )}
       <FieldSet label={t('settings.ui.flame-graph.label', 'Flame graph')} data-testid="flamegraph-settings">
         <InlineFieldRow>
           <InlineField label={t('settings.ui.collapsed-flame-graphs.label', 'Collapsed flame graphs')} labelWidth={24}>
@@ -136,6 +154,9 @@ export function UISettingsView({ children }: { children: React.ReactNode }) {
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  fetchErrorList: css`
+    margin: ${theme.spacing(0, 0, 1, 2)};
+  `,
   settingsForm: css`
     & > fieldset {
       border: 0 none;

--- a/src/shared/domain/url-params/useMaxNodesFromUrl.ts
+++ b/src/shared/domain/url-params/useMaxNodesFromUrl.ts
@@ -1,4 +1,3 @@
-import { displayWarning } from '@shared/domain/displayStatus';
 import { DEFAULT_SETTINGS } from '@shared/infrastructure/settings/PluginSettings';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
 import { logger } from '@shared/infrastructure/tracking/logger';
@@ -13,10 +12,6 @@ function useSetDefaultMaxNodes(hasMaxNodes: boolean, setMaxNodes: (newMaxNodes: 
   }
 
   if (error) {
-    displayWarning([
-      'Error while retrieving the plugin settings!',
-      'Some features might not work as expected (e.g. flame graph max nodes). Please try to reload the page, sorry for the inconvenience.',
-    ]);
     logger.error(error);
 
     setMaxNodes(DEFAULT_SETTINGS.maxNodes);


### PR DESCRIPTION
We currently show this not really actionable error toasts:

<img width="630" height="143" alt="image" src="https://github.com/user-attachments/assets/a7ad2ea0-9402-4cb5-82d1-d796dbd610b4" />

They mostly happens for OSS users, that point the datasource directly at the query-frontend rather than at a proxy that handles tenant-setttings.

I have decided to improve on this and only show those errors as part of the error page:

<img width="1197" height="614" alt="image" src="https://github.com/user-attachments/assets/bacd9757-22dc-4ae1-9496-1baffba3ef20" />
