### PR TITLE
fix: remove span heatmap hover header

### DIFF
--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/SceneExploreServiceHeatmap.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/SceneExploreServiceHeatmap.tsx
@@ -100,7 +100,7 @@ export class SceneExploreServiceHeatmap extends SceneObjectBase<SceneExploreServ
       body: new SceneFlexLayout({
         direction: 'column',
         children: [
-          new SceneFlexItem({ height: '400px', body: new SceneHeatmap({ embedded }) }),
+          new SceneFlexItem({ height: '400px', body: new SceneHeatmap() }),
           new SceneFlexItem({ minHeight: '200px', body: new SceneExemplarTable() }),
         ],
       }),

--- a/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/SceneHeatmap.tsx
+++ b/src/pages/ProfilesExplorerView/components/SceneExploreServiceHeatmap/SceneHeatmap.tsx
@@ -25,30 +25,25 @@ const EXEMPLAR_COLOR_DEFAULT = 'rgba(31, 120, 193, 0.7)';
 const EXEMPLAR_COLOR_SELECTED = 'rgba(255, 152, 0, 1)';
 
 export class SceneHeatmap extends SceneObjectBase<SceneHeatmapState> {
-  constructor({ embedded = false }: { embedded?: boolean } = {}) {
+  constructor() {
     super({
       key: 'scene-heatmap',
-      body: SceneHeatmap.buildPanel(embedded),
+      body: SceneHeatmap.buildPanel(),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));
   }
 
-  private static buildPanel(embedded = false): VizPanel {
-    let builder = PanelBuilders.heatmap()
+  private static buildPanel(): VizPanel {
+    return PanelBuilders.heatmap()
       .setTitle('Span Profile Heatmap')
       .setOption('calculate', false)
       .setOption('cellGap', 1)
       .setOption('color', { scheme: 'Spectral', steps: 64 })
       .setOption('tooltip', { mode: TooltipDisplayMode.Single, yHistogram: true, showColorScale: true })
       .setOption('exemplars', { color: EXEMPLAR_COLOR_DEFAULT })
-      .setData(new SceneDataNode());
-
-    if (embedded) {
-      builder = builder.setHoverHeader(true);
-    }
-
-    return builder.build();
+      .setData(new SceneDataNode())
+      .build();
   }
 
   onActivate() {


### PR DESCRIPTION
Removes the unnecessary hover header from the span profile heatmap.

<img width="754" height="133" alt="image" src="https://github.com/user-attachments/assets/7a7ba329-6912-43db-9ea1-558a8733e0b8" />

## Validation
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:ci`

Lint completed with existing deprecation warnings only.