### PR TITLE
fix(header): use ButtonGroup for plugin header toolbar buttons

### DIFF
--- a/src/shared/ui/PluginHeaderToolbar.tsx
+++ b/src/shared/ui/PluginHeaderToolbar.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { useChromeHeaderHeight, usePluginComponent } from '@grafana/runtime';
-import { Dropdown, ErrorBoundary, Field, Icon, Menu, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { ButtonGroup, Dropdown, ErrorBoundary, Field, Icon, Menu, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { SaveSearchButton } from '@shared/components/SavedSearches/SaveSearchButton';
 import { useFlagMetricsFromProfiles } from '@shared/infrastructure/featureFlags/featureFlags';
 import { useFetchPluginSettings } from '@shared/infrastructure/settings/useFetchPluginSettings';
@@ -106,7 +106,7 @@ export function PluginHeaderToolbar(props: PluginHeaderToolbarProps) {
           )}
 
           {!props.isEmbedded && (
-            <div className={styles.appMiscButtons}>
+            <ButtonGroup>
               {settings?.enableMetricsFromProfiles && metricsFromProfiles && (
                 <Dropdown overlay={metricsFromProfilesMenu}>
                   <ToolbarButton
@@ -140,7 +140,7 @@ export function PluginHeaderToolbar(props: PluginHeaderToolbarProps) {
               />
 
               <PluginInfo variant="canvas" />
-            </div>
+            </ButtonGroup>
           )}
         </div>
       </div>
@@ -213,27 +213,6 @@ const getStyles = (theme: GrafanaTheme2, chromeHeaderHeight: number, isEmbedded:
     display: flex;
     align-items: center;
     gap: ${theme.spacing(1)};
-  `,
-  appMiscButtons: css`
-    display: flex;
-    align-items: stretch;
-    height: ${theme.spacing(theme.components.height.md)};
-    box-sizing: border-box;
-    border: 1px solid ${theme.colors.border.weak};
-    background-color: ${theme.colors.background.secondary};
-    border-radius: ${theme.shape.radius.default};
-    overflow: hidden;
-
-    button {
-      border: none;
-      border-radius: 0;
-      height: auto;
-
-      &:hover,
-      &:focus {
-        border: none;
-      }
-    }
   `,
   sceneControls: css`
     display: flex;


### PR DESCRIPTION
✨Description

The group of buttons at the far right of the header (upload, share, settings, plugin info, and the recording-rules dropdown when enabled) was wrapped in an `appMiscButtons` div that drew its own border and background, then stripped the borders off the buttons inside. The result did not match the standard secondary/canvas button styling used by the neighbouring time-range and refresh controls.

This replaces the custom wrapper with `ButtonGroup` from `@grafana/ui`, which is the standard component for this. No custom styling is needed here.

Same fix as [grafana/logs-drilldown#2009](https://github.com/grafana/logs-drilldown/pull/2009); originally reported in [Slack](https://raintank-corp.slack.com/archives/C075BDBTX96/p1784800446330289).

📖 Summary of the changes

- `src/shared/ui/PluginHeaderToolbar.tsx`: the `appMiscButtons` wrapper div is now a `ButtonGroup`.
- Removed the `appMiscButtons` style block. It set a container border + `background.secondary` and then applied `button { border: none; border-radius: 0; }` (plus the same on `:hover`/`:focus`) to every child, which is what removed the standard button styling.
- `ButtonGroup` handles joining the buttons (unsets the inner border radii and adds the divider) while each button keeps its own border and background.
- All five buttons in the group were already `ToolbarButton variant="canvas"`, so no change was needed there.

Net: 3 insertions, 24 deletions.

🧪 How to test?
<img width="1896" height="414" alt="Screenshot 2026-07-24 at 2 18 58 PM" src="https://github.com/user-attachments/assets/4ccb52b3-00ef-4917-ac71-db1a3b221da2" />

