### PR TITLE
fix: scope span trace lookups to visible page

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/SceneExemplarTable.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/SceneExemplarTable.tsx
@@ -3,7 +3,7 @@ import { DataSourceJsonData, getValueFormat, GrafanaTheme2 } from '@grafana/data
 import { t } from '@grafana/i18n';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { Column, Field as FormField, IconButton, InteractiveTable, Select, Spinner, useStyles2 } from '@grafana/ui';
+import { Column, Field as FormField, IconButton, InteractiveTable, Pagination, Select, Spinner, useStyles2 } from '@grafana/ui';
 import { getProfileMetric, ProfileMetricId } from '@shared/infrastructure/profile-metrics/getProfileMetric';
 import { reportInteraction } from '@shared/domain/reportInteraction';
 import React, { useMemo } from 'react';
@@ -17,10 +17,14 @@ import { PanelType } from '../SceneByVariableRepeaterGrid/components/ScenePanelT
 import { buildUnitFormatter } from '../SceneExploreServiceFlameGraph/components/SceneFunctionDetailsPanel/domain/buildUnitFormatter';
 import { CopyableId } from './components/CopyableId';
 import { getDisplayedExemplarRows } from './domain/getDisplayedExemplarRows';
+import { getVisiblePageRows, uniqueSpanTimestamps } from './domain/getVisiblePageSpans';
+import { SpanTimestamp } from './domain/mergeSpanTraceWindows';
 import { selectTempoDataSourceUid, TempoDataSourceOption } from './domain/selectTempoDataSourceUid';
 import { ExemplarRow } from './infrastructure/buildHeatmapDataFrames';
 import { lookupTempoTraceInfo, TraceInfo } from './infrastructure/lookupTempoTraceInfo';
 import { SceneExploreServiceHeatmap } from './SceneExploreServiceHeatmap';
+
+const PAGE_SIZE = 5;
 
 interface SceneExemplarTableState extends SceneObjectState {
   rows: ExemplarRow[];
@@ -28,6 +32,7 @@ interface SceneExemplarTableState extends SceneObjectState {
   loadingSpanIds: string[];
   tempoDatasources: TempoDataSourceOption[];
   traceLookupFailed: boolean;
+  page: number;
 }
 
 interface TempoDataSourceJsonData extends DataSourceJsonData {
@@ -51,6 +56,7 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
       loadingSpanIds: [],
       tempoDatasources: [],
       traceLookupFailed: false,
+      page: 0,
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
@@ -90,6 +96,11 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
     const parentSub = parent.subscribeToState((newState, prevState) => {
       if (newState.exemplarRows !== prevState.exemplarRows) {
         this.handleNewExemplarRows(newState.exemplarRows);
+        return;
+      }
+
+      if (newState.selectedSpanId !== prevState.selectedSpanId || newState.selectedTimestamp !== prevState.selectedTimestamp) {
+        this.setPage(0, true);
       }
     });
 
@@ -119,19 +130,44 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
 
   private handleNewExemplarRows(rows: ExemplarRow[]) {
     this.invalidateTraceInfo();
-    const spanIds = [...new Set(rows.filter((r) => r.spanId).map((r) => r.spanId!))];
-    this.setState({ rows, traceInfoBySpanId: {}, loadingSpanIds: [], traceLookupFailed: false });
-
-    const tempoDataSourceUid = this.getParent().state.tempoDataSourceUid;
-    if (tempoDataSourceUid) {
-      if (spanIds.length > 0) {
-        this.lookupTraceInfo(spanIds);
-      }
-    }
+    this.setState({ rows, traceInfoBySpanId: {}, loadingSpanIds: [], traceLookupFailed: false, page: 0 });
+    this.lookupVisibleSpans(rows, 0);
   }
 
   private invalidateTraceInfo() {
     this.traceLookupRequestId++;
+  }
+
+  /**
+   * Sets the current table page and looks up trace info only for the span IDs
+   * visible on that page, so Tempo lookups stay scoped to a handful of spans
+   * instead of every exemplar.
+   */
+  setPage(page: number, lookupVisibleSpans = false) {
+    if (page === this.state.page) {
+      if (lookupVisibleSpans) {
+        this.lookupVisibleSpans(this.state.rows, page);
+      }
+      return;
+    }
+
+    this.setState({ page });
+    this.lookupVisibleSpans(this.state.rows, page);
+  }
+
+  private lookupVisibleSpans(rows: ExemplarRow[], page: number) {
+    const parent = this.getParent();
+    const { selectedSpanId, selectedTimestamp } = parent.state;
+    const pageRows = getVisiblePageRows(rows, selectedSpanId, selectedTimestamp, page, PAGE_SIZE);
+    const visibleSpans = uniqueSpanTimestamps(pageRows);
+
+    const pendingSpans = visibleSpans.filter(
+      (span) => !(span.spanId in this.state.traceInfoBySpanId) && !this.state.loadingSpanIds.includes(span.spanId)
+    );
+
+    if (this.getParent().state.tempoDataSourceUid && pendingSpans.length > 0) {
+      this.lookupTraceInfo(pendingSpans);
+    }
   }
 
   setTempoDataSourceUid(tempoDataSourceUid?: string) {
@@ -142,31 +178,29 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
 
     this.invalidateTraceInfo();
 
-    const spanIds = [...new Set(this.state.rows.filter((row) => row.spanId).map((row) => row.spanId!))];
-
     this.setState({ traceInfoBySpanId: {}, loadingSpanIds: [], traceLookupFailed: false });
     parent.setTempoDataSourceUid(tempoDataSourceUid);
 
-    if (tempoDataSourceUid && spanIds.length > 0) {
-      this.lookupTraceInfo(spanIds);
+    if (tempoDataSourceUid) {
+      this.lookupVisibleSpans(this.state.rows, this.state.page);
     }
   }
 
-  lookupTraceInfo(spanIds: string[]) {
+  lookupTraceInfo(spans: SpanTimestamp[]) {
     const tempoDataSourceUid = this.getParent().state.tempoDataSourceUid;
-    if (!tempoDataSourceUid || spanIds.length === 0) {
+    if (!tempoDataSourceUid || spans.length === 0) {
       return;
     }
 
     const requestId = this.traceLookupRequestId;
     const requestTempoDataSourceUid = tempoDataSourceUid;
+    const spanIds = spans.map((span) => span.spanId);
 
     this.setState({ loadingSpanIds: [...this.state.loadingSpanIds, ...spanIds] });
 
     (async () => {
       try {
-        const timeRange = sceneGraph.getTimeRange(this).state.value;
-        const traceInfoBySpanId = await lookupTempoTraceInfo(tempoDataSourceUid, spanIds, timeRange);
+        const { traceInfoBySpanId, failed } = await lookupTempoTraceInfo(tempoDataSourceUid, spans);
 
         if (
           requestId !== this.traceLookupRequestId ||
@@ -178,11 +212,9 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
         this.setState({
           traceInfoBySpanId: { ...this.state.traceInfoBySpanId, ...traceInfoBySpanId },
           loadingSpanIds: this.state.loadingSpanIds.filter((id) => !spanIds.includes(id)),
-          traceLookupFailed: false,
+          traceLookupFailed: failed,
         });
       } catch {
-        const notFound = Object.fromEntries(spanIds.map((id) => [id, null]));
-
         if (
           requestId !== this.traceLookupRequestId ||
           requestTempoDataSourceUid !== this.getParent().state.tempoDataSourceUid
@@ -191,7 +223,6 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
         }
 
         this.setState({
-          traceInfoBySpanId: { ...this.state.traceInfoBySpanId, ...notFound },
           loadingSpanIds: this.state.loadingSpanIds.filter((id) => !spanIds.includes(id)),
           traceLookupFailed: true,
         });
@@ -246,7 +277,7 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
 
   static Component({ model }: SceneComponentProps<SceneExemplarTable>) {
     const styles = useStyles2(getStyles);
-    const { rows, traceInfoBySpanId, loadingSpanIds, tempoDatasources, traceLookupFailed } = model.useState();
+    const { rows, traceInfoBySpanId, loadingSpanIds, tempoDatasources, traceLookupFailed, page } = model.useState();
 
     let selectedSpanId: string | undefined;
     let selectedTimestamp: number | undefined;
@@ -268,6 +299,12 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
     const displayedRows = useMemo(
       () => getDisplayedExemplarRows(rows, selectedSpanId, selectedTimestamp),
       [rows, selectedSpanId, selectedTimestamp]
+    );
+    const numberOfPages = Math.max(1, Math.ceil(displayedRows.length / PAGE_SIZE));
+    const safePage = Math.min(page, numberOfPages - 1);
+    const pageRows = useMemo(
+      () => getVisiblePageRows(rows, selectedSpanId, selectedTimestamp, safePage, PAGE_SIZE),
+      [rows, selectedSpanId, selectedTimestamp, safePage]
     );
     const columns = useMemo<Array<Column<ExemplarRow>>>(() => {
       const getRow = (props: { row: { original: ExemplarRow } }) => props.row.original;
@@ -461,14 +498,22 @@ export class SceneExemplarTable extends SceneObjectBase<SceneExemplarTableState>
             {t('heatmap.exemplar-table.empty', 'No span exemplars in the selected time range.')}
           </div>
         ) : (
-          <InteractiveTable
-            className={selectedSpanId ? styles.selectedTable : styles.table}
-            columns={columns}
-            data={displayedRows}
-            pageSize={5}
-            autoResetPage
-            getRowId={(row) => `${row.profileId}-${row.spanId ?? 'no-span'}-${row.timestamp}`}
-          />
+          <>
+            <InteractiveTable
+              className={selectedSpanId ? styles.selectedTable : styles.table}
+              columns={columns}
+              data={pageRows}
+              getRowId={(row) => `${row.profileId}-${row.spanId ?? 'no-span'}-${row.timestamp}`}
+            />
+            <div className={styles.pagination}>
+              <Pagination
+                currentPage={safePage + 1}
+                numberOfPages={numberOfPages}
+                onNavigate={(toPage) => model.setPage(toPage - 1)}
+                hideWhenSinglePage
+              />
+            </div>
+          </>
         )}
       </div>
     );
@@ -541,5 +586,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     text-align: center;
     color: ${theme.colors.text.secondary};
     font-style: italic;
+  `,
+  pagination: css`
+    display: flex;
+    justify-content: center;
+    padding: ${theme.spacing(1)};
+    flex-shrink: 0;
   `,
 });

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/__tests__/getVisiblePageSpans.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/__tests__/getVisiblePageSpans.spec.ts
@@ -1,0 +1,64 @@
+import { ExemplarRow } from '../../infrastructure/buildHeatmapDataFrames';
+import { getVisiblePageRows, uniqueSpanTimestamps } from '../getVisiblePageSpans';
+
+function buildRow(profileId: string, spanId: string | undefined, timestamp: number): ExemplarRow {
+  return { profileId, spanId, timestamp, value: 1 };
+}
+
+const rows: ExemplarRow[] = [
+  buildRow('profile-1', 'span-a', 1),
+  buildRow('profile-2', 'span-b', 2),
+  buildRow('profile-3', 'span-c', 3),
+  buildRow('profile-4', 'span-d', 4),
+  buildRow('profile-5', 'span-e', 5),
+  buildRow('profile-6', 'span-f', 6),
+];
+
+describe('getVisiblePageRows', () => {
+  it('returns only the rows for the requested page', () => {
+    expect(getVisiblePageRows(rows, undefined, undefined, 0, 5)).toEqual(rows.slice(0, 5));
+    expect(getVisiblePageRows(rows, undefined, undefined, 1, 5)).toEqual(rows.slice(5, 6));
+  });
+
+  it('returns an empty array for a page past the end of the data', () => {
+    expect(getVisiblePageRows(rows, undefined, undefined, 2, 5)).toEqual([]);
+  });
+
+  it('applies the span selection filter before paginating', () => {
+    const selectedRows: ExemplarRow[] = [
+      buildRow('profile-1', 'span-a', 1),
+      buildRow('profile-2', 'span-a', 2),
+      buildRow('profile-3', 'span-b', 3),
+    ];
+
+    expect(getVisiblePageRows(selectedRows, 'span-a', undefined, 0, 5)).toEqual([
+      buildRow('profile-1', 'span-a', 1),
+      buildRow('profile-2', 'span-a', 2),
+    ]);
+  });
+});
+
+describe('uniqueSpanTimestamps', () => {
+  it('returns one entry per unique span ID, keeping the first timestamp seen', () => {
+    const withDuplicates: ExemplarRow[] = [
+      buildRow('profile-1', 'span-a', 1),
+      buildRow('profile-2', 'span-a', 2),
+      buildRow('profile-3', 'span-b', 3),
+    ];
+
+    expect(uniqueSpanTimestamps(withDuplicates)).toEqual([
+      { spanId: 'span-a', timestamp: 1 },
+      { spanId: 'span-b', timestamp: 3 },
+    ]);
+  });
+
+  it('ignores rows without a span ID', () => {
+    const withoutSpan: ExemplarRow[] = [buildRow('profile-1', undefined, 1)];
+
+    expect(uniqueSpanTimestamps(withoutSpan)).toEqual([]);
+  });
+
+  it('returns an empty array for no rows', () => {
+    expect(uniqueSpanTimestamps([])).toEqual([]);
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/__tests__/mergeSpanTraceWindows.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/__tests__/mergeSpanTraceWindows.spec.ts
@@ -1,0 +1,101 @@
+import { mergeSpanTraceWindows } from '../mergeSpanTraceWindows';
+
+describe('mergeSpanTraceWindows', () => {
+  it('creates one window per span padded by the given duration', () => {
+    const result = mergeSpanTraceWindows([{ spanId: 'span-a', timestamp: 1_000_000 }], 30_000, 30_000);
+
+    expect(result).toEqual([{ spanIds: ['span-a'], from: 970_000, to: 1_030_000 }]);
+  });
+
+  it('uses a five-minute lookback and a 30-second lookahead by default', () => {
+    const result = mergeSpanTraceWindows([{ spanId: 'span-a', timestamp: 1_000_000 }]);
+
+    expect(result).toEqual([{ spanIds: ['span-a'], from: 700_000, to: 1_030_000 }]);
+  });
+
+  it('merges spans whose padded windows overlap', () => {
+    const result = mergeSpanTraceWindows(
+      [
+        { spanId: 'span-a', timestamp: 1_000_000 },
+        { spanId: 'span-b', timestamp: 1_020_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual([{ spanIds: ['span-a', 'span-b'], from: 970_000, to: 1_050_000 }]);
+  });
+
+  it('merges spans whose padded windows only touch at the boundary', () => {
+    const result = mergeSpanTraceWindows(
+      [
+        { spanId: 'span-a', timestamp: 1_000_000 },
+        { spanId: 'span-b', timestamp: 1_060_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual([{ spanIds: ['span-a', 'span-b'], from: 970_000, to: 1_090_000 }]);
+  });
+
+  it('keeps spans separate when their padded windows do not overlap', () => {
+    const result = mergeSpanTraceWindows(
+      [
+        { spanId: 'span-a', timestamp: 1_000_000 },
+        { spanId: 'span-b', timestamp: 1_100_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual([
+      { spanIds: ['span-a'], from: 970_000, to: 1_030_000 },
+      { spanIds: ['span-b'], from: 1_070_000, to: 1_130_000 },
+    ]);
+  });
+
+  it('chains merges across more than two overlapping spans', () => {
+    const result = mergeSpanTraceWindows(
+      [
+        { spanId: 'span-a', timestamp: 1_000_000 },
+        { spanId: 'span-b', timestamp: 1_020_000 },
+        { spanId: 'span-c', timestamp: 1_040_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual([{ spanIds: ['span-a', 'span-b', 'span-c'], from: 970_000, to: 1_070_000 }]);
+  });
+
+  it('sorts unordered input before merging', () => {
+    const result = mergeSpanTraceWindows(
+      [
+        { spanId: 'span-b', timestamp: 1_020_000 },
+        { spanId: 'span-a', timestamp: 1_000_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual([{ spanIds: ['span-a', 'span-b'], from: 970_000, to: 1_050_000 }]);
+  });
+
+  it('deduplicates repeated span IDs, keeping the first timestamp seen', () => {
+    const result = mergeSpanTraceWindows(
+      [
+        { spanId: 'span-a', timestamp: 1_000_000 },
+        { spanId: 'span-a', timestamp: 5_000_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual([{ spanIds: ['span-a'], from: 970_000, to: 1_030_000 }]);
+  });
+
+  it('returns an empty array for no spans', () => {
+    expect(mergeSpanTraceWindows([])).toEqual([]);
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/getVisiblePageSpans.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/getVisiblePageSpans.ts
@@ -1,0 +1,34 @@
+import { ExemplarRow } from '../infrastructure/buildHeatmapDataFrames';
+import { getDisplayedExemplarRows } from './getDisplayedExemplarRows';
+import { SpanTimestamp } from './mergeSpanTraceWindows';
+
+/**
+ * Returns the exemplar rows visible on the given table page, after applying the
+ * current span selection filter (if any).
+ */
+export function getVisiblePageRows(
+  rows: ExemplarRow[],
+  selectedSpanId: string | undefined,
+  selectedTimestamp: number | undefined,
+  page: number,
+  pageSize: number
+): ExemplarRow[] {
+  const displayedRows = getDisplayedExemplarRows(rows, selectedSpanId, selectedTimestamp);
+  return displayedRows.slice(page * pageSize, (page + 1) * pageSize);
+}
+
+/**
+ * Returns the first (spanId, timestamp) pair per unique span ID among the given
+ * rows, preserving row order. Used to scope Tempo trace lookups to only the
+ * spans currently visible in the table, deduplicating span IDs that appear at
+ * multiple exemplar timestamps.
+ */
+export function uniqueSpanTimestamps(rows: ExemplarRow[]): SpanTimestamp[] {
+  const timestampBySpanId = new Map<string, number>();
+  for (const row of rows) {
+    if (row.spanId && !timestampBySpanId.has(row.spanId)) {
+      timestampBySpanId.set(row.spanId, row.timestamp);
+    }
+  }
+  return [...timestampBySpanId.entries()].map(([spanId, timestamp]) => ({ spanId, timestamp }));
+}

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/mergeSpanTraceWindows.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/domain/mergeSpanTraceWindows.ts
@@ -1,0 +1,57 @@
+export interface SpanTimestamp {
+  spanId: string;
+  timestamp: number;
+}
+
+export interface SpanTraceWindow {
+  spanIds: string[];
+  from: number;
+  to: number;
+}
+
+// TraceQL filters by span start time, while an exemplar marks the profile sample
+// time. Use a longer lookback for spans that started before the sample window.
+export const TRACE_LOOKUP_PADDING_BEFORE_MS = 5 * 60_000;
+export const TRACE_LOOKUP_PADDING_AFTER_MS = 30_000;
+
+/**
+ * Groups span IDs into narrow, non-overlapping time windows so that Tempo trace
+ * lookups can be scoped to a tight range around each exemplar instead of the
+ * full dashboard time range.
+ *
+ * Each span gets a `[timestamp - paddingBeforeMs, timestamp + paddingAfterMs]`
+ * window. Spans whose windows overlap (or touch) are merged into a single group
+ * sharing one `from`/`to` range, so they can be queried together in one request.
+ */
+export function mergeSpanTraceWindows(
+  spans: SpanTimestamp[],
+  paddingBeforeMs = TRACE_LOOKUP_PADDING_BEFORE_MS,
+  paddingAfterMs = TRACE_LOOKUP_PADDING_AFTER_MS
+): SpanTraceWindow[] {
+  const firstTimestampBySpanId = new Map<string, number>();
+  for (const { spanId, timestamp } of spans) {
+    if (!firstTimestampBySpanId.has(spanId)) {
+      firstTimestampBySpanId.set(spanId, timestamp);
+    }
+  }
+
+  const uniqueSpans = [...firstTimestampBySpanId.entries()]
+    .map(([spanId, timestamp]) => ({ spanId, from: timestamp - paddingBeforeMs, to: timestamp + paddingAfterMs }))
+    .sort((a, b) => a.from - b.from);
+
+  const windows: SpanTraceWindow[] = [];
+
+  for (const span of uniqueSpans) {
+    const current = windows[windows.length - 1];
+
+    if (current && span.from <= current.to) {
+      current.spanIds.push(span.spanId);
+      current.to = Math.max(current.to, span.to);
+      continue;
+    }
+
+    windows.push({ spanIds: [span.spanId], from: span.from, to: span.to });
+  }
+
+  return windows;
+}

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/infrastructure/__tests__/lookupTempoTraceInfo.spec.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/infrastructure/__tests__/lookupTempoTraceInfo.spec.ts
@@ -1,0 +1,118 @@
+import { DataFrame, DataQuery, DataQueryRequest, DataQueryResponse, DataSourceApi } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+
+import { lookupTempoTraceInfo } from '../lookupTempoTraceInfo';
+
+interface TempoSpanQuery extends DataQuery {
+  query: string;
+}
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: jest.fn(),
+}));
+
+function buildSpanFrame(rows: Array<{ spanId: string; traceId: string; name?: string; duration?: number }>): DataFrame {
+  return {
+    fields: [
+      { name: 'traceIdHidden', values: rows.map((row) => row.traceId) },
+      { name: 'spanID', values: rows.map((row) => row.spanId) },
+      { name: 'name', values: rows.map((row) => row.name) },
+      { name: 'duration', values: rows.map((row) => row.duration) },
+    ],
+    length: rows.length,
+  } as unknown as DataFrame;
+}
+
+describe('lookupTempoTraceInfo', () => {
+  it('issues one request per merged time window, scoped to that window, and merges the results', async () => {
+    const query = jest.fn((request: DataQueryRequest<TempoSpanQuery>) => {
+      const target = request.targets[0];
+      let data: DataFrame[] = [];
+
+      if (target.query.includes('span-a') && target.query.includes('span-b')) {
+        data = [buildSpanFrame([{ spanId: 'span-a', traceId: 'trace-1' }, { spanId: 'span-b', traceId: 'trace-2' }])];
+      } else if (target.query.includes('span-c')) {
+        data = [buildSpanFrame([{ spanId: 'span-c', traceId: 'trace-3' }])];
+      }
+
+      return Promise.resolve({ data } as DataQueryResponse);
+    });
+
+    const dataSource = { query } as unknown as DataSourceApi;
+    (getDataSourceSrv as jest.Mock).mockReturnValue({ get: jest.fn().mockResolvedValue(dataSource) });
+
+    const result = await lookupTempoTraceInfo(
+      'tempo-uid',
+      [
+        { spanId: 'span-a', timestamp: 1_000_000 },
+        { spanId: 'span-b', timestamp: 1_020_000 },
+        { spanId: 'span-c', timestamp: 5_000_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(query).toHaveBeenCalledTimes(2);
+
+    const [firstRequest, secondRequest] = query.mock.calls.map(([request]) => request as DataQueryRequest<TempoSpanQuery>);
+
+    expect(firstRequest.targets[0].query).toBe('{span:id="span-a" || span:id="span-b"}');
+    expect(firstRequest.range.from.valueOf()).toBe(970_000);
+    expect(firstRequest.range.to.valueOf()).toBe(1_050_000);
+
+    expect(secondRequest.targets[0].query).toBe('{span:id="span-c"}');
+    expect(secondRequest.range.from.valueOf()).toBe(4_970_000);
+    expect(secondRequest.range.to.valueOf()).toBe(5_030_000);
+
+    expect(result).toEqual({
+      traceInfoBySpanId: {
+        'span-a': { traceId: 'trace-1', spanName: undefined, duration: undefined },
+        'span-b': { traceId: 'trace-2', spanName: undefined, duration: undefined },
+        'span-c': { traceId: 'trace-3', spanName: undefined, duration: undefined },
+      },
+      failed: false,
+    });
+  });
+
+  it('sets a span to null when no trace is found within its window', async () => {
+    const query = jest.fn().mockResolvedValue({ data: [] } as DataQueryResponse);
+    const dataSource = { query } as unknown as DataSourceApi;
+    (getDataSourceSrv as jest.Mock).mockReturnValue({ get: jest.fn().mockResolvedValue(dataSource) });
+
+    const result = await lookupTempoTraceInfo(
+      'tempo-uid',
+      [{ spanId: 'span-a', timestamp: 1_000_000 }],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual({ traceInfoBySpanId: { 'span-a': null }, failed: false });
+  });
+
+  it('keeps successful windows when another window fails', async () => {
+    const query = jest.fn((request: DataQueryRequest<TempoSpanQuery>) => {
+      if (request.targets[0].query.includes('span-a')) {
+        return Promise.resolve({ data: [buildSpanFrame([{ spanId: 'span-a', traceId: 'trace-1' }])] } as DataQueryResponse);
+      }
+      return Promise.reject(new Error('Tempo unavailable'));
+    });
+    const dataSource = { query } as unknown as DataSourceApi;
+    (getDataSourceSrv as jest.Mock).mockReturnValue({ get: jest.fn().mockResolvedValue(dataSource) });
+
+    const result = await lookupTempoTraceInfo(
+      'tempo-uid',
+      [
+        { spanId: 'span-a', timestamp: 1_000_000 },
+        { spanId: 'span-b', timestamp: 5_000_000 },
+      ],
+      30_000,
+      30_000
+    );
+
+    expect(result).toEqual({
+      traceInfoBySpanId: { 'span-a': { traceId: 'trace-1', spanName: undefined, duration: undefined } },
+      failed: true,
+    });
+  });
+});

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/infrastructure/lookupTempoTraceInfo.ts
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/infrastructure/lookupTempoTraceInfo.ts
@@ -1,11 +1,18 @@
-import { DataFrame, DataQuery, DataQueryRequest, DataQueryResponse, DataSourceApi, Field, TimeRange } from '@grafana/data';
+import { DataFrame, DataQuery, DataQueryRequest, DataQueryResponse, DataSourceApi, dateTime, Field } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { lastValueFrom, Observable } from 'rxjs';
+
+import { mergeSpanTraceWindows, SpanTimestamp } from '../domain/mergeSpanTraceWindows';
 
 export interface TraceInfo {
   traceId: string;
   spanName?: string;
   duration?: number;
+}
+
+export interface TraceLookupResult {
+  traceInfoBySpanId: Record<string, TraceInfo | null>;
+  failed: boolean;
 }
 
 interface TempoSpanQuery extends DataQuery {
@@ -15,15 +22,45 @@ interface TempoSpanQuery extends DataQuery {
   limit: number;
 }
 
+/**
+ * Looks up Tempo trace info for a small set of spans, scoping each request to a
+ * narrow asymmetric time window around the span's exemplar timestamp instead of
+ * the full dashboard time range. The window extends further backwards because
+ * TraceQL filters by a span's start time. Spans with overlapping windows are
+ * batched into a single request; spans far apart in time are queried independently.
+ */
 export async function lookupTempoTraceInfo(
   tempoDataSourceUid: string,
-  spanIds: string[],
-  timeRange: TimeRange
-): Promise<Record<string, TraceInfo | null>> {
-  const conditions = spanIds.map((id) => `span:id="${id}"`).join(' || ');
+  spans: SpanTimestamp[],
+  paddingBeforeMs?: number,
+  paddingAfterMs?: number
+): Promise<TraceLookupResult> {
   const dataSource: DataSourceApi = await getDataSourceSrv().get(tempoDataSourceUid);
+  const windows = mergeSpanTraceWindows(spans, paddingBeforeMs, paddingAfterMs);
+
+  const results = await Promise.allSettled(
+    windows.map((window) => queryTraceInfoForWindow(dataSource, tempoDataSourceUid, window))
+  );
+
+  const traceInfoBySpanId: Record<string, TraceInfo | null> = {};
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      Object.assign(traceInfoBySpanId, result.value);
+    }
+  }
+
+  return { traceInfoBySpanId, failed: results.some((result) => result.status === 'rejected') };
+}
+
+async function queryTraceInfoForWindow(
+  dataSource: DataSourceApi,
+  tempoDataSourceUid: string,
+  window: { spanIds: string[]; from: number; to: number }
+): Promise<Record<string, TraceInfo | null>> {
+  const { spanIds, from, to } = window;
+  const conditions = spanIds.map((id) => `span:id="${id}"`).join(' || ');
   const request: DataQueryRequest<TempoSpanQuery> = {
-    requestId: 'span-trace-lookup',
+    requestId: `span-trace-lookup-${from}-${to}`,
     targets: [
       {
         refId: 'A',
@@ -34,7 +71,11 @@ export async function lookupTempoTraceInfo(
         datasource: { type: 'tempo', uid: tempoDataSourceUid },
       },
     ],
-    range: timeRange,
+    range: {
+      from: dateTime(from),
+      to: dateTime(to),
+      raw: { from: dateTime(from), to: dateTime(to) },
+    },
     interval: '1s',
     intervalMs: 1000,
     maxDataPoints: spanIds.length,


### PR DESCRIPTION
### ✨ Description

Fixes: 
Related issue(s): 

Limits span-to-trace Tempo lookups to the visible exemplar table page. Uses merged asymmetric lookup windows with a five-minute lookback and 30-second lookahead, preserves successful windows when another fails, and retries failed spans.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/profiles-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm jest src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap`