### PR TITLE
fix: normalize string spanSelector in drilldown link builder

### DIFF
--- a/src/links.test.ts
+++ b/src/links.test.ts
@@ -166,6 +166,51 @@ describe('buildURL - Original Functionality', () => {
 
       expect(result).not.toContain('var-spanSelector');
     });
+
+    // Grafana's Trace View passes spanSelector as a single string rather than the declared
+    // Array<string>, which used to throw `spanSelector.join is not a function`. See
+    // https://github.com/grafana/profiles-drilldown/issues/775
+    it('should handle a string span selector from trace view context', () => {
+      const pyroscopeQuery = {
+        refId: 'A',
+        datasource: mockDatasource,
+        profileTypeId: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+        labelSelector: '{}',
+        groupBy: [],
+        includeExemplars: false,
+        includeHeatmap: false,
+        heatmapType: 'individual',
+        spanSelector: 'single-span-id',
+      } as unknown as GrafanaPyroscopeDataQuery;
+
+      const result = buildURL({
+        pyroscopeQuery,
+        timeRange: mockTimeRange,
+      });
+
+      expect(result).toContain('var-spanSelector=single-span-id');
+    });
+
+    it('should omit the span selector param for an empty string span selector', () => {
+      const pyroscopeQuery = {
+        refId: 'A',
+        datasource: mockDatasource,
+        profileTypeId: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+        labelSelector: '{}',
+        groupBy: [],
+        includeExemplars: false,
+        includeHeatmap: false,
+        heatmapType: 'individual',
+        spanSelector: '',
+      } as unknown as GrafanaPyroscopeDataQuery;
+
+      const result = buildURL({
+        pyroscopeQuery,
+        timeRange: mockTimeRange,
+      });
+
+      expect(result).not.toContain('var-spanSelector');
+    });
   });
 
   describe('enhanced functionality', () => {

--- a/src/links.ts
+++ b/src/links.ts
@@ -77,9 +77,22 @@ function addTimeRangeParams(params: string[], timeRange: RawTimeRange | undefine
   }
 }
 
+/**
+ * Normalizes `spanSelector` to an array: the type declares `Array<string>`, but Grafana's
+ * Trace View passes a single string, which satisfies `?.length` and then throws on `.join()`.
+ */
+function normalizeSpanSelector(spanSelector: unknown): string[] {
+  if (Array.isArray(spanSelector)) {
+    return spanSelector;
+  }
+
+  return typeof spanSelector === 'string' && spanSelector.length > 0 ? [spanSelector] : [];
+}
+
 function addQueryParams(params: string[], pyroscopeQuery: GrafanaPyroscopeDataQuery): void {
-  if (pyroscopeQuery.spanSelector?.length) {
-    params.push(`var-spanSelector=${pyroscopeQuery.spanSelector.join(',')}`);
+  const spanSelector = normalizeSpanSelector(pyroscopeQuery.spanSelector);
+  if (spanSelector.length) {
+    params.push(`var-spanSelector=${spanSelector.join(',')}`);
   }
 
   if (pyroscopeQuery.maxNodes) {


### PR DESCRIPTION
### ✨ Description

Fixes: #775
Related issue(s): #872 (prior fix for this bug — approved, but closed unmerged because its commits lacked verified signatures)

Credit to @saschabuehrle, who diagnosed this and wrote the original fix in #872. This restores that work with signed commits, rebased onto current `main`. The normalization logic is theirs; it is factored into a documented helper here to match the surrounding style, and an extra empty-string test case is included.

### 🧪 How to test?

Automated — two regression cases added to `src/links.test.ts`:

- [x] `pnpm jest src/links.test.ts` → 16 passed
- [x] Reverting only the `src/links.ts` change makes the new string case fail with the exact reported error, `TypeError: pyroscopeQuery.spanSelector.join is not a function` at `links.ts:82` — confirming it guards the real defect rather than merely passing
