### PR TITLE
fix: time picker menu position

### DIFF
--- a/src/shared/ui/PluginHeaderToolbar.tsx
+++ b/src/shared/ui/PluginHeaderToolbar.tsx
@@ -213,6 +213,12 @@ const getStyles = (theme: GrafanaTheme2, chromeHeaderHeight: number, isEmbedded:
     display: flex;
     align-items: center;
     gap: ${theme.spacing(1)};
+
+    /* TimeRangePicker defaults to right:0; open into the page so the docked nav does not clip it */
+    [data-testid='data-testid TimePicker Overlay Content'] > section {
+      right: auto;
+      left: 0;
+    }
   `,
   appMiscButtons: css`
     display: flex;


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/profiles-drilldown/issues/1016

When the time picker sits near the left edge, its panel opens with right: 0 and grows under the docked mega menu. Align the overlay with left: 0 so it opens into the page instead.